### PR TITLE
security: standardize env config with python-dotenv

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,35 +1,53 @@
 # EnvForge Backend — Environment Variables
-# Copy this to .env and fill in real values.
-# NEVER commit .env to version control.
+# Copy this file to `.env` and replace each `<placeholder>` with a real value.
+# `.env` is git-ignored — NEVER commit real secrets.
+#
+# Required (no defaults in code, app will fail to start if unset):
+#   - SECRET_KEY
+#   - DATABASE_URL
 
 # ── Application ──────────────────────────────────────────────
 ENVIRONMENT=development        # development | staging | production
 DEBUG=true
-SECRET_KEY=change_me_in_production_use_openssl_rand_hex_32
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=<your-secret-key-min-32-chars>
 
 # ── Database ──────────────────────────────────────────────────
 # Format: postgresql+asyncpg://user:password@host:port/dbname
-DATABASE_URL=postgresql+asyncpg://envforge:envforge_dev_secret@localhost:5432/envforge
+DATABASE_URL=postgresql+asyncpg://envforge:<your-db-password>@localhost:5432/envforge
+
+# ── Redis (optional locally, required in production) ──────────
+# Format: redis://[:password@]host:port[/db]
+# REDIS_URL=redis://localhost:6379/0
+
+# ── CORS ─────────────────────────────────────────────────────
+ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 
 # ── AI / LLM Provider ─────────────────────────────────────────
 # Options: openai | openrouter | ollama | mock
 ENVFORGE_LLM_PROVIDER=mock
 
 # OpenAI (if ENVFORGE_LLM_PROVIDER=openai)
-OPENAI_API_KEY=sk-...
+OPENAI_API_KEY=<your-openai-api-key>
 OPENAI_MODEL=gpt-4o
 
 # OpenRouter (if ENVFORGE_LLM_PROVIDER=openrouter)
-OPENROUTER_API_KEY=sk-or-...
+OPENROUTER_API_KEY=<your-openrouter-api-key>
 OPENROUTER_MODEL=openai/gpt-4o
 
 # Ollama (if ENVFORGE_LLM_PROVIDER=ollama)
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=llama3
 
-# ── Rate Limiting ─────────────────────────────────────────────
-# Redis URL (required in Phase 4+)
-# REDIS_URL=redis://localhost:6379/0
+# AI tuning
+AI_MAX_TOKENS=2048
+AI_TEMPERATURE=0.3
 
-# ── CORS ─────────────────────────────────────────────────────
-ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+# ── Pagination ────────────────────────────────────────────────
+DEFAULT_PAGE_SIZE=20
+MAX_PAGE_SIZE=100
+
+# ── Rate Limiting (requests per minute) ───────────────────────
+RATE_LIMIT_AI_RPM=10
+RATE_LIMIT_REPAIR_RPM=20
+RATE_LIMIT_GENERAL_RPM=60

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -2,7 +2,9 @@
 script_location = alembic
 prepend_sys_path = .
 version_path_separator = os
-sqlalchemy.url = postgresql+asyncpg://envforge:envforge_dev_secret@localhost:5432/envforge
+; sqlalchemy.url is loaded from the DATABASE_URL env var in alembic/env.py.
+; Leave this blank — do not commit credentials here.
+sqlalchemy.url =
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,11 +1,18 @@
 """
 EnvForge application settings.
-All configuration is sourced from environment variables or .env file.
+
+All configuration is sourced from environment variables or a local `.env` file.
+`load_dotenv()` is invoked here so any code path that imports `app.config`
+(FastAPI, Alembic migrations, the seed service, ad-hoc `python -m ...` scripts)
+shares the same env-loading bootstrap before `Settings` is read.
 """
 from functools import lru_cache
 from typing import Literal
 
+from dotenv import load_dotenv
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+load_dotenv()
 
 
 class Settings(BaseSettings):
@@ -19,14 +26,12 @@ class Settings(BaseSettings):
     # ── Application ───────────────────────────────────────────
     environment: Literal["development", "staging", "production"] = "development"
     debug: bool = False
-    secret_key: str = "change_me"
+    secret_key: str
     app_name: str = "EnvForge API"
     app_version: str = "0.1.0"
 
     # ── Database ──────────────────────────────────────────────
-    database_url: str = (
-        "postgresql+asyncpg://envforge:envforge_dev_secret@localhost:5432/envforge"
-    )
+    database_url: str
 
     # ── Redis ─────────────────────────────────────────────────
     # If set, the rate limiter will use Redis instead of in-memory storage.
@@ -60,8 +65,6 @@ class Settings(BaseSettings):
     rate_limit_ai_rpm: int = 10       # AI troubleshoot: requests per minute
     rate_limit_repair_rpm: int = 20   # Repair endpoint: requests per minute
     rate_limit_general_rpm: int = 60  # General API: requests per minute
-    
-    redis_url: str | None = None
 
 
 @lru_cache

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "uvicorn[standard]>=0.29.0",
     "pydantic>=2.7.0",
     "pydantic-settings>=2.2.0",
+    "python-dotenv>=1.0.0",
     "sqlalchemy>=2.0.30",
     "asyncpg>=0.29.0",
     "alembic>=1.13.0",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,19 @@
 """Pytest configuration and shared fixtures."""
