### PR TITLE
feat(api): expose compatibility matrices via REST endpoints (#85)

### DIFF
--- a/backend/app/api/v1/compatibility.py
+++ b/backend/app/api/v1/compatibility.py
@@ -1,0 +1,205 @@
+"""
+Compatibility Matrix API endpoints.
+Exposes CUDA, ROCm, and Python compatibility matrices as read-only REST endpoints.
+Resolves Issue #85.
+"""
+from fastapi import APIRouter, HTTPException
+from app.compatibility.matrix.cuda import (
+ CUDA_MATRIX,
+ FRAMEWORK_CUDA_SUPPORT,
+ SUPPORTED_CUDA_VERSIONS,
+)
+from app.compatibility.matrix.rocm import (
+ ROCM_MATRIX,
+ FRAMEWORK_ROCM_SUPPORT,
+ SUPPORTED_ROCM_VERSIONS,
+)
+from app.compatibility.matrix.python import PYTHON_MATRIX
+router = APIRouter(prefix="/compatibility")
+# ── Summary ───────────────────────────────────────────────────────────────────
+@router.get("", summary="Summary of all compatibility matrices")
+async def get_compatibility_summary() -> dict:
+ """
+ Returns a high-level summary of all available compatibility matrices.
+ Useful for frontend dropdowns and dynamic table headers.
+ """
+ return {
+ "matrices": {
+ "cuda": {
+ "description": "CUDA version → NVIDIA driver + cuDNN + supported GPU architectures",
+ "endpoint": "/api/v1/compatibility/cuda",
+ "supported_versions": SUPPORTED_CUDA_VERSIONS,
+ "count": len(CUDA_MATRIX),
+ },
+ "rocm": {
+ "description": "ROCm version → Linux driver + supported AMD GPU architectures",
+ "endpoint": "/api/v1/compatibility/rocm",
+ "supported_versions": SUPPORTED_ROCM_VERSIONS,
+ "count": len(ROCM_MATRIX),
+ },
+ "python": {
+ "description": "Framework version → supported Python versions + CUDA/ROCm versions",
+ "endpoint": "/api/v1/compatibility/python",
+ "supported_frameworks": sorted(PYTHON_MATRIX.keys()),
+ "count": sum(len(v) for v in PYTHON_MATRIX.values()),
+ },
+ }
+ }
+# ── CUDA ──────────────────────────────────────────────────────────────────────
+@router.get("/cuda", summary="List all CUDA compatibility entries")
+async def get_cuda_matrix() -> dict:
+ """
+ Returns the full CUDA compatibility matrix.
+ Each entry maps a CUDA version to its minimum required NVIDIA driver
+ (Linux + Windows), supported cuDNN versions, and supported GPU architectures.
+ """
+ return {
+ "matrix": "cuda",
+ "count": len(CUDA_MATRIX),
+ "supported_versions": SUPPORTED_CUDA_VERSIONS,
+ "data": {version: entry.model_dump() for version, entry in CUDA_MATRIX.items()},
+ }
+@router.get("/cuda/frameworks", summary="List framework → CUDA version support map")
+async def get_framework_cuda_support() -> dict:
+ """
+ Returns the framework → CUDA version support map.
+ Shows which CUDA versions each framework version officially supports.
+ """
+ return {
+ "matrix": "framework_cuda_support",
+ "data": FRAMEWORK_CUDA_SUPPORT,
+ }
+@router.get("/cuda/{cuda_version}", summary="Get a single CUDA version entry")
+async def get_cuda_version(cuda_version: str) -> dict:
+ """
+ Returns the compatibility entry for a specific CUDA version.
+ - **cuda_version**: e.g. `11.8`, `12.1`, `12.4`
+ """
+ entry = CUDA_MATRIX.get(cuda_version)
+ if entry is None:
+ raise HTTPException(
+ status_code=404,
+ detail={
+ "error": {
+ "code": "CUDA_VERSION_NOT_FOUND",
+ "message": f"CUDA version '{cuda_version}' is not in the compatibility matrix.",
+ "supported_versions": SUPPORTED_CUDA_VERSIONS,
+ }
+ },
+ )
+ return {"cuda_version": cuda_version, **entry.model_dump()}
+# ── ROCm ──────────────────────────────────────────────────────────────────────
+@router.get("/rocm", summary="List all ROCm compatibility entries")
+async def get_rocm_matrix() -> dict:
+ """
+ Returns the full ROCm compatibility matrix.
+ Each entry maps a ROCm version to its minimum required Linux driver version
+ and supported AMD GPU architectures.
+ """
+ return {
+ "matrix": "rocm",
+ "count": len(ROCM_MATRIX),
+ "supported_versions": SUPPORTED_ROCM_VERSIONS,
+ "data": {version: entry.model_dump() for version, entry in ROCM_MATRIX.items()},
+ }
+@router.get("/rocm/frameworks", summary="List framework → ROCm version support map")
+async def get_framework_rocm_support() -> dict:
+ """
+ Returns the framework → ROCm version support map.
+ Shows which ROCm versions each framework version officially supports.
+ """
+ return {
+ "matrix": "framework_rocm_support",
+ "data": FRAMEWORK_ROCM_SUPPORT,
+ }
+@router.get("/rocm/{rocm_version}", summary="Get a single ROCm version entry")
+async def get_rocm_version(rocm_version: str) -> dict:
+ """
+ Returns the compatibility entry for a specific ROCm version.
+ - **rocm_version**: e.g. `5.7.0`, `6.0.0`
+ """
+ entry = ROCM_MATRIX.get(rocm_version)
+ if entry is None:
+ raise HTTPException(
+ status_code=404,
+ detail={
+ "error": {
+ "code": "ROCM_VERSION_NOT_FOUND",
+ "message": f"ROCm version '{rocm_version}' is not in the compatibility matrix.",
+ "supported_versions": SUPPORTED_ROCM_VERSIONS,
+ }
+ },
+ )
+ return {"rocm_version": rocm_version, **entry.model_dump()}
+# ── Python ────────────────────────────────────────────────────────────────────
+@router.get("/python", summary="List all Python compatibility entries")
+async def get_python_matrix() -> dict:
+ """
+ Returns the full Python compatibility matrix.
+ Each framework maps to a list of versioned entries showing supported
+ Python versions, CUDA versions, and ROCm versions.
+ """
+ return {
+ "matrix": "python",
+ "supported_frameworks": sorted(PYTHON_MATRIX.keys()),
+ "data": {
+ framework: [entry.model_dump() for entry in entries]
+ for framework, entries in PYTHON_MATRIX.items()
+ },
+ }
+@router.get("/python/{framework}", summary="Get Python compatibility for a specific framework")
+async def get_python_framework(framework: str) -> dict:
+ """
+ Returns all versioned Python compatibility entries for a given framework.
+ - **framework**: e.g. `torch`, `tensorflow`, `ultralytics`
+ """
+ entries = PYTHON_MATRIX.get(framework)
+ if entries is None:
+ raise HTTPException(
+ status_code=404,
+ detail={
+ "error": {
+ "code": "FRAMEWORK_NOT_FOUND",
+ "message": f"Framework '{framework}' is not in the Python compatibility matrix.",
+ "supported_frameworks": sorted(PYTHON_MATRIX.keys()),
+ }
+ },
+ )
+ return {
+ "framework": framework,
+ "count": len(entries),
+ "data": [entry.model_dump() for entry in entries],
+ }
+@router.get("/python/{framework}/{version}", summary="Get Python compatibility for a specific
+framework version")
+async def get_python_framework_version(framework: str, version: str) -> dict:
+ """
+ Returns the Python compatibility entry for a specific framework version.
+ - **framework**: e.g. `torch`, `tensorflow`
+ - **version**: e.g. `2.1.0`, `2.15.0`
+ """
+ entries = PYTHON_MATRIX.get(framework)
+ if entries is None:
+ raise HTTPException(
+ status_code=404,
+ detail={
+ "error": {
+ "code": "FRAMEWORK_NOT_FOUND",
+ "message": f"Framework '{framework}' is not in the Python compatibility matrix.",
+ "supported_frameworks": sorted(PYTHON_MATRIX.keys()),
+ }
+ },
+ )
+ for entry in entries:
+ if entry.version == version:
+ return {"framework": framework, "version": version, **entry.model_dump()}
+ raise HTTPException(
+ status_code=404,
+ detail={
+ "error": {
+ "code": "FRAMEWORK_VERSION_NOT_FOUND",
+ "message": f"Version '{version}' not found for framework '{framework}'.",
+ "available_versions": [e.version for e in entries],
+ }
+ },
+ )

--- a/backend/app/api/v1/compatibility.py
+++ b/backend/app/api/v1/compatibility.py
@@ -3,6 +3,7 @@ Compatibility Matrix API endpoints.
 Exposes CUDA, ROCm, and Python compatibility matrices as read-only REST endpoints.
 Resolves Issue #85.
 """
+from dataclasses import asdict
 from fastapi import APIRouter, HTTPException
 from app.compatibility.matrix.cuda import (
     CUDA_MATRIX,
@@ -62,7 +63,7 @@ async def get_cuda_matrix() -> dict:
         "matrix": "cuda",
         "count": len(CUDA_MATRIX),
         "supported_versions": SUPPORTED_CUDA_VERSIONS,
-        "data": {version: entry.model_dump() for version, entry in CUDA_MATRIX.items()},
+        "data": {version: asdict(entry) for version, entry in CUDA_MATRIX.items()},
     }
 
 @router.get("/cuda/frameworks", summary="List framework → CUDA version support map")
@@ -94,7 +95,7 @@ async def get_cuda_version(cuda_version: str) -> dict:
                 }
             },
         )
-    return {"cuda_version": cuda_version, **entry.model_dump()}
+    return {"cuda_version": cuda_version, **asdict(entry)}
 
 # ── ROCm ──────────────────────────────────────────────────────────────────────
 
@@ -109,7 +110,7 @@ async def get_rocm_matrix() -> dict:
         "matrix": "rocm",
         "count": len(ROCM_MATRIX),
         "supported_versions": SUPPORTED_ROCM_VERSIONS,
-        "data": {version: entry.model_dump() for version, entry in ROCM_MATRIX.items()},
+        "data": {version: asdict(entry) for version, entry in ROCM_MATRIX.items()},
     }
 
 @router.get("/rocm/frameworks", summary="List framework → ROCm version support map")
@@ -141,7 +142,7 @@ async def get_rocm_version(rocm_version: str) -> dict:
                 }
             },
         )
-    return {"rocm_version": rocm_version, **entry.model_dump()}
+    return {"rocm_version": rocm_version, **asdict(entry)}
 
 # ── Python ────────────────────────────────────────────────────────────────────
 
@@ -156,7 +157,7 @@ async def get_python_matrix() -> dict:
         "matrix": "python",
         "supported_frameworks": sorted(PYTHON_MATRIX.keys()),
         "data": {
-            framework: [entry.model_dump() for entry in entries]
+            framework: [asdict(entry) for entry in entries]
             for framework, entries in PYTHON_MATRIX.items()
         },
     }
@@ -182,7 +183,7 @@ async def get_python_framework(framework: str) -> dict:
     return {
         "framework": framework,
         "count": len(entries),
-        "data": [entry.model_dump() for entry in entries],
+        "data": [asdict(entry) for entry in entries],
     }
 
 @router.get("/python/{framework}/{version}", summary="Get Python compatibility for a specific framework version")
@@ -206,7 +207,7 @@ async def get_python_framework_version(framework: str, version: str) -> dict:
         )
     for entry in entries:
         if entry.version == version:
-            return {"framework": framework, "version": version, **entry.model_dump()}
+            return {"framework": framework, "version": version, **asdict(entry)}
     raise HTTPException(
         status_code=404,
         detail={

--- a/backend/app/api/v1/compatibility.py
+++ b/backend/app/api/v1/compatibility.py
@@ -170,8 +170,7 @@ async def get_python_framework(framework: str) -> dict:
  "count": len(entries),
  "data": [entry.model_dump() for entry in entries],
  }
-@router.get("/python/{framework}/{version}", summary="Get Python compatibility for a specific
-framework version")
+@router.get("/python/{framework}/{version}", summary="Get Python compatibility for a specific framework version")
 async def get_python_framework_version(framework: str, version: str) -> dict:
  """
  Returns the Python compatibility entry for a specific framework version.

--- a/backend/app/api/v1/compatibility.py
+++ b/backend/app/api/v1/compatibility.py
@@ -5,200 +5,215 @@ Resolves Issue #85.
 """
 from fastapi import APIRouter, HTTPException
 from app.compatibility.matrix.cuda import (
- CUDA_MATRIX,
- FRAMEWORK_CUDA_SUPPORT,
- SUPPORTED_CUDA_VERSIONS,
+    CUDA_MATRIX,
+    FRAMEWORK_CUDA_SUPPORT,
+    SUPPORTED_CUDA_VERSIONS,
 )
 from app.compatibility.matrix.rocm import (
- ROCM_MATRIX,
- FRAMEWORK_ROCM_SUPPORT,
- SUPPORTED_ROCM_VERSIONS,
+    ROCM_MATRIX,
+    FRAMEWORK_ROCM_SUPPORT,
+    SUPPORTED_ROCM_VERSIONS,
 )
 from app.compatibility.matrix.python import PYTHON_MATRIX
+
 router = APIRouter(prefix="/compatibility")
+
 # ── Summary ───────────────────────────────────────────────────────────────────
+
 @router.get("", summary="Summary of all compatibility matrices")
 async def get_compatibility_summary() -> dict:
- """
- Returns a high-level summary of all available compatibility matrices.
- Useful for frontend dropdowns and dynamic table headers.
- """
- return {
- "matrices": {
- "cuda": {
- "description": "CUDA version → NVIDIA driver + cuDNN + supported GPU architectures",
- "endpoint": "/api/v1/compatibility/cuda",
- "supported_versions": SUPPORTED_CUDA_VERSIONS,
- "count": len(CUDA_MATRIX),
- },
- "rocm": {
- "description": "ROCm version → Linux driver + supported AMD GPU architectures",
- "endpoint": "/api/v1/compatibility/rocm",
- "supported_versions": SUPPORTED_ROCM_VERSIONS,
- "count": len(ROCM_MATRIX),
- },
- "python": {
- "description": "Framework version → supported Python versions + CUDA/ROCm versions",
- "endpoint": "/api/v1/compatibility/python",
- "supported_frameworks": sorted(PYTHON_MATRIX.keys()),
- "count": sum(len(v) for v in PYTHON_MATRIX.values()),
- },
- }
- }
+    """
+    Returns a high-level summary of all available compatibility matrices.
+    Useful for frontend dropdowns and dynamic table headers.
+    """
+    return {
+        "matrices": {
+            "cuda": {
+                "description": "CUDA version → NVIDIA driver + cuDNN + supported GPU architectures",
+                "endpoint": "/api/v1/compatibility/cuda",
+                "supported_versions": SUPPORTED_CUDA_VERSIONS,
+                "count": len(CUDA_MATRIX),
+            },
+            "rocm": {
+                "description": "ROCm version → Linux driver + supported AMD GPU architectures",
+                "endpoint": "/api/v1/compatibility/rocm",
+                "supported_versions": SUPPORTED_ROCM_VERSIONS,
+                "count": len(ROCM_MATRIX),
+            },
+            "python": {
+                "description": "Framework version → supported Python versions + CUDA/ROCm versions",
+                "endpoint": "/api/v1/compatibility/python",
+                "supported_frameworks": sorted(PYTHON_MATRIX.keys()),
+                "count": sum(len(v) for v in PYTHON_MATRIX.values()),
+            },
+        }
+    }
+
 # ── CUDA ──────────────────────────────────────────────────────────────────────
+
 @router.get("/cuda", summary="List all CUDA compatibility entries")
 async def get_cuda_matrix() -> dict:
- """
- Returns the full CUDA compatibility matrix.
- Each entry maps a CUDA version to its minimum required NVIDIA driver
- (Linux + Windows), supported cuDNN versions, and supported GPU architectures.
- """
- return {
- "matrix": "cuda",
- "count": len(CUDA_MATRIX),
- "supported_versions": SUPPORTED_CUDA_VERSIONS,
- "data": {version: entry.model_dump() for version, entry in CUDA_MATRIX.items()},
- }
+    """
+    Returns the full CUDA compatibility matrix.
+    Each entry maps a CUDA version to its minimum required NVIDIA driver
+    (Linux + Windows), supported cuDNN versions, and supported GPU architectures.
+    """
+    return {
+        "matrix": "cuda",
+        "count": len(CUDA_MATRIX),
+        "supported_versions": SUPPORTED_CUDA_VERSIONS,
+        "data": {version: entry.model_dump() for version, entry in CUDA_MATRIX.items()},
+    }
+
 @router.get("/cuda/frameworks", summary="List framework → CUDA version support map")
 async def get_framework_cuda_support() -> dict:
- """
- Returns the framework → CUDA version support map.
- Shows which CUDA versions each framework version officially supports.
- """
- return {
- "matrix": "framework_cuda_support",
- "data": FRAMEWORK_CUDA_SUPPORT,
- }
+    """
+    Returns the framework → CUDA version support map.
+    Shows which CUDA versions each framework version officially supports.
+    """
+    return {
+        "matrix": "framework_cuda_support",
+        "data": FRAMEWORK_CUDA_SUPPORT,
+    }
+
 @router.get("/cuda/{cuda_version}", summary="Get a single CUDA version entry")
 async def get_cuda_version(cuda_version: str) -> dict:
- """
- Returns the compatibility entry for a specific CUDA version.
- - **cuda_version**: e.g. `11.8`, `12.1`, `12.4`
- """
- entry = CUDA_MATRIX.get(cuda_version)
- if entry is None:
- raise HTTPException(
- status_code=404,
- detail={
- "error": {
- "code": "CUDA_VERSION_NOT_FOUND",
- "message": f"CUDA version '{cuda_version}' is not in the compatibility matrix.",
- "supported_versions": SUPPORTED_CUDA_VERSIONS,
- }
- },
- )
- return {"cuda_version": cuda_version, **entry.model_dump()}
+    """
+    Returns the compatibility entry for a specific CUDA version.
+    - **cuda_version**: e.g. `11.8`, `12.1`, `12.4`
+    """
+    entry = CUDA_MATRIX.get(cuda_version)
+    if entry is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": {
+                    "code": "CUDA_VERSION_NOT_FOUND",
+                    "message": f"CUDA version '{cuda_version}' is not in the compatibility matrix.",
+                    "supported_versions": SUPPORTED_CUDA_VERSIONS,
+                }
+            },
+        )
+    return {"cuda_version": cuda_version, **entry.model_dump()}
+
 # ── ROCm ──────────────────────────────────────────────────────────────────────
+
 @router.get("/rocm", summary="List all ROCm compatibility entries")
 async def get_rocm_matrix() -> dict:
- """
- Returns the full ROCm compatibility matrix.
- Each entry maps a ROCm version to its minimum required Linux driver version
- and supported AMD GPU architectures.
- """
- return {
- "matrix": "rocm",
- "count": len(ROCM_MATRIX),
- "supported_versions": SUPPORTED_ROCM_VERSIONS,
- "data": {version: entry.model_dump() for version, entry in ROCM_MATRIX.items()},
- }
+    """
+    Returns the full ROCm compatibility matrix.
+    Each entry maps a ROCm version to its minimum required Linux driver version
+    and supported AMD GPU architectures.
+    """
+    return {
+        "matrix": "rocm",
+        "count": len(ROCM_MATRIX),
+        "supported_versions": SUPPORTED_ROCM_VERSIONS,
+        "data": {version: entry.model_dump() for version, entry in ROCM_MATRIX.items()},
+    }
+
 @router.get("/rocm/frameworks", summary="List framework → ROCm version support map")
 async def get_framework_rocm_support() -> dict:
- """
- Returns the framework → ROCm version support map.
- Shows which ROCm versions each framework version officially supports.
- """
- return {
- "matrix": "framework_rocm_support",
- "data": FRAMEWORK_ROCM_SUPPORT,
- }
+    """
+    Returns the framework → ROCm version support map.
+    Shows which ROCm versions each framework version officially supports.
+    """
+    return {
+        "matrix": "framework_rocm_support",
+        "data": FRAMEWORK_ROCM_SUPPORT,
+    }
+
 @router.get("/rocm/{rocm_version}", summary="Get a single ROCm version entry")
 async def get_rocm_version(rocm_version: str) -> dict:
- """
- Returns the compatibility entry for a specific ROCm version.
- - **rocm_version**: e.g. `5.7.0`, `6.0.0`
- """
- entry = ROCM_MATRIX.get(rocm_version)
- if entry is None:
- raise HTTPException(
- status_code=404,
- detail={
- "error": {
- "code": "ROCM_VERSION_NOT_FOUND",
- "message": f"ROCm version '{rocm_version}' is not in the compatibility matrix.",
- "supported_versions": SUPPORTED_ROCM_VERSIONS,
- }
- },
- )
- return {"rocm_version": rocm_version, **entry.model_dump()}
+    """
+    Returns the compatibility entry for a specific ROCm version.
+    - **rocm_version**: e.g. `5.7.0`, `6.0.0`
+    """
+    entry = ROCM_MATRIX.get(rocm_version)
+    if entry is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": {
+                    "code": "ROCM_VERSION_NOT_FOUND",
+                    "message": f"ROCm version '{rocm_version}' is not in the compatibility matrix.",
+                    "supported_versions": SUPPORTED_ROCM_VERSIONS,
+                }
+            },
+        )
+    return {"rocm_version": rocm_version, **entry.model_dump()}
+
 # ── Python ────────────────────────────────────────────────────────────────────
+
 @router.get("/python", summary="List all Python compatibility entries")
 async def get_python_matrix() -> dict:
- """
- Returns the full Python compatibility matrix.
- Each framework maps to a list of versioned entries showing supported
- Python versions, CUDA versions, and ROCm versions.
- """
- return {
- "matrix": "python",
- "supported_frameworks": sorted(PYTHON_MATRIX.keys()),
- "data": {
- framework: [entry.model_dump() for entry in entries]
- for framework, entries in PYTHON_MATRIX.items()
- },
- }
+    """
+    Returns the full Python compatibility matrix.
+    Each framework maps to a list of versioned entries showing supported
+    Python versions, CUDA versions, and ROCm versions.
+    """
+    return {
+        "matrix": "python",
+        "supported_frameworks": sorted(PYTHON_MATRIX.keys()),
+        "data": {
+            framework: [entry.model_dump() for entry in entries]
+            for framework, entries in PYTHON_MATRIX.items()
+        },
+    }
+
 @router.get("/python/{framework}", summary="Get Python compatibility for a specific framework")
 async def get_python_framework(framework: str) -> dict:
- """
- Returns all versioned Python compatibility entries for a given framework.
- - **framework**: e.g. `torch`, `tensorflow`, `ultralytics`
- """
- entries = PYTHON_MATRIX.get(framework)
- if entries is None:
- raise HTTPException(
- status_code=404,
- detail={
- "error": {
- "code": "FRAMEWORK_NOT_FOUND",
- "message": f"Framework '{framework}' is not in the Python compatibility matrix.",
- "supported_frameworks": sorted(PYTHON_MATRIX.keys()),
- }
- },
- )
- return {
- "framework": framework,
- "count": len(entries),
- "data": [entry.model_dump() for entry in entries],
- }
+    """
+    Returns all versioned Python compatibility entries for a given framework.
+    - **framework**: e.g. `torch`, `tensorflow`, `ultralytics`
+    """
+    entries = PYTHON_MATRIX.get(framework)
+    if entries is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": {
+                    "code": "FRAMEWORK_NOT_FOUND",
+                    "message": f"Framework '{framework}' is not in the Python compatibility matrix.",
+                    "supported_frameworks": sorted(PYTHON_MATRIX.keys()),
+                }
+            },
+        )
+    return {
+        "framework": framework,
+        "count": len(entries),
+        "data": [entry.model_dump() for entry in entries],
+    }
+
 @router.get("/python/{framework}/{version}", summary="Get Python compatibility for a specific framework version")
 async def get_python_framework_version(framework: str, version: str) -> dict:
- """
- Returns the Python compatibility entry for a specific framework version.
- - **framework**: e.g. `torch`, `tensorflow`
- - **version**: e.g. `2.1.0`, `2.15.0`
- """
- entries = PYTHON_MATRIX.get(framework)
- if entries is None:
- raise HTTPException(
- status_code=404,
- detail={
- "error": {
- "code": "FRAMEWORK_NOT_FOUND",
- "message": f"Framework '{framework}' is not in the Python compatibility matrix.",
- "supported_frameworks": sorted(PYTHON_MATRIX.keys()),
- }
- },
- )
- for entry in entries:
- if entry.version == version:
- return {"framework": framework, "version": version, **entry.model_dump()}
- raise HTTPException(
- status_code=404,
- detail={
- "error": {
- "code": "FRAMEWORK_VERSION_NOT_FOUND",
- "message": f"Version '{version}' not found for framework '{framework}'.",
- "available_versions": [e.version for e in entries],
- }
- },
- )
+    """
+    Returns the Python compatibility entry for a specific framework version.
+    - **framework**: e.g. `torch`, `tensorflow`
+    - **version**: e.g. `2.1.0`, `2.15.0`
+    """
+    entries = PYTHON_MATRIX.get(framework)
+    if entries is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": {
+                    "code": "FRAMEWORK_NOT_FOUND",
+                    "message": f"Framework '{framework}' is not in the Python compatibility matrix.",
+                    "supported_frameworks": sorted(PYTHON_MATRIX.keys()),
+                }
+            },
+        )
+    for entry in entries:
+        if entry.version == version:
+            return {"framework": framework, "version": version, **entry.model_dump()}
+    raise HTTPException(
+        status_code=404,
+        detail={
+            "error": {
+                "code": "FRAMEWORK_VERSION_NOT_FOUND",
+                "message": f"Version '{version}' not found for framework '{framework}'.",
+                "available_versions": [e.version for e in entries],
+            }
+        },
+    )

--- a/backend/app/api/v1/compatibility.py
+++ b/backend/app/api/v1/compatibility.py
@@ -4,6 +4,7 @@ Exposes CUDA, ROCm, and Python compatibility matrices as read-only REST endpoint
 Resolves Issue #85.
 """
 from dataclasses import asdict
+from typing import Any
 
 from fastapi import APIRouter, HTTPException
 
@@ -24,7 +25,7 @@ router = APIRouter(prefix="/compatibility")
 # ── Summary ───────────────────────────────────────────────────────────────────
 
 @router.get("", summary="Summary of all compatibility matrices")
-async def get_compatibility_summary() -> dict:
+async def get_compatibility_summary() -> dict[str, Any]:
     """
     Returns a high-level summary of all available compatibility matrices.
     Useful for frontend dropdowns and dynamic table headers.
@@ -55,7 +56,7 @@ async def get_compatibility_summary() -> dict:
 # ── CUDA ──────────────────────────────────────────────────────────────────────
 
 @router.get("/cuda", summary="List all CUDA compatibility entries")
-async def get_cuda_matrix() -> dict:
+async def get_cuda_matrix() -> dict[str, Any]:
     """
     Returns the full CUDA compatibility matrix.
     Each entry maps a CUDA version to its minimum required NVIDIA driver
@@ -69,7 +70,7 @@ async def get_cuda_matrix() -> dict:
     }
 
 @router.get("/cuda/frameworks", summary="List framework → CUDA version support map")
-async def get_framework_cuda_support() -> dict:
+async def get_framework_cuda_support() -> dict[str, Any]:
     """
     Returns the framework → CUDA version support map.
     Shows which CUDA versions each framework version officially supports.
@@ -80,7 +81,7 @@ async def get_framework_cuda_support() -> dict:
     }
 
 @router.get("/cuda/{cuda_version}", summary="Get a single CUDA version entry")
-async def get_cuda_version(cuda_version: str) -> dict:
+async def get_cuda_version(cuda_version: str) -> dict[str, Any]:
     """
     Returns the compatibility entry for a specific CUDA version.
     - **cuda_version**: e.g. `11.8`, `12.1`, `12.4`
@@ -102,7 +103,7 @@ async def get_cuda_version(cuda_version: str) -> dict:
 # ── ROCm ──────────────────────────────────────────────────────────────────────
 
 @router.get("/rocm", summary="List all ROCm compatibility entries")
-async def get_rocm_matrix() -> dict:
+async def get_rocm_matrix() -> dict[str, Any]:
     """
     Returns the full ROCm compatibility matrix.
     Each entry maps a ROCm version to its minimum required Linux driver version
@@ -116,7 +117,7 @@ async def get_rocm_matrix() -> dict:
     }
 
 @router.get("/rocm/frameworks", summary="List framework → ROCm version support map")
-async def get_framework_rocm_support() -> dict:
+async def get_framework_rocm_support() -> dict[str, Any]:
     """
     Returns the framework → ROCm version support map.
     Shows which ROCm versions each framework version officially supports.
@@ -127,7 +128,7 @@ async def get_framework_rocm_support() -> dict:
     }
 
 @router.get("/rocm/{rocm_version}", summary="Get a single ROCm version entry")
