### PR TITLE
feat(seed): add Pydantic validation for profiles.yaml

### DIFF
--- a/backend/app/schemas/seed_profile.py
+++ b/backend/app/schemas/seed_profile.py
@@ -1,0 +1,57 @@
+"""Pydantic schemas for validating backend/seeds/profiles.yaml."""
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+ALLOWED_OS = frozenset({"LINUX", "WSL", "WIN"})
+
+
+class ProfilePackageSeedSchema(BaseModel):
+    """Package entry as defined in profiles.yaml."""
+
+    name: str = Field(..., min_length=1, max_length=128)
+    version_spec: str = Field(..., min_length=1, max_length=64)
+    cuda_variant: str | None = Field(None, max_length=32)
+    is_optional: bool = False
+    install_order: int = Field(0, ge=0)
+
+
+class ProfileSeedSchema(BaseModel):
+    """Single environment profile entry from profiles.yaml."""
+
+    slug: str = Field(..., min_length=1, max_length=64, pattern=r"^[a-z0-9-]+$")
+    name: str = Field(..., min_length=1, max_length=128)
+    description: str = ""
+    tags: list[str] = Field(default_factory=list)
+    os_support: list[str] = Field(..., min_length=1)
+    cuda_required: bool = False
+    python_versions: list[str] = Field(..., min_length=1)
+    cuda_versions: list[str] = Field(default_factory=list)
+    status: Literal["ACTIVE", "DEPRECATED"] = "ACTIVE"
+    last_validated: date | None = None
+    packages: list[ProfilePackageSeedSchema] = Field(default_factory=list)
+
+    @field_validator("description", mode="before")
+    @classmethod
+    def normalize_description(cls, value: object) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
+
+    @field_validator("os_support")
+    @classmethod
+    def validate_os_support(cls, value: list[str]) -> list[str]:
+        invalid = [os_name for os_name in value if os_name not in ALLOWED_OS]
+        if invalid:
+            allowed = ", ".join(sorted(ALLOWED_OS))
+            raise ValueError(
+                f"Invalid os_support values: {invalid}. Allowed: {allowed}"
+            )
+        return value
+
+
+class ProfilesYamlSchema(BaseModel):
+    """Root structure of profiles.yaml."""
+
+    profiles: list[ProfileSeedSchema]

--- a/backend/app/schemas/seed_profile.py
+++ b/backend/app/schemas/seed_profile.py
@@ -37,7 +37,9 @@ class ProfileSeedSchema(BaseModel):
     def normalize_description(cls, value: object) -> str:
         if value is None:
             return ""
-        return str(value).strip()
+        if not isinstance(value, str):
+            raise ValueError("description must be a string")
+        return value.strip()
 
     @field_validator("os_support")
     @classmethod

