### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/backend/app/api/v1/troubleshoot.py
+++ b/backend/app/api/v1/troubleshoot.py
@@ -48,8 +48,8 @@ async def troubleshoot(
                     # Format as standard SSE
                     yield f"data: {chunk}\n\n"
             except Exception as exc:
-                logger.error("Error in troubleshoot stream generator: %s", exc)
-                yield f"data: {{\"error\": \"STREAM_ERROR\", \"message\": \"{str(exc)}\"}}\n\n"
+                logger.exception("Error in troubleshoot stream generator")
+                yield "data: {\"error\": \"STREAM_ERROR\", \"message\": \"An internal error occurred while streaming analysis.\"}\n\n"
 
         return StreamingResponse(
             event_generator(),


### PR DESCRIPTION
Potential fix for [https://github.com/rishabh0510rishabh/EnvForage/security/code-scanning/3](https://github.com/rishabh0510rishabh/EnvForage/security/code-scanning/3)

The fix is to stop returning raw exception details to clients and replace them with a generic, non-sensitive message, while keeping detailed diagnostics in server logs.

Best fix for this file:
- In `backend/app/api/v1/troubleshoot.py`, within `event_generator()`’s `except Exception as exc:` block (around lines 50–52), keep logging the exception but change the streamed error payload to a constant generic message.
- Also prefer `logger.exception(...)` there so stack trace remains available server-side without exposing it to clients.
- No functional behavior change to streaming protocol: still emits an SSE error event-like data payload, just sanitized.

No new methods or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling in the streaming API with standardized error responses, ensuring consistent messaging across the application. Enhanced server-side error logging provides better system diagnostics and reliability monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->