-async def get_rocm_version(rocm_version: str) -> dict:
+async def get_rocm_version(rocm_version: str) -> dict[str, Any]:
     """
     Returns the compatibility entry for a specific ROCm version.
     - **rocm_version**: e.g. `5.7.0`, `6.0.0`
@@ -149,7 +150,7 @@ async def get_rocm_version(rocm_version: str) -> dict:
 # ── Python ────────────────────────────────────────────────────────────────────
 
 @router.get("/python", summary="List all Python compatibility entries")
-async def get_python_matrix() -> dict:
+async def get_python_matrix() -> dict[str, Any]:
     """
     Returns the full Python compatibility matrix.
     Each framework maps to a list of versioned entries showing supported
@@ -165,7 +166,7 @@ async def get_python_matrix() -> dict:
     }
 
 @router.get("/python/{framework}", summary="Get Python compatibility for a specific framework")
-async def get_python_framework(framework: str) -> dict:
+async def get_python_framework(framework: str) -> dict[str, Any]:
     """
     Returns all versioned Python compatibility entries for a given framework.
     - **framework**: e.g. `torch`, `tensorflow`, `ultralytics`
@@ -189,7 +190,7 @@ async def get_python_framework(framework: str) -> dict:
     }
 
 @router.get("/python/{framework}/{version}", summary="Get Python compatibility for a specific framework version")
-async def get_python_framework_version(framework: str, version: str) -> dict:
+async def get_python_framework_version(framework: str, version: str) -> dict[str, Any]:
     """
     Returns the Python compatibility entry for a specific framework version.
     - **framework**: e.g. `torch`, `tensorflow`

