### PR TITLE
feat(compatibility): add CUDA 12.5 and 12.6 to compatibility matrix

### DIFF
--- a/backend/app/compatibility/matrix/cuda.py
+++ b/backend/app/compatibility/matrix/cuda.py
@@ -63,6 +63,24 @@ CUDA_MATRIX: dict[str, CUDAMatrixEntry] = {
         notes="Latest stable. Required for PyTorch 2.3+.",
         source_url="https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/",
     ),
+    "12.5": CUDAMatrixEntry(
+        cuda_version="12.5",
+        min_driver_linux="555.42.02",
+        min_driver_windows="555.85",
+        cudnn_versions=["9.2.0", "9.3.0"],
+        supported_archs=["sm_50", "sm_60", "sm_70", "sm_75", "sm_80", "sm_86", "sm_89", "sm_90"],
+        notes="Supports Blackwell architecture (sm_100). Required for PyTorch 2.4+.",
+        source_url="https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/",
+    ),
+    "12.6": CUDAMatrixEntry(
+        cuda_version="12.6",
+        min_driver_linux="560.35.03",
+        min_driver_windows="560.94",
+        cudnn_versions=["9.3.0", "9.5.0"],
+        supported_archs=["sm_50", "sm_60", "sm_70", "sm_75", "sm_80", "sm_86", "sm_89", "sm_90"],
+        notes="Latest release. Broad Blackwell and Ada Lovelace support.",
+        source_url="https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/",
+    ),
 }
 
 # Ordered list for display / validation purposes
@@ -89,6 +107,7 @@ FRAMEWORK_CUDA_SUPPORT: dict[str, dict[str, list[str]]] = {
         "2.3.0": ["11.8", "12.1"],
         "2.3.1": ["11.8", "12.1"],
         "2.4.0": ["11.8", "12.1", "12.4"],
+        "2.5.0": ["12.1", "12.4", "12.6"],
     },
     "tensorflow": {
         # TensorFlow uses XLA CUDA support — often lags behind PyTorch
@@ -110,6 +129,7 @@ FRAMEWORK_CUDA_SUPPORT: dict[str, dict[str, list[str]]] = {
         "0.4.25": ["11.8", "12.1", "12.3"],
         "0.4.26": ["12.1"],
         "0.4.28": ["12.1", "12.4"],
+        "0.4.30": ["12.1", "12.4", "12.6"],
     },
 }
 

--- a/backend/app/compatibility/matrix/cuda.py
+++ b/backend/app/compatibility/matrix/cuda.py
@@ -69,7 +69,7 @@ CUDA_MATRIX: dict[str, CUDAMatrixEntry] = {
         min_driver_windows="555.85",
         cudnn_versions=["9.2.0", "9.3.0"],
         supported_archs=["sm_50", "sm_60", "sm_70", "sm_75", "sm_80", "sm_86", "sm_89", "sm_90"],
-        notes="Supports Blackwell architecture (sm_100). Required for PyTorch 2.4+.",
+        notes="Improved Ada Lovelace support. Required for PyTorch 2.4+.",
         source_url="https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/",
     ),
     "12.6": CUDAMatrixEntry(
@@ -78,7 +78,7 @@ CUDA_MATRIX: dict[str, CUDAMatrixEntry] = {
         min_driver_windows="560.94",
         cudnn_versions=["9.3.0", "9.5.0"],
         supported_archs=["sm_50", "sm_60", "sm_70", "sm_75", "sm_80", "sm_86", "sm_89", "sm_90"],
-        notes="Latest release. Broad Blackwell and Ada Lovelace support.",
+        notes="Latest stable release. Broad Ada Lovelace (RTX 40xx) support.",
         source_url="https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/",
     ),
 }

--- a/backend/seeds/cuda_matrix.yaml
+++ b/backend/seeds/cuda_matrix.yaml
@@ -25,3 +25,20 @@ cuda_matrix:
     supported_archs: ["sm_50", "sm_60", "sm_70", "sm_75", "sm_80", "sm_86", "sm_89", "sm_90"]
     notes: "Latest stable. Required for PyTorch 2.3+."
     source_url: "https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/"
+
+  - cuda_version: "12.5"
+    min_driver_linux: "555.42.02"
+    min_driver_windows: "555.85"
+    cudnn_versions: ["9.2.0", "9.3.0"]
+    supported_archs: ["sm_50", "sm_60", "sm_70", "sm_75", "sm_80", "sm_86", "sm_89", "sm_90"]
+    notes: "Supports Blackwell architecture (sm_100). Required for PyTorch 2.4+."
+    source_url: "https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/"
+
+  - cuda_version: "12.6"
+    min_driver_linux: "560.35.03"
+    min_driver_windows: "560.94"
+    cudnn_versions: ["9.3.0", "9.5.0"]
+    supported_archs: ["sm_50", "sm_60", "sm_70", "sm_75", "sm_80", "sm_86", "sm_89", "sm_90"]
+    notes: "Latest release. Broad Blackwell and Ada Lovelace support."
+    source_url: "https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/"
+    

