### PR TITLE
feat: add environment verification engine for CLI agent

### DIFF
--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -223,51 +223,112 @@ def _print_diagnose_response(result: dict) -> None:
 
 @cli.command("verify")
 @click.option(
-    "--profile", "-p", required=True,
+    "--profile", "-p", required=False,
     help="Profile slug to verify against (e.g. pytorch-cuda).",
 )
-@click.option(
-    "--api-url",
-    default="http://localhost:8000",
-    show_default=True,
-    envvar="ENVFORGE_API_URL",
-)
-def verify(profile: str, api_url: str) -> None:
+def verify(profile: str | None) -> None:
     """
-    Check if this system is compatible with a specific EnvForge profile.
+    Verify whether the generated ML environment works after setup.
 
-    Collects a DiagnosticReport and sends it to the API for analysis
-    against the requested profile.
+    Checks PyTorch import and, if a GPU profile is detected, CUDA availability.
+    Returns a structured PASS/FAIL JSON result.
     """
-    console.print(f"[bold cyan]Verifying compatibility with profile:[/] {profile}")
+    import subprocess
+
+    # 1. Determine active Python
     report = ReportBuilder().build()
+    active_py = report.active_python
+    py_executable = active_py.path if active_py else sys.executable
 
-    url = f"{api_url.rstrip('/')}/api/v1/diagnose"
+    # 2. Run inline Python script to test torch import and CUDA
+    inspector_script = (
+        "import sys\n"
+        "import json\n"
+        "result = {'import_ok': False, 'cuda_ok': False, 'error': None}\n"
+        "try:\n"
+        "    import torch\n"
+        "    result['import_ok'] = True\n"
+        "    try:\n"
+        "        result['cuda_ok'] = torch.cuda.is_available()\n"
+        "    except Exception as e:\n"
+        "        result['cuda_ok'] = False\n"
+        "except Exception as e:\n"
+        "    result['import_ok'] = False\n"
+        "    result['error'] = f'{type(e).__name__}: {str(e)}'\n"
+        "print(json.dumps(result))\n"
+    )
+
     try:
-        response = httpx.post(
-            url,
-            content=report.to_json(),
-            headers={"Content-Type": "application/json"},
-            timeout=30,
+        proc = subprocess.run(
+            [py_executable, "-c", inspector_script],
+            capture_output=True,
+            text=True,
+            timeout=15
         )
-        response.raise_for_status()
-        result = response.json()
-
-        compatible = profile in result.get("compatible_profiles", [])
-        if compatible:
-            console.print(f"[bold green]✓ COMPATIBLE[/] — {profile} is compatible with this system.")
+        if proc.returncode != 0:
+            res = {
+                "status": "FAIL",
+                "message": "Python verification script failed to execute",
+                "error": proc.stderr.strip() or f"Exit code {proc.returncode}"
+            }
+            click.echo(json.dumps(res, indent=2))
+            sys.exit(1)
+        
+        data = json.loads(proc.stdout.strip())
+        
+        # 3. Analyze checks
+        if not data["import_ok"]:
+            res = {
+                "status": "FAIL",
+                "message": "PyTorch import failed — is it installed?",
+                "error": data["error"]
+            }
+            click.echo(json.dumps(res, indent=2))
+            sys.exit(1)
+        
+        # Check if CUDA profile is detected
+        is_gpu_profile = False
+        if profile:
+            is_gpu_profile = any(term in profile.lower() for term in ["cuda", "gpu", "diffusion", "finetune"])
+        
+        if is_gpu_profile and not data["cuda_ok"]:
+            res = {
+                "status": "FAIL",
+                "message": "PyTorch installed but CUDA not available",
+                "error": "torch.cuda.is_available() returned False"
+            }
+            click.echo(json.dumps(res, indent=2))
+            sys.exit(1)
+        
+        # All required checks passed!
+        msg = "Environment works: PyTorch imported successfully"
+        if data["cuda_ok"]:
+            msg += " with CUDA support"
         else:
-            console.print(f"[bold red]✗ NOT COMPATIBLE[/] — {profile} is not compatible.")
+            msg += " (CPU only)"
+            
+        res = {
+            "status": "PASS",
+            "message": msg
+        }
+        click.echo(json.dumps(res, indent=2))
+        sys.exit(0)
 
-        if result.get("issues"):
-            console.print("\n[bold yellow]Issues:[/]")
-            for issue in result["issues"]:
-                console.print(f"  • {issue['message']}")
-                if issue.get("suggested_fix"):
-                    console.print(f"    → {issue['suggested_fix']}")
-
-    except httpx.ConnectError:
-        err_console.print(f"Cannot connect to {url}. Is the API running?")
+    except subprocess.TimeoutExpired:
+        res = {
+            "status": "FAIL",
+            "message": "Verification timed out",
+            "error": "Subprocess took longer than 15 seconds"
+        }
+        click.echo(json.dumps(res, indent=2))
+        sys.exit(1)
+    except Exception as e:
+        res = {
+            "status": "FAIL",
+            "message": "Verification failed due to an unexpected error",
+            "error": str(e)
+        }
+        click.echo(json.dumps(res, indent=2))
         sys.exit(1)
 
 

--- a/cli/envforge_agent/report.py
+++ b/cli/envforge_agent/report.py
@@ -8,6 +8,10 @@ Usage:
 """
 from __future__ import annotations
 
+from envforge_agent.detectors import (
+    detect_cpu,
+    detect_cuda,
+    detect_gpus,
     detect_os,
     detect_python,
     detect_ram,

--- a/cli/tests/test_agent.py
+++ b/cli/tests/test_agent.py
@@ -320,6 +320,88 @@ def test_sarif_no_issues_when_healthy():
     sarif = report.to_sarif()
     assert sarif["runs"][0]["results"] == []
 
+
+class TestVerifyCommand:
+    """Tests for the envforge verify CLI command."""
+
+    @patch("subprocess.run")
+    def test_verify_pass_no_profile(self, mock_run: MagicMock) -> None:
+        from envforge_agent.cli import cli
+        from click.testing import CliRunner
+
+        # Mock the subprocess execution
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = '{"import_ok": true, "cuda_ok": false, "error": null}'
+        mock_run.return_value = mock_proc
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["verify"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "PASS"
+        assert "imported successfully" in data["message"]
+        assert "CPU only" in data["message"]
+
+    @patch("subprocess.run")
+    def test_verify_pass_cuda_profile(self, mock_run: MagicMock) -> None:
+        from envforge_agent.cli import cli
+        from click.testing import CliRunner
+
+        # Mock the subprocess execution
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = '{"import_ok": true, "cuda_ok": true, "error": null}'
+        mock_run.return_value = mock_proc
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["verify", "--profile", "pytorch-cuda"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "PASS"
+        assert "with CUDA support" in data["message"]
+
+    @patch("subprocess.run")
+    def test_verify_fail_import(self, mock_run: MagicMock) -> None:
+        from envforge_agent.cli import cli
+        from click.testing import CliRunner
+
+        # Mock the subprocess execution
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = '{"import_ok": false, "cuda_ok": false, "error": "ModuleNotFoundError: No module named \'torch\'"}'
+        mock_run.return_value = mock_proc
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["verify"])
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["status"] == "FAIL"
+        assert "PyTorch import failed" in data["message"]
+        assert "ModuleNotFoundError" in data["error"]
+
+    @patch("subprocess.run")
+    def test_verify_fail_cuda_on_gpu_profile(self, mock_run: MagicMock) -> None:
+        from envforge_agent.cli import cli
+        from click.testing import CliRunner
+
+        # Mock the subprocess execution
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = '{"import_ok": true, "cuda_ok": false, "error": null}'
+        mock_run.return_value = mock_proc
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["verify", "--profile", "pytorch-cuda"])
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["status"] == "FAIL"
+        assert "CUDA not available" in data["message"]
+
         
 
             


### PR DESCRIPTION
## Description
This PR introduces a deterministic Environment Verification feature to the EnvForge CLI agent. It enables users to validate whether a generated ML environment is correctly functional after setup by performing runtime checks directly on the active Python interpreter.

The verification system ensures that key ML dependencies (specifically PyTorch) are correctly installed and optionally validates CUDA availability for GPU-based profiles. This bridges the gap between environment generation and actual usability.

## Related Issues
Fixes #41

## Changes Made
Added envforge verify CLI command in cli.py
Implemented subprocess-based isolated environment inspection for safe runtime validation
Added PyTorch import validation check
Added CUDA availability check using torch.cuda.is_available() (for GPU-related profiles)
Implemented structured JSON output with status, message, and optional error
Added conditional profile-based GPU validation logic
Integrated proper exit codes (0 for PASS, 1 for FAIL)
Added comprehensive CLI unit tests for:
 - CPU-only environment verification
 - CUDA-enabled environment verification
 - PyTorch import failure handling
 - CUDA mismatch scenarios

## Verification
- [x] Added unit tests
- [x] Ran `pytest tests/` successfully
- [x] Manually tested via the API / CLI
- [x] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted

## Screenshots (if applicable)
<img width="1125" height="677" alt="image" src="https://github.com/user-attachments/assets/a75740e9-11c5-41b3-8935-6bf48a69208e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `verify` command now validates your local environment independently without requiring API access
  * Added checks for Python interpreter, PyTorch installation, and CUDA availability

* **Changes**
  * The `--profile` flag is now optional (previously required)
  * The `--api-url` flag has been removed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->