### PR TITLE
feat: support pyproject.toml generation as output format (#82)

### DIFF
--- a/backend/app/schemas/script.py
+++ b/backend/app/schemas/script.py
@@ -5,7 +5,7 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 OSTarget = Literal["LINUX", "WSL", "WIN"]
-OutputFormat = Literal["setup.sh", "setup.ps1", "requirements.txt", "Dockerfile", "devcontainer.json"]
+OutputFormat = Literal["setup.sh", "setup.ps1", "requirements.txt", "Dockerfile", "devcontainer.json", "pyproject.toml"]
 
 
 class GenerationRequest(BaseModel):

--- a/backend/app/templates/engine.py
+++ b/backend/app/templates/engine.py
@@ -25,7 +25,8 @@ TEMPLATE_MAP: dict[str, str] = {
     "verify_torch.sh":    "verify/verify_torch.sh.j2",
     "verify_tf.sh":       "verify/verify_tf.sh.j2",
     "verify_opencv.sh":   "verify/verify_opencv.sh.j2",
-    "environment.yml":      "config/environment.yml.j2",
+    "environment.yml":    "config/environment.yml.j2",
+    "pyproject.toml":     "config/pyproject.toml.j2",
 }
 
 # ── Profile-specific verify template mapping ───────────────────────────────────

--- a/backend/app/templates/jinja/config/pyproject.toml.j2
+++ b/backend/app/templates/jinja/config/pyproject.toml.j2
@@ -1,0 +1,19 @@
+# ==============================================================================
+# EnvForge Generated pyproject.toml
+# Profile  : {{ profile.name }}
+# Python   : {{ python_version }}
+{% if cuda_version %}# CUDA     : {{ cuda_version }}
+{% endif %}# Generated: {{ generated_at }}
+# EnvForge : v{{ envforge_version }}
+# ==============================================================================
+
+[project]
+name = "envforge-generated"
+version = "0.1.0"
+description = "Generated dependencies for {{ profile.name }}"
+requires-python = ">= {{ python_version }}"
+dependencies = [
+{% for pkg in packages %}
+    "{{ pkg.pip_spec }}",
+{% endfor %}
+]

--- a/backend/tests/unit/templates/test_pyproject_template.py
+++ b/backend/tests/unit/templates/test_pyproject_template.py
@@ -1,0 +1,79 @@
+from app.compatibility.models import ResolvedEnvironment, ResolvedPackage
+from app.templates.engine import TemplateRenderer
+from app.templates.models import TemplateContext
+
+
+def make_context(
+    profile_name="myenv",
+    python_version="3.10",
+    cuda_version=None,
+    packages=None,
+):
+    if packages is None:
+        packages = []
+    resolved = ResolvedEnvironment(
+        python_version=python_version,
+        cuda_version=cuda_version,
+        target_os="LINUX",
+        packages=packages,
+    )
+    return TemplateContext(
+        profile_id="test-id",
+        profile_name=profile_name,
+        resolved=resolved,
+    )
+
+
+def test_pyproject_template_renders_basic():
+    context = make_context(
+        profile_name="myenv",
+        python_version="3.10",
+        packages=[
+            ResolvedPackage(name="numpy", version="1.24.0", cuda_variant=None),
+            ResolvedPackage(name="pandas", version="2.0.0", cuda_variant=None),
+        ],
+    )
+    renderer = TemplateRenderer()
+    result = renderer.render("pyproject.toml", context)
+    
+    # Check headers
+    assert "myenv" in result.content
+    assert "3.10" in result.content
+    
+    # Check TOML format
+    assert '[project]' in result.content
+    assert 'name = "envforge-generated"' in result.content
+    assert 'requires-python = ">= 3.10"' in result.content
+    assert 'dependencies = [' in result.content
+    assert '"numpy==1.24.0",' in result.content
+    assert '"pandas==2.0.0",' in result.content
+
+
+def test_pyproject_template_no_cuda():
+    context = make_context(
+        profile_name="cpu-env",
+        python_version="3.9",
+        cuda_version=None,
+        packages=[
+            ResolvedPackage(name="scipy", version="1.10.0", cuda_variant=None),
+        ],
+    )
+    renderer = TemplateRenderer()
+    result = renderer.render("pyproject.toml", context)
+    assert "CUDA" not in result.content
+    assert '"scipy==1.10.0",' in result.content
+
+
+def test_pyproject_template_with_cuda():
+    context = make_context(
+        profile_name="gpu-env",
+        python_version="3.11",
+        cuda_version="11.8",
+        packages=[
+            ResolvedPackage(name="torch", version="2.0.0", cuda_variant="cu118"),
+        ],
+    )
+    renderer = TemplateRenderer()
+    result = renderer.render("pyproject.toml", context)
+    assert "# CUDA     : 11.8" in result.content
+    assert '"torch==2.0.0+cu118",' in result.content


### PR DESCRIPTION
Closes #82

Adds support for generating PEP 621 compliant `pyproject.toml` files from the backend API.

- Added `"pyproject.toml"` to valid `OutputFormat` API payload schema.
- Registered `"pyproject.toml"` mapped to `pyproject.toml.j2` Jinja2 template.
- Iterates over resolved dependencies array correctly.
- Added comprehensive unit tests (all passing).

### Proof of working format:


<img width="432" height="490" alt="Screenshot 2026-05-20 at 7 25 59 PM" src="https://github.com/user-attachments/assets/1964fccc-9f7a-4c90-a0e8-57629b5277de" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating `pyproject.toml` configuration files with project metadata, Python version requirements, and dependencies (including optional CUDA support).

* **Tests**
  * Added comprehensive test coverage for `pyproject.toml` generation functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->