--- a/backend/app/services/seed_service.py
+++ b/backend/app/services/seed_service.py
@@ -6,18 +6,34 @@ Usage:
     python -m app.services.seed_service
 """
 import asyncio
-import datetime
-import sys
 from pathlib import Path
 
 import yaml
+from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import AsyncSessionLocal
 from app.models.profile import EnvironmentProfile, ProfilePackage
+from app.schemas.seed_profile import ProfileSeedSchema
 
 SEEDS_DIR = Path(__file__).parent.parent.parent / "seeds"
+
+
+def _format_validation_errors(exc: ValidationError) -> str:
+    parts: list[str] = []
+    for error in exc.errors():
+        location = ".".join(str(part) for part in error["loc"])
+        parts.append(f"{location}: {error['msg']}")
+    return "; ".join(parts)
+
+
+def _profile_ref(raw: object, index: int) -> str:
+    if isinstance(raw, dict):
+        slug = raw.get("slug")
+        if slug:
+            return str(slug)
+    return f"index={index}"
 
 
 async def seed_profiles(db: AsyncSession) -> None:
@@ -27,60 +43,88 @@ async def seed_profiles(db: AsyncSession) -> None:
         print(f"[seed] profiles.yaml not found at {profiles_file}")
         return
 
-    data = yaml.safe_load(profiles_file.read_text(encoding="utf-8"))
-    profiles_data = data.get("profiles", [])
+    try:
+        data = yaml.safe_load(profiles_file.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        print(f"[seed] Failed to parse profiles.yaml: {exc}")
+        return
+
+    if data is None:
+        print("[seed] profiles.yaml is empty")
+        return
+
+    if not isinstance(data, dict):
+        print(
+            f"[seed] Invalid profiles.yaml: expected mapping at root, "
+            f"got {type(data).__name__}"
+        )
+        return
+
+    profiles_data = data.get("profiles")
+    if not isinstance(profiles_data, list):
+        print("[seed] Invalid profiles.yaml: 'profiles' must be a list")
+        return
+
     seeded = 0
     skipped = 0
+    invalid = 0
 
-    for p in profiles_data:
-        # Check if profile already exists (idempotent)
+    for index, raw_profile in enumerate(profiles_data):
+        profile_ref = _profile_ref(raw_profile, index)
+        try:
+            profile_data = ProfileSeedSchema.model_validate(raw_profile)
+        except ValidationError as exc:
+            print(
+                f"[seed] Skipping profile '{profile_ref}': "
+                f"{_format_validation_errors(exc)}"
+            )
+            invalid += 1
+            continue
+
         result = await db.execute(
-            select(EnvironmentProfile).where(EnvironmentProfile.slug == p["slug"])
+            select(EnvironmentProfile).where(
+                EnvironmentProfile.slug == profile_data.slug
+            )
         )
         existing = result.scalar_one_or_none()
         if existing:
             skipped += 1
             continue
 
-        # Build profile
-        last_validated = None
-        if p.get("last_validated"):
-            lv = p["last_validated"]
-            if isinstance(lv, str):
-                last_validated = datetime.date.fromisoformat(lv)
-            elif isinstance(lv, datetime.date):
-                last_validated = lv
-
         profile = EnvironmentProfile(
-            slug=p["slug"],
-            name=p["name"],
-            description=p.get("description", "").strip(),
-            tags=p.get("tags", []),
-            os_support=p["os_support"],
-            cuda_required=p.get("cuda_required", False),
-            python_versions=p["python_versions"],
-            cuda_versions=p.get("cuda_versions") or [],
-            status=p.get("status", "ACTIVE"),
-            last_validated=last_validated,
+            slug=profile_data.slug,
+            name=profile_data.name,
+            description=profile_data.description,
+            tags=profile_data.tags,
+            os_support=profile_data.os_support,
+            cuda_required=profile_data.cuda_required,
+            python_versions=profile_data.python_versions,
+            cuda_versions=profile_data.cuda_versions,
+            status=profile_data.status,
+            last_validated=profile_data.last_validated,
         )
         db.add(profile)
-        await db.flush()  # Get profile.id
+        await db.flush()
 
-        # Build packages
-        for pkg in p.get("packages", []):
-            db.add(ProfilePackage(
-                profile_id=profile.id,
-                package_name=pkg["name"],
-                version_spec=pkg["version_spec"],
-                cuda_variant=pkg.get("cuda_variant"),
-                is_optional=pkg.get("is_optional", False),
-                install_order=pkg.get("install_order", 0),
-            ))
+        for pkg in profile_data.packages:
+            db.add(
+                ProfilePackage(
+                    profile_id=profile.id,
+                    package_name=pkg.name,
+                    version_spec=pkg.version_spec,
+                    cuda_variant=pkg.cuda_variant,
+                    is_optional=pkg.is_optional,
+                    install_order=pkg.install_order,
+                )
+            )
 
         seeded += 1
 
     await db.commit()
-    print(f"[seed] Profiles: {seeded} seeded, {skipped} already existed.")
+    print(
+        f"[seed] Profiles: {seeded} seeded, {skipped} already existed, "
+        f"{invalid} invalid (skipped)."
+    )
 
 
 async def run_all_seeds() -> None:

--- a/backend/app/services/seed_service.py
+++ b/backend/app/services/seed_service.py
@@ -44,7 +44,11 @@ async def seed_profiles(db: AsyncSession) -> None:
         return
 
     try:
-        data = yaml.safe_load(profiles_file.read_text(encoding="utf-8"))
+        raw_text = profiles_file.read_text(encoding="utf-8")
+        data = yaml.safe_load(raw_text)
+    except (OSError, UnicodeDecodeError) as exc:
+        print(f"[seed] Failed to read profiles.yaml: {exc}")
+        return
     except yaml.YAMLError as exc:
         print(f"[seed] Failed to parse profiles.yaml: {exc}")
         return

--- a/backend/tests/unit/services/test_seed_profile_validation.py
+++ b/backend/tests/unit/services/test_seed_profile_validation.py
@@ -71,6 +71,13 @@ def test_invalid_status_raises():
         ProfileSeedSchema.model_validate(data)
 
 
+def test_non_string_description_raises():
+    data = _valid_profile()
+    data["description"] = ["not", "a", "string"]
+    with pytest.raises(ValidationError):
+        ProfileSeedSchema.model_validate(data)
+
+
 def test_profiles_yaml_root_schema():
     root = ProfilesYamlSchema.model_validate(
         {"profiles": [_valid_profile()]}

--- a/backend/tests/unit/services/test_seed_profile_validation.py
+++ b/backend/tests/unit/services/test_seed_profile_validation.py
@@ -1,0 +1,89 @@
+"""Unit tests for profiles.yaml Pydantic validation schemas."""
+from datetime import date
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from app.schemas.seed_profile import ProfileSeedSchema, ProfilesYamlSchema
+
+SEEDS_FILE = (
+    Path(__file__).resolve().parents[3] / "seeds" / "profiles.yaml"
+)
+
+
+def _valid_profile() -> dict:
+    return {
+        "slug": "pytorch-cuda",
+        "name": "PyTorch CUDA",
+        "description": "Test profile",
+        "tags": ["gpu"],
+        "os_support": ["LINUX", "WSL"],
+        "cuda_required": True,
+        "python_versions": ["3.10", "3.11"],
+        "cuda_versions": ["11.8"],
+        "status": "ACTIVE",
+        "last_validated": "2024-12-01",
+        "packages": [
+            {
+                "name": "torch",
+                "version_spec": "2.1.2",
+                "cuda_variant": "cu118",
+                "install_order": 0,
+            }
+        ],
+    }
+
+
+def test_valid_profile_parses():
+    profile = ProfileSeedSchema.model_validate(_valid_profile())
+    assert profile.slug == "pytorch-cuda"
+    assert profile.packages[0].name == "torch"
+    assert profile.last_validated == date(2024, 12, 1)
+
+
+def test_missing_slug_raises():
+    data = _valid_profile()
+    del data["slug"]
+    with pytest.raises(ValidationError):
+        ProfileSeedSchema.model_validate(data)
+
+
+def test_invalid_os_support_raises():
+    data = _valid_profile()
+    data["os_support"] = ["MAC"]
+    with pytest.raises(ValidationError):
+        ProfileSeedSchema.model_validate(data)
+
+
+def test_missing_package_version_spec_raises():
+    data = _valid_profile()
+    del data["packages"][0]["version_spec"]
+    with pytest.raises(ValidationError):
+        ProfileSeedSchema.model_validate(data)
+
+
+def test_invalid_status_raises():
+    data = _valid_profile()
+    data["status"] = "active"
+    with pytest.raises(ValidationError):
+        ProfileSeedSchema.model_validate(data)
+
+
+def test_profiles_yaml_root_schema():
+    root = ProfilesYamlSchema.model_validate(
+        {"profiles": [_valid_profile()]}
+    )
+    assert len(root.profiles) == 1
+
+
+def test_profiles_yaml_missing_profiles_raises():
+    with pytest.raises(ValidationError):
+        ProfilesYamlSchema.model_validate({})
+
+
+def test_shipped_profiles_yaml_validates():
+    data = yaml.safe_load(SEEDS_FILE.read_text(encoding="utf-8"))
+    root = ProfilesYamlSchema.model_validate(data)
+    assert len(root.profiles) >= 6


### PR DESCRIPTION
## Description

Implements Phase 6 hardening for the YAML seed service (ADR-005): `profiles.yaml` is now validated with Pydantic before any database insert.

Previously, `seed_profiles()` read YAML into plain dicts and accessed keys directly (`p["slug"]`, `pkg["version_spec"]`, etc.), so typos or malformed entries could cause `KeyError` or failed inserts at startup. 

This PR validates each profile first, logs clear errors for invalid entries, and skips only the broken profiles while continuing to seed valid ones.

## Related Issues
Closes #10

## Changes Made
- Added `backend/app/schemas/seed_profile.py` with Pydantic models:
  - `ProfilePackageSeedSchema` — package fields from YAML (`name`, `version_spec`, `cuda_variant`, etc.)
  - `ProfileSeedSchema` — profile fields with `os_support` and `status` validation
  - `ProfilesYamlSchema` — root `{ profiles: [...] }` structure
- Updated `backend/app/services/seed_service.py` to:
  - Validate each profile via `ProfileSeedSchema.model_validate()` before insert
  - Handle YAML parse errors and invalid root structure
  - On `ValidationError`, log profile slug (or `index=N`) and field-level errors, then skip that profile
  - Report `invalid (skipped)` count in the seed summary
- Added `backend/tests/unit/services/test_seed_profile_validation.py` (9 unit tests)


## Verification
<!-- Describe how you verified that your changes work. -->
- [X] Added unit tests
- [X] Ran `pytest tests/` successfully

**Test command:**
```bash
cd backend
python3 -m pytest tests/unit/services/test_seed_profile_validation.py -v
```

## Screenshots 

<img width="1274" height="294" alt="Screenshot 2026-05-19 at 12 29 37 PM" src="https://github.com/user-attachments/assets/304f0b1a-4a8c-43fb-8360-9de203fde9b2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced profile seeding with improved validation and detailed error reporting for invalid configurations
  
* **Tests**
  * Added comprehensive validation tests ensuring profile data integrity and configuration correctness

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->