### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   backend-tests:
     name: Backend Tests


### PR DESCRIPTION
Potential fix for [https://github.com/rishabh0510rishabh/EnvForage/security/code-scanning/1](https://github.com/rishabh0510rishabh/EnvForage/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access by default.

Best single fix without changing functionality:
- In `.github/workflows/ci.yml`, insert after the `on:` trigger block (before `jobs:`):
  - `permissions:`
  - `contents: read`

Why this is best:
- It addresses the CodeQL finding for all current jobs at once.
- It preserves current workflow behavior for checkout/tests.
- It documents intended minimal token scope and protects against permissive defaults if the workflow is moved/copied.

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