--- a/backend/seeds/cuda_matrix.yaml
+++ b/backend/seeds/cuda_matrix.yaml
@@ -31,7 +31,8 @@ cuda_matrix:
     min_driver_windows: "555.85"
     cudnn_versions: ["9.2.0", "9.3.0"]
     supported_archs: ["sm_50", "sm_60", "sm_70", "sm_75", "sm_80", "sm_86", "sm_89", "sm_90"]
-    notes: "Supports Blackwell architecture (sm_100). Required for PyTorch 2.4+."
+    notes: "Improved Ada Lovelace support. Required for PyTorch 2.4+."
+    
     source_url: "https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/"
 
   - cuda_version: "12.6"
@@ -39,6 +40,6 @@ cuda_matrix:
     min_driver_windows: "560.94"
     cudnn_versions: ["9.3.0", "9.5.0"]
     supported_archs: ["sm_50", "sm_60", "sm_70", "sm_75", "sm_80", "sm_86", "sm_89", "sm_90"]
-    notes: "Latest release. Broad Blackwell and Ada Lovelace support."
+    notes: "Latest stable release. Broad Ada Lovelace (RTX 40xx) support."
     source_url: "https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/"
-    
+

--- a/backend/tests/unit/compatibility/test_resolver.py
+++ b/backend/tests/unit/compatibility/test_resolver.py
@@ -144,3 +144,27 @@ def test_jax_unknown_version_returns_empty():
     from app.compatibility.matrix.cuda import get_supported_cuda_for_framework
     cuda_versions = get_supported_cuda_for_framework("jax", "0.0.0")
     assert cuda_versions == []
+
+def test_cuda_125_in_matrix():
+    """CUDA 12.5 must be recognized in the matrix."""
+    from app.compatibility.matrix.cuda import get_cuda_entry
+    entry = get_cuda_entry("12.5")
+    assert entry is not None
+    assert entry.min_driver_linux == "555.42.02"
+    assert entry.min_driver_windows == "555.85"
+
+
+def test_cuda_126_in_matrix():
+    """CUDA 12.6 must be recognized in the matrix."""
+    from app.compatibility.matrix.cuda import get_cuda_entry
+    entry = get_cuda_entry("12.6")
+    assert entry is not None
+    assert entry.min_driver_linux == "560.35.03"
+    assert entry.min_driver_windows == "560.94"
+
+
+def test_cuda_125_126_in_supported_versions():
+    """12.5 and 12.6 must appear in SUPPORTED_CUDA_VERSIONS."""
+    from app.compatibility.matrix.cuda import SUPPORTED_CUDA_VERSIONS
+    assert "12.5" in SUPPORTED_CUDA_VERSIONS
+    assert "12.6" in SUPPORTED_CUDA_VERSIONS


### PR DESCRIPTION
## Description
NVIDIA has released CUDA 12.5 and 12.6, but EnvForge's Compatibility Engine
only mapped up to CUDA 12.4. Users with latest hardware and drivers were
getting `UnknownVersionError`. This PR adds full support for both versions.

## Related Issues
Closes #89

## Changes Made
- Added CUDA 12.5 entry to `CUDA_MATRIX` (min driver Linux 555.42.02, Windows 555.85)
- Added CUDA 12.6 entry to `CUDA_MATRIX` (min driver Linux 560.35.03, Windows 560.94)
- Added PyTorch 2.5.0 CUDA support mapping (12.1, 12.4, 12.6)
- Added JAX 0.4.30 CUDA support mapping (12.1, 12.4, 12.6)
- Updated `seeds/cuda_matrix.yaml` with both new entries
- Added 3 unit tests verifying 12.5 and 12.6 recognition

## Verification
- [x] Added unit tests
- [x] Ran `pytest tests/` successfully — 115 passed, 0 failed
- [x] Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated `docs/FEATURES.md`
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted

## Screenshots (if applicable)
All 115 tests passing — verified locally via pytest.
<img width="362" height="27" alt="image" src="https://github.com/user-attachments/assets/77af29f0-9a30-49f8-9a8c-acf8c8a75e46" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CUDA versions 12.5 and 12.6 with corresponding driver version requirements and GPU architecture compatibility
  * Updated framework compatibility information for PyTorch 2.5.0 and JAX 0.4.30 to include CUDA 12.6 support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->