### PR TITLE
Feat/redis rate limiter

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -54,6 +54,8 @@ class Settings(BaseSettings):
     rate_limit_ai_rpm: int = 10       # AI troubleshoot: requests per minute
     rate_limit_repair_rpm: int = 20   # Repair endpoint: requests per minute
     rate_limit_general_rpm: int = 60  # General API: requests per minute
+    
+    redis_url: str | None = None
 
 
 @lru_cache

--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -128,36 +128,62 @@ class RedisBackend(RateLimitBackend):
         self.redis = redis.from_url(redis_url, decode_responses=True)
 
     async def is_allowed(self, key: str, max_requests: int, window_seconds: int):
+        import time
+
         now = time.time()
         window_start = now - window_seconds
 
-        await self.redis.zremrangebyscore(key, 0, window_start)
+        try:
+            
+            await self.redis.zremrangebyscore(key, 0, window_start)
 
-        current_count = await self.redis.zcard(key)
+            
+            current_count = await self.redis.zcard(key)
 
-        if current_count >= max_requests:
-            ttl = await self.redis.ttl(key)
-            return False, {
-                "remaining": 0,
+            
+            if current_count >= max_requests:
+                oldest = await self.redis.zrange(key, 0, 0, withscores=True)
+
+                if oldest:
+                    oldest_time = oldest[0][1]
+                    reset = int((oldest_time + window_seconds) - now)
+                    reset = max(reset, 0)
+                else:
+                    reset = window_seconds
+
+                return False, {
+                    "remaining": 0,
+                    "limit": max_requests,
+                    "reset": reset,
+                    "window": window_seconds,
+                }
+
+            # Add current request (sorted set: score = timestamp)
+            await self.redis.zadd(key, {str(now): now})
+
+            # Keep TTL as safety cleanup (not for logic)
+            await self.redis.expire(key, window_seconds)
+
+            return True, {
+                "remaining": max_requests - current_count - 1,
                 "limit": max_requests,
-                "reset": ttl if ttl > 0 else window_seconds,
+                "reset": window_seconds,
                 "window": window_seconds,
             }
 
-        await self.redis.zadd(key, {str(now): now})
-        await self.redis.expire(key, window_seconds)
-
-        return True, {
-            "remaining": max_requests - current_count - 1,
-            "limit": max_requests,
-            "reset": window_seconds,
-            "window": window_seconds,
-        }
+        except Exception:
+            # Fail-open strategy (do not break API if Redis fails)
+            return True, {
+                "remaining": max_requests,
+                "limit": max_requests,
+                "reset": window_seconds,
+                "window": window_seconds,
+            }
 
     async def cleanup(self) -> None:
         """
         Redis handles cleanup automatically using key expiration.
-        No manual clean up required for sliding window rate limiting.
+        No manual cleanup required for sliding window rate limiting.
         """
         return
         

--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -122,10 +122,57 @@ class InMemoryBackend(RateLimitBackend):
         if empty_keys:
             logger.debug("Rate limiter cleanup: removed %d stale keys", len(empty_keys))
 
+class RedisBackend(RateLimitBackend):
+    def __init__(self, redis_url: str):
+        import redis.asyncio as redis
+        self.redis = redis.from_url(redis_url, decode_responses=True)
+
+    async def is_allowed(self, key: str, max_requests: int, window_seconds: int):
+        now = time.time()
+        window_start = now - window_seconds
+
+        await self.redis.zremrangebyscore(key, 0, window_start)
+
+        current_count = await self.redis.zcard(key)
+
+        if current_count >= max_requests:
+            ttl = await self.redis.ttl(key)
+            return False, {
+                "remaining": 0,
+                "limit": max_requests,
+                "reset": ttl if ttl > 0 else window_seconds,
+                "window": window_seconds,
+            }
+
+        await self.redis.zadd(key, {str(now): now})
+        await self.redis.expire(key, window_seconds)
+
+        return True, {
+            "remaining": max_requests - current_count - 1,
+            "limit": max_requests,
+            "reset": window_seconds,
+            "window": window_seconds,
+        }
+
+    async def cleanup(self) -> None:
+        """
+        Redis handles cleanup automatically using key expiration.
+        No manual clean up required for sliding window rate limiting.
+        """
+        return
+        
+    
+        
 
 # ── Singleton backend ─────────────────────────────────────────────────────────
 
-_backend = InMemoryBackend()
+
+settings = get_settings()
+
+if settings.redis_url:
+    _backend = RedisBackend(settings.redis_url)
+else:
+    _backend = InMemoryBackend()
 
 
 # ── Rate Limiter ──────────────────────────────────────────────────────────────

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "httpx>=0.27.0",
     "python-multipart>=0.0.9",
     "aiofiles>=23.2.1",
+    "redis>=5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,13 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
-
+  
+  redis:
+    image: redis:7-alpine
+    container_name: envforge_redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
   api:
     build:
       context: ./backend
@@ -31,6 +37,7 @@ services:
     ports:
       - "8000:8000"
     environment:
+      REDIS_URL : redis://redis:6379
       DATABASE_URL: postgresql+asyncpg://envforge:envforge_dev_secret@db:5432/envforge
       ENVIRONMENT: development
       DEBUG: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      REDIS_URL : redis://redis:6379
+      REDIS_URL: redis://redis:6379
       DATABASE_URL: postgresql+asyncpg://envforge:envforge_dev_secret@db:5432/envforge
       ENVIRONMENT: development
       DEBUG: "true"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
<!-- What does this PR do? Why is it needed? -->
Implements a Redis-backed sliding window rate limiter for distributed environments, with an in-memory fallback for single-instance deployments.

## Related Issues
<!-- Link to any related issues. Use "Fixes #123" or "Resolves #123" to auto-close the issue on merge. -->

## Changes Made
<!-- List the main changes made in this PR -->
- Added RedisBackend using Redis sorted sets (ZSET)
- Implemented sliding window using ZADD, ZREMRANGEBYSCORE, ZCARD, EXPIRE
- Added Redis fallback via InMemoryBackend
- Integrated Redis via REDIS_URL in docker-compose
- Added redis dependency to backend requirements
- Updated config to support Redis URL injection

## Verification
<!-- Describe how you verified that your changes work. -->
- Tested rate limiting via Docker Compose
- Verified 429 responses after threshold exceeded
- Confirmed Redis container integration
- API endpoints working correctly under load

## Notes
Production-ready distributed rate limiting implementation for FastAPI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Redis-backed rate limiting: when configured, rate limits use Redis for improved performance and scalability.
  * New configuration option to specify Redis connection (via environment).

* **Chores**
  * Added Redis runtime dependency.
  * Docker Compose updated to include a Redis service and set the backend's Redis URL.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->