### PR TITLE
fix: Ollama provider timeout & graceful error handling (closes #55)

### DIFF
--- a/backend/app/ai/providers/__init__.py
+++ b/backend/app/ai/providers/__init__.py
@@ -48,10 +48,12 @@ def get_provider() -> LLMProvider:
         )
 
     if provider_name == "ollama":
-        raise LLMProviderError(
-            "ollama",
-            "Ollama local provider is not yet implemented. "
-            "Use 'openrouter' or 'mock' for now.",
+        from app.ai.providers.ollama import OllamaProvider
+        return OllamaProvider(
+            base_url=settings.ollama_base_url,
+            model=settings.ollama_model,
+            max_tokens=settings.ai_max_tokens,
+            temperature=settings.ai_temperature,
         )
 
     raise LLMProviderError(

--- a/backend/app/ai/providers/ollama.py
+++ b/backend/app/ai/providers/ollama.py
@@ -1,0 +1,224 @@
+"""Ollama local LLM provider with timeout and connection-error handling."""
+import json
+import logging
+from typing import AsyncIterator, TypeVar
+
+import httpx
+from pydantic import BaseModel
+
+from app.ai.providers.base import LLMProvider, LLMProviderError
+
+T = TypeVar("T", bound=BaseModel)
+logger = logging.getLogger(__name__)
+
+OLLAMA_TIMEOUT = 30.0  # seconds — per issue #55 requirement
+MAX_RETRIES = 2
+RETRY_BACKOFF_BASE = 2  # seconds
+
+
+class OllamaProvider(LLMProvider):
+    """
+    LLM provider for locally-running Ollama instances.
+
+    Communicates via Ollama's OpenAI-compatible /v1/chat/completions endpoint.
+    Implements timeout enforcement and graceful error handling so that a
+    crashed or overloaded Ollama daemon never propagates as a 500.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:11434",
+        model: str = "llama3",
+        max_tokens: int = 2048,
+        temperature: float = 0.3,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+        self._chat_url = f"{self.base_url}/v1/chat/completions"
+
+    async def complete(
+        self,
+        system_prompt: str,
+        user_message: str,
+        response_model: type[T],
+    ) -> T:
+        schema_json = json.dumps(response_model.model_json_schema(), indent=2)
+        enhanced_system = (
+            f"{system_prompt}\n\n"
+            f"You MUST respond with ONLY valid JSON matching this exact schema:\n"
+            f"```json\n{schema_json}\n```\n"
+            f"Do NOT include any text outside the JSON object."
+        )
+
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": enhanced_system},
+                {"role": "user", "content": user_message},
+            ],
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "stream": False,
+        }
+
+        last_error: LLMProviderError | None = None
+
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                async with httpx.AsyncClient(timeout=OLLAMA_TIMEOUT) as client:
+                    response = await client.post(self._chat_url, json=payload)
+
+                if response.status_code >= 500:
+                    import asyncio
+                    wait = RETRY_BACKOFF_BASE ** attempt
+                    logger.warning(
+                        "Ollama server error (%d). Retry %d/%d in %ds",
+                        response.status_code, attempt, MAX_RETRIES, wait,
+                    )
+                    last_error = LLMProviderError(
+                        "ollama",
+                        f"Ollama returned HTTP {response.status_code} (attempt {attempt}/{MAX_RETRIES})",
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+
+                if response.status_code != 200:
+                    raise LLMProviderError(
+                        "ollama",
+                        f"HTTP {response.status_code}: {response.text[:500]}",
+                    )
+
+                data = response.json()
+                choices = data.get("choices", [])
+                if not choices:
+                    raise LLMProviderError("ollama", "No choices in response.")
+
+                content = choices[0].get("message", {}).get("content", "")
+                if not content:
+                    raise LLMProviderError("ollama", "Empty content in response.")
+
+                content = content.strip()
+                if content.startswith("```json"):
+                    content = content[7:]
+                if content.startswith("```"):
+                    content = content[3:]
+                if content.endswith("```"):
+                    content = content[:-3]
+                content = content.strip()
+
+                try:
+                    return response_model.model_validate_json(content)
+                except Exception as parse_err:
+                    raise LLMProviderError(
+                        "ollama",
+                        f"Failed to parse response into {response_model.__name__}: "
+                        f"{parse_err}. Raw content: {content[:300]}",
+                    ) from parse_err
+
+            except LLMProviderError:
+                raise
+            except httpx.TimeoutException:
+                last_error = LLMProviderError(
+                    "ollama",
+                    "LLM Provider is currently unavailable. Please try again later.",
+                )
+                logger.warning(
+                    "Ollama request timed out after %.0fs (attempt %d/%d)",
+                    OLLAMA_TIMEOUT, attempt, MAX_RETRIES,
+                )
+                import asyncio
+                await asyncio.sleep(RETRY_BACKOFF_BASE ** attempt)
+            except httpx.ConnectError:
+                last_error = LLMProviderError(
+                    "ollama",
+                    "LLM Provider is currently unavailable. Please try again later.",
+                )
+                logger.warning(
+                    "Ollama connection refused at %s (attempt %d/%d)",
+                    self.base_url, attempt, MAX_RETRIES,
+                )
+                import asyncio
+                await asyncio.sleep(RETRY_BACKOFF_BASE ** attempt)
+            except httpx.HTTPError as exc:
+                last_error = LLMProviderError(
+                    "ollama",
+                    "LLM Provider is currently unavailable. Please try again later.",
+                )
+                logger.warning(
+                    "Ollama HTTP error: %s (attempt %d/%d)", exc, attempt, MAX_RETRIES,
+                )
+                import asyncio
+                await asyncio.sleep(RETRY_BACKOFF_BASE ** attempt)
+
+        raise last_error or LLMProviderError("ollama", "All retries exhausted.")
+
+    async def stream(
+        self,
+        system_prompt: str,
+        user_message: str,
+        response_model: type[T],
+    ) -> AsyncIterator[str]:
+        schema_json = json.dumps(response_model.model_json_schema(), indent=2)
+        enhanced_system = (
+            f"{system_prompt}\n\n"
+            f"You MUST respond with ONLY valid JSON matching this exact schema:\n"
+            f"```json\n{schema_json}\n```\n"
+            f"Do NOT include any text outside the JSON object."
+        )
+
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": enhanced_system},
+                {"role": "user", "content": user_message},
+            ],
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "stream": True,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=OLLAMA_TIMEOUT) as client:
+                async with client.stream("POST", self._chat_url, json=payload) as response:
+                    if response.status_code != 200:
+                        error_body = await response.aread()
+                        raise LLMProviderError(
+                            "ollama",
+                            f"HTTP {response.status_code}: {error_body[:500]}",
+                        )
+
+                    async for line in response.aiter_lines():
+                        if not line or not line.startswith("data: "):
+                            continue
+                        data_str = line[6:].strip()
+                        if data_str == "[DONE]":
+                            break
+                        try:
+                            data = json.loads(data_str)
+                            choices = data.get("choices", [])
+                            if choices:
+                                delta = choices[0].get("delta", {})
+                                content = delta.get("content", "")
+                                if content:
+                                    yield content
+                        except json.JSONDecodeError:
+                            continue
+        except LLMProviderError:
+            raise
+        except httpx.TimeoutException as exc:
+            raise LLMProviderError(
+                "ollama",
+                "LLM Provider is currently unavailable. Please try again later.",
+            ) from exc
+        except httpx.ConnectError as exc:
+            raise LLMProviderError(
+                "ollama",
+                "LLM Provider is currently unavailable. Please try again later.",
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise LLMProviderError(
+                "ollama",
+                "LLM Provider is currently unavailable. Please try again later.",
+            ) from exc

--- a/backend/tests/unit/ai/test_ollama_provider.py
+++ b/backend/tests/unit/ai/test_ollama_provider.py
@@ -1,0 +1,244 @@
+"""Tests for OllamaProvider — timeout, connection-error, and happy-path coverage."""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from app.ai.providers.base import LLMProviderError
+from app.ai.providers.ollama import OLLAMA_TIMEOUT, OllamaProvider
+
+
+class _SimpleResponse(BaseModel):
+    answer: str
+
+
+def _make_httpx_response(status_code: int, body: dict | str) -> httpx.Response:
+    content = json.dumps(body).encode() if isinstance(body, dict) else body.encode()
+    return httpx.Response(status_code, content=content)
+
+
+# ── Constructor ────────────────────────────────────────────────────────────────
+
+class TestOllamaProviderInit:
+    def test_defaults(self):
+        p = OllamaProvider()
+        assert p.base_url == "http://localhost:11434"
+        assert p.model == "llama3"
+        assert p._chat_url == "http://localhost:11434/v1/chat/completions"
+
+    def test_trailing_slash_stripped(self):
+        p = OllamaProvider(base_url="http://localhost:11434/")
+        assert p._chat_url == "http://localhost:11434/v1/chat/completions"
+
+    def test_custom_params(self):
+        p = OllamaProvider(base_url="http://gpu-box:11434", model="mistral", max_tokens=512)
+        assert p.model == "mistral"
+        assert p.max_tokens == 512
+
+
+# ── complete() — happy path ────────────────────────────────────────────────────
+
+class TestOllamaProviderComplete:
+    @pytest.fixture
+    def provider(self):
+        return OllamaProvider()
+
+    @pytest.mark.asyncio
+    async def test_successful_completion(self, provider):
+        response_body = {
+            "choices": [{"message": {"content": '{"answer": "42"}'}}]
+        }
+        mock_response = _make_httpx_response(200, response_body)
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            result = await provider.complete("sys", "user", _SimpleResponse)
+
+        assert result.answer == "42"
+
+    @pytest.mark.asyncio
+    async def test_strips_markdown_fences(self, provider):
+        content = "```json\n{\"answer\": \"hello\"}\n```"
+        response_body = {"choices": [{"message": {"content": content}}]}
+        mock_response = _make_httpx_response(200, response_body)
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            result = await provider.complete("sys", "user", _SimpleResponse)
+
+        assert result.answer == "hello"
+
+    @pytest.mark.asyncio
+    async def test_timeout_configured(self, provider):
+        """Ensure the AsyncClient is created with the required timeout."""
+        response_body = {"choices": [{"message": {"content": '{"answer": "ok"}'}}]}
+        mock_response = _make_httpx_response(200, response_body)
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            await provider.complete("sys", "user", _SimpleResponse)
+
+        mock_client_cls.assert_called_once_with(timeout=OLLAMA_TIMEOUT)
+        assert OLLAMA_TIMEOUT == 30.0
+
+
+# ── complete() — error handling ────────────────────────────────────────────────
+
+class TestOllamaProviderErrors:
+    @pytest.fixture
+    def provider(self):
+        return OllamaProvider()
+
+    @pytest.mark.asyncio
+    async def test_timeout_raises_llm_provider_error(self, provider):
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+            mock_client_cls.return_value = mock_client
+
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                with pytest.raises(LLMProviderError) as exc_info:
+                    await provider.complete("sys", "user", _SimpleResponse)
+
+        assert exc_info.value.provider == "ollama"
+        assert "unavailable" in exc_info.value.reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_connect_error_raises_llm_provider_error(self, provider):
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(
+                side_effect=httpx.ConnectError("Connection refused")
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                with pytest.raises(LLMProviderError) as exc_info:
+                    await provider.complete("sys", "user", _SimpleResponse)
+
+        assert exc_info.value.provider == "ollama"
+        assert "unavailable" in exc_info.value.reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_http_error_raises_llm_provider_error(self, provider):
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(
+                side_effect=httpx.HTTPError("network error")
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                with pytest.raises(LLMProviderError) as exc_info:
+                    await provider.complete("sys", "user", _SimpleResponse)
+
+        assert exc_info.value.provider == "ollama"
+
+    @pytest.mark.asyncio
+    async def test_non_200_raises_llm_provider_error(self, provider):
+        mock_response = _make_httpx_response(404, {"error": "model not found"})
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(LLMProviderError) as exc_info:
+                await provider.complete("sys", "user", _SimpleResponse)
+
+        assert "404" in exc_info.value.reason
+
+    @pytest.mark.asyncio
+    async def test_empty_choices_raises_llm_provider_error(self, provider):
+        mock_response = _make_httpx_response(200, {"choices": []})
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(LLMProviderError) as exc_info:
+                await provider.complete("sys", "user", _SimpleResponse)
+
+        assert "no choices" in exc_info.value.reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_raises_llm_provider_error(self, provider):
+        response_body = {"choices": [{"message": {"content": "not json at all"}}]}
+        mock_response = _make_httpx_response(200, response_body)
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(LLMProviderError) as exc_info:
+                await provider.complete("sys", "user", _SimpleResponse)
+
+        assert "_SimpleResponse" in exc_info.value.reason
+
+    @pytest.mark.asyncio
+    async def test_server_error_retries_then_raises(self, provider):
+        mock_response = _make_httpx_response(503, {"error": "overloaded"})
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                with pytest.raises(LLMProviderError) as exc_info:
+                    await provider.complete("sys", "user", _SimpleResponse)
+
+        assert "503" in exc_info.value.reason
+
+
+# ── Provider factory integration ───────────────────────────────────────────────
+
+class TestProviderFactory:
+    def test_factory_returns_ollama_provider(self):
+        with patch("app.config.get_settings") as mock_settings:
+            settings = MagicMock()
+            settings.envforge_llm_provider = "ollama"
+            settings.ollama_base_url = "http://localhost:11434"
+            settings.ollama_model = "llama3"
+            settings.ai_max_tokens = 2048
+            settings.ai_temperature = 0.3
+            mock_settings.return_value = settings
+
+            from app.ai.providers import get_provider
+            provider = get_provider()
+
+        assert isinstance(provider, OllamaProvider)
+        assert provider.model == "llama3"


### PR DESCRIPTION
## Summary

- Implements the `OllamaProvider` class (`backend/app/ai/providers/ollama.py`) using Ollama's OpenAI-compatible `/v1/chat/completions` endpoint
- Enforces a **30-second timeout** on every HTTP request (`timeout=30.0`) as required by issue #55
- Catches `httpx.TimeoutException`, `httpx.ConnectError`, and `httpx.HTTPError` and converts them to a structured `LLMProviderError` with the user-facing message `"LLM Provider is currently unavailable. Please try again later."` — the existing `troubleshoot` endpoint already converts `LLMProviderError` to HTTP 503, so callers never see a raw 500
- Retries transient server errors (5xx) up to 2 times with exponential backoff before giving up
- Wires the provider into the factory so `ENVFORGE_LLM_PROVIDER=ollama` is now functional

## Test plan

- [x] 14 new unit tests in `backend/tests/unit/ai/test_ollama_provider.py` — all pass
  - Constructor defaults and custom params
  - Successful completion and markdown-fence stripping
  - Timeout enforced (`timeout=30.0` verified on `AsyncClient` instantiation)
  - `TimeoutException` → `LLMProviderError` with "unavailable" message
  - `ConnectError` (daemon not running) → `LLMProviderError`
  - `HTTPError` → `LLMProviderError`
  - Non-200 response → `LLMProviderError` with status code
  - Empty choices → `LLMProviderError`
  - Invalid JSON body → `LLMProviderError` naming the response model
  - 503 server error retries then raises
  - Provider factory returns `OllamaProvider` when configured

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ollama local LLM provider with streaming and non-streaming request modes.
  * Implemented automatic retry behavior with exponential backoff for improved reliability.
  * Added comprehensive response validation and error handling for robust operation.

* **Tests**
  * Added unit tests covering Ollama provider initialization, request handling, and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->