+import os
+
+# Provide safe defaults for required settings BEFORE any `app.*` import,
+# so module-level `get_settings()` calls (e.g. app.middleware.rate_limit)
+# don't fail on missing SECRET_KEY / DATABASE_URL when tests run without a .env.
+os.environ.setdefault("SECRET_KEY", "test-secret-key-not-used-in-prod")
+# Use a postgres-format URL so app.database can construct its module-level
+# engine with pool_size/max_overflow (postgres-only kwargs). The engine is
+# lazy — it never connects. Tests open their own in-memory SQLite engine
+# in the db_session fixture below.
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://test:test@localhost:5432/test",
+)
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from app.database import Base


### PR DESCRIPTION
## Summary
Standardize secrets and configuration management across the backend: declare `python-dotenv` as an explicit dependency, centralize `load_dotenv()` in the config module, and remove insecure code-level defaults. Closes #53.

## Changes
- **`backend/pyproject.toml`** — Added `python-dotenv>=1.0.0`. It was already imported by `backend/alembic/env.py` as an undeclared transitive dep (working only because `pydantic-settings` pulled it in).
- **`backend/app/config.py`** — Added `load_dotenv()` at module top so every entrypoint that imports `app.config` (FastAPI, Alembic migrations, the seed service, ad-hoc `python -m ...` scripts) shares a single env-loading bootstrap.
- **`backend/app/config.py`** — Made `SECRET_KEY` and `DATABASE_URL` required (no defaults). Misconfigured deployments now fail fast at startup with a clear `pydantic.ValidationError` instead of silently booting with `secret_key="change_me"` or a baked-in dev DB password.
- **`backend/app/config.py`** — Removed the duplicate `redis_url` field declaration in `Settings` (the second declaration silently shadowed the first — latent bug).
- **`backend/alembic.ini`** — Cleared the hardcoded `sqlalchemy.url`. `alembic/env.py` already reads `DATABASE_URL` from the environment, so no stale credential needs to ship in the repo.
- **`backend/.env.example`** — Documented the rate-limit vars (`RATE_LIMIT_AI_RPM`, `RATE_LIMIT_REPAIR_RPM`, `RATE_LIMIT_GENERAL_RPM`) and `REDIS_URL` (previously only a comment). Replaced dev-looking placeholders (`envforge_dev_secret`, `sk-...`) with unambiguous `<your-...>` tokens so contributors don't copy them verbatim.
- **`backend/tests/conftest.py`** — Set safe test defaults for `SECRET_KEY` and `DATABASE_URL` before any `app.*` import, so the module-level `get_settings()` call in `app.middleware.rate_limit` doesn't blow up when the suite runs without a `.env`.
- **No `.gitignore` change needed** — `.env`, `.env.local`, `.env.production`, `.env.prod`, and `frontend/.env.local` are already ignored.

## Environment variables documented
All 22 keys actually referenced in the backend codebase — see the refreshed `backend/.env.example` for the canonical list.

**Required** (no defaults; app refuses to start without them):
- `SECRET_KEY`
- `DATABASE_URL`

**Optional** (sensible defaults in `Settings`):
`ENVIRONMENT`, `DEBUG`, `APP_NAME`, `APP_VERSION`, `REDIS_URL`, `ALLOWED_ORIGINS`, `ENVFORGE_LLM_PROVIDER`, `OPENAI_API_KEY`, `OPENAI_MODEL`, `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, `AI_MAX_TOKENS`, `AI_TEMPERATURE`, `DEFAULT_PAGE_SIZE`, `MAX_PAGE_SIZE`, `RATE_LIMIT_AI_RPM`, `RATE_LIMIT_REPAIR_RPM`, `RATE_LIMIT_GENERAL_RPM`.

## Local setup
```bash
cd backend
cp .env.example .env
# Edit .env: at minimum set SECRET_KEY and DATABASE_URL
pip install -e ".[dev]"
uvicorn app.main:app --reload
```

## Security impact
- No secret value ships in the repo — only `<your-...>` placeholders in `.env.example`.
- The previous `secret_key="change_me"` default meant a misconfigured production deploy could silently boot with a known-weak key. That is now impossible.
- Removing `python-dotenv` as an undeclared transitive dep eliminates a "works by accident" risk if `pydantic-settings` ever drops the transitive pull.
- One env-loading bootstrap means rotating a secret only requires updating `.env`, with no per-script `load_dotenv()` calls to forget.

## Developer experience
- Single source of truth: copy `backend/.env.example` to `backend/.env`.
- Fail-fast on missing critical config; no silent fallback to insecure defaults.
- Same `pydantic-settings` interface as before — `get_settings()` works exactly as it did.

## Test plan
- [x] `pytest -q` in `backend/` — 79 passed (the 2 pre-existing failures in `tests/unit/compatibility/test_resolver.py` for JAX CUDA matrix data are unrelated to this PR and reproduce on `main`).
- [x] Manual `uvicorn app.main:app` startup with a populated `.env` — app factory builds, all 14 routes register, settings load from `.env`.
- [x] Negative test: removed `.env`, re-instantiated `Settings` — fails fast with `pydantic_core.ValidationError` naming both missing required fields, exactly as intended.
- [x] `pip show python-dotenv` confirms it's a declared dep, not transitive.

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Environment variables are now required for application startup (SECRET_KEY and DATABASE_URL must be configured).
  * Updated `.env.example` with clearer organization and explicit placeholders for easier setup.
  * Added new configurable options for AI tuning, pagination, and rate limiting.
  * Database migrations now load credentials from environment variables instead of hardcoded values, improving security.

* **Chores**
  * Added python-dotenv dependency for environment variable management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->