### PR TITLE
feat(cli): add --dry-run flag to envforge fix command

### DIFF
--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -410,7 +410,11 @@ def _print_verification_summary(data: dict, is_gpu_profile: bool) -> None:
     show_default=True,
     envvar="ENVFORGE_API_URL",
 )
-def fix(report: str, profile: str, api_url: str) -> None:
+@click.option(
+    "--dry-run", is_flag=True, default=False,
+    help="Preview the names of the scripts and resolved packages without printing their full contents.",
+)
+def fix(report: str, profile: str, api_url: str, dry_run: bool) -> None:
     """
     Generate a repair script based on a saved diagnostic report.
 
@@ -444,13 +448,22 @@ def fix(report: str, profile: str, api_url: str) -> None:
         result = response.json()
 
         console.print(f"[green]✓[/] Scripts generated (job: {result.get('job_id', '?')})")
-        for script in result.get("scripts", []):
-            console.print(
-                Panel(
-                    Syntax(script["content"], "bash", theme="monokai", line_numbers=True),
-                    title=f"[bold]{script['filename']}[/]",
+        
+        if result.get("resolved_packages"):
+            console.print(f"  [cyan]Resolved Packages:[/] {', '.join(result['resolved_packages'])}")
+            
+        if dry_run:
+            console.print("\n[bold]Files to be generated:[/]")
+            for script in result.get("scripts", []):
+                console.print(f"  • {script['filename']}")
+        else:
+            for script in result.get("scripts", []):
+                console.print(
+                    Panel(
+                        Syntax(script["content"], "bash", theme="monokai", line_numbers=True),
+                        title=f"[bold]{script['filename']}[/]",
+                    )
                 )
-            )
 
         download_url = f"{api_url.rstrip('/')}{result.get('download_url', '')}"
         console.print(f"\n  Download all: [link={download_url}]{download_url}[/link]")


### PR DESCRIPTION
## Summary
Closes #87

## What changed
Added `--dry-run` flag to `envforge fix` command in `cli/envforge_agent/cli.py`.

## Why
Users reported that `envforge fix` immediately floods the terminal 
with full script payloads. The `--dry-run` flag lets users preview 
what will be generated before committing.

## Changes
- Added `--dry-run` boolean flag to the `fix` Click command
- Added resolved packages display (was missing in original)
- Branched output logic:
  - `--dry-run`: shows job ID, resolved packages, filenames only
  - normal: renders full syntax-highlighted script panels

## Testing
Tested via `CliRunner` with mocked API response (as EnvForge does not support macOS natively).

<img width="572" height="542" alt="Screenshot 2026-05-19 at 11 57 22 PM" src="https://github.com/user-attachments/assets/607d1933-7c82-4815-aee9-f93d0f1894ef" />

## How to test
```bash
envforge fix --report report.json --profile pytorch-cuda --dry-run
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --dry-run flag to the envforge fix command to show resolved packages and script filenames without rendering full script contents.
* **Bug Fixes**
  * /api/v1/diagnose now requires active_python and consistently derives python_version; defaults target OS to LINUX when absent.
  * Health response now reflects the configured application name.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->