--- a/backend/app/api/v1/compatibility.py
+++ b/backend/app/api/v1/compatibility.py
@@ -4,18 +4,20 @@ Exposes CUDA, ROCm, and Python compatibility matrices as read-only REST endpoint
 Resolves Issue #85.
 """
 from dataclasses import asdict
+
 from fastapi import APIRouter, HTTPException
+
 from app.compatibility.matrix.cuda import (
     CUDA_MATRIX,
     FRAMEWORK_CUDA_SUPPORT,
     SUPPORTED_CUDA_VERSIONS,
 )
+from app.compatibility.matrix.python import PYTHON_MATRIX
 from app.compatibility.matrix.rocm import (
-    ROCM_MATRIX,
     FRAMEWORK_ROCM_SUPPORT,
+    ROCM_MATRIX,
     SUPPORTED_ROCM_VERSIONS,
 )
-from app.compatibility.matrix.python import PYTHON_MATRIX
 
 router = APIRouter(prefix="/compatibility")
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.v1 import diagnose, profiles, repair, scripts, troubleshoot, verify
+from app.api.v1 import compatibility,diagnose, profiles, repair, scripts, troubleshoot, verify
 from app.config import get_settings
 
 
@@ -55,6 +55,7 @@ def create_app() -> FastAPI:
     app.include_router(troubleshoot.router, prefix="/api/v1", tags=["ai"])
     app.include_router(repair.router, prefix="/api/v1", tags=["ai"])
     app.include_router(verify.router, prefix="/api/v1", tags=["verify"])
+    app.include_router(compatibility.router,prefix="/api/v1",tags=["compatibility"])
 
     # ── Health check ──────────────────────────────────────────
     @app.get("/health", include_in_schema=False)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.v1 import compatibility,diagnose, profiles, repair, scripts, troubleshoot, verify
+from app.api.v1 import compatibility, diagnose, profiles, repair, scripts, troubleshoot, verify
 from app.config import get_settings
 
 
@@ -55,7 +55,7 @@ def create_app() -> FastAPI:
     app.include_router(troubleshoot.router, prefix="/api/v1", tags=["ai"])
     app.include_router(repair.router, prefix="/api/v1", tags=["ai"])
     app.include_router(verify.router, prefix="/api/v1", tags=["verify"])
-    app.include_router(compatibility.router,prefix="/api/v1",tags=["compatibility"])
+    app.include_router(compatibility.router, prefix="/api/v1", tags=["compatibility"])
 
     # ── Health check ──────────────────────────────────────────
     @app.get("/health", include_in_schema=False)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,15 @@ from typing import Any
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.v1 import compatibility, diagnose, profiles, repair, scripts, troubleshoot, verify
+from app.api.v1 import (
+    compatibility,
+    diagnose,
+    profiles,
+    repair,
+    scripts,
+    troubleshoot,
+    verify,
+)
 from app.config import get_settings
 
 

--- a/backend/tests/api/test_compatibility_endpoints.py
+++ b/backend/tests/api/test_compatibility_endpoints.py
@@ -1,0 +1,126 @@
+"""
+Tests for GET /api/v1/compatibility/* endpoints.
+Issue #85 — Expose Compatibility Matrices via REST API.
+"""
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+BASE = "/api/v1/compatibility"
+
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+def test_summary_returns_all_three_matrices():
+    res = client.get(BASE)
+    assert res.status_code == 200
+    body = res.json()
+    assert "matrices" in body
+    assert set(body["matrices"].keys()) == {"cuda", "rocm", "python"}
+
+
+# ── CUDA ──────────────────────────────────────────────────────────────────────
+
+def test_cuda_matrix_returns_data():
+    res = client.get(f"{BASE}/cuda")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["matrix"] == "cuda"
+    assert body["count"] > 0
+    assert "data" in body
+    assert "supported_versions" in body
+
+
+def test_cuda_known_version_returns_entry():
+    res = client.get(f"{BASE}/cuda/11.8")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["cuda_version"] == "11.8"
+    assert "min_driver_linux" in body
+    assert "min_driver_windows" in body
+    assert "cudnn_versions" in body
+    assert "supported_archs" in body
+
+
+def test_cuda_unknown_version_returns_404():
+    res = client.get(f"{BASE}/cuda/99.9")
+    assert res.status_code == 404
+    body = res.json()
+    assert body["detail"]["error"]["code"] == "CUDA_VERSION_NOT_FOUND"
+    assert "supported_versions" in body["detail"]["error"]
+
+
+def test_cuda_framework_support_map():
+    res = client.get(f"{BASE}/cuda/frameworks")
+    assert res.status_code == 200
+    body = res.json()
+    assert "data" in body
+    assert "torch" in body["data"]
+
+
+# ── ROCm ──────────────────────────────────────────────────────────────────────
+
+def test_rocm_matrix_returns_data():
+    res = client.get(f"{BASE}/rocm")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["matrix"] == "rocm"
+    assert body["count"] > 0
+
+
+def test_rocm_known_version_returns_entry():
+    res = client.get(f"{BASE}/rocm/6.0.0")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["rocm_version"] == "6.0.0"
+    assert "supported_gpus" in body
+    assert "min_driver_linux" in body
+
+
+def test_rocm_unknown_version_returns_404():
+    res = client.get(f"{BASE}/rocm/99.9")
+    assert res.status_code == 404
+    assert res.json()["detail"]["error"]["code"] == "ROCM_VERSION_NOT_FOUND"
+
+
+# ── Python ────────────────────────────────────────────────────────────────────
+
+def test_python_matrix_returns_data():
+    res = client.get(f"{BASE}/python")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["matrix"] == "python"
+    assert "torch" in body["data"]
+
+
+def test_python_known_framework_returns_entries():
+    res = client.get(f"{BASE}/python/torch")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["framework"] == "torch"
+    assert body["count"] > 0
+    assert isinstance(body["data"], list)
+
+
+def test_python_known_framework_version_returns_entry():
+    res = client.get(f"{BASE}/python/torch/2.1.0")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["version"] == "2.1.0"
+    assert "min_python" in body
+    assert "max_python" in body
+    assert "supported_python" in body
+    assert "supported_cuda" in body
+
+
+def test_python_unknown_framework_returns_404():
+    res = client.get(f"{BASE}/python/unicorn")
+    assert res.status_code == 404
+    assert res.json()["detail"]["error"]["code"] == "FRAMEWORK_NOT_FOUND"
+
+
+def test_python_unknown_version_returns_404():
+    res = client.get(f"{BASE}/python/torch/0.0.0")
+    assert res.status_code == 404
+    assert res.json()["detail"]["error"]["code"] == "FRAMEWORK_VERSION_NOT_FOUND"

--- a/backend/tests/api/test_compatibility_endpoints.py
+++ b/backend/tests/api/test_compatibility_endpoints.py
@@ -2,7 +2,6 @@
 Tests for GET /api/v1/compatibility/* endpoints.
 Issue #85 — Expose Compatibility Matrices via REST API.
 """
-import pytest
 from fastapi.testclient import TestClient
 from app.main import app
 

--- a/backend/tests/api/test_compatibility_endpoints.py
+++ b/backend/tests/api/test_compatibility_endpoints.py
@@ -3,6 +3,7 @@ Tests for GET /api/v1/compatibility/* endpoints.
 Issue #85 — Expose Compatibility Matrices via REST API.
 """
 from fastapi.testclient import TestClient
+
 from app.main import app
 
 client = TestClient(app)


### PR DESCRIPTION
## Summary

Closes #85

Exposes the CUDA, ROCm, and Python compatibility matrices as read-only REST API endpoints under `/api/v1/compatibility/`. The frontend can now dynamically query supported versions and build compatibility tables without hardcoding any data.

---

## Changes

- `backend/app/api/v1/compatibility.py` — new router with 9 read-only GET endpoints
- `backend/app/main.py` — registered the new compatibility router
- `backend/tests/api/test_compatibility_endpoints.py` — 14 tests covering positive, negative, and edge cases

---

## Endpoints Added

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/v1/compatibility` | Summary of all 3 matrices |
| GET | `/api/v1/compatibility/cuda` | Full CUDA matrix |
| GET | `/api/v1/compatibility/cuda/frameworks` | Framework → CUDA support map |
| GET | `/api/v1/compatibility/cuda/{cuda_version}` | Single CUDA version entry |
| GET | `/api/v1/compatibility/rocm` | Full ROCm matrix |
| GET | `/api/v1/compatibility/rocm/frameworks` | Framework → ROCm support map |
| GET | `/api/v1/compatibility/rocm/{rocm_version}` | Single ROCm version entry |
| GET | `/api/v1/compatibility/python` | Full Python matrix |
| GET | `/api/v1/compatibility/python/{framework}` | All versions for a framework |
| GET | `/api/v1/compatibility/python/{framework}/{version}` | Single framework version entry |

---

## Notes

- No existing matrix files were modified — only imported from
- All endpoints are read-only (GET), no mutations
- 404 responses include structured error codes and a list of valid options to aid frontend error handling
- Endpoints are visible in Swagger UI at `/api/docs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added REST API endpoints under /api/v1/compatibility to query CUDA, ROCm, and Python compatibility matrices, including framework→CUDA/ROCm support mappings, grouped Python-by-framework listings, and version-specific lookups that return structured 404 responses listing available options.
* **Tests**
  * Added comprehensive test coverage validating summary, per-matrix listings, framework mappings, known/unknown version behavior, and error payloads for all compatibility endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->