### PR TITLE
test(cli): add unit tests for diagnose --output flag

### DIFF
--- a/cli/tests/test_diagnose_output.py
+++ b/cli/tests/test_diagnose_output.py
@@ -73,8 +73,10 @@ class TestDiagnoseOutputFlag:
             mock_builder.return_value.build.return_value = mock_report
 
             runner = CliRunner()
-            runner.invoke(cli, ["diagnose", "--output", str(output_file)])
+            result = runner.invoke(cli, ["diagnose", "--output", str(output_file)])
 
+        assert result.exit_code == 0
+        assert output_file.exists(), "Output file was not created"
         parsed = json.loads(output_file.read_text(encoding="utf-8"))
         for field in ["agent_version", "os", "cpu", "ram", "gpus", "cuda", "python_installations"]:
             assert field in parsed, f"Missing field: {field}"

--- a/cli/tests/test_diagnose_output.py
+++ b/cli/tests/test_diagnose_output.py
@@ -1,0 +1,97 @@
+"""Tests for the --output flag of the envforge diagnose command."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from envforge_agent.schemas import DiagnosticReport
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES_DIR / name).read_text(encoding="utf-8"))
+
+
+class TestDiagnoseOutputFlag:
+    """Tests for the --output flag of the envforge diagnose command."""
+
+    def test_output_flag_creates_json_file(self, tmp_path) -> None:
+        """--output saves a valid JSON DiagnosticReport to the given file path."""
+        from envforge_agent.cli import cli
+        from click.testing import CliRunner
+
+        output_file = tmp_path / "report.json"
+
+        with patch("envforge_agent.cli.ReportBuilder") as mock_builder:
+            mock_report = DiagnosticReport.model_validate(load_fixture("linux_gpu.json"))
+            mock_builder.return_value.build.return_value = mock_report
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["diagnose", "--output", str(output_file)])
+
+        assert result.exit_code == 0
+        assert output_file.exists(), "Output file was not created"
+        parsed = json.loads(output_file.read_text(encoding="utf-8"))
+        assert "agent_version" in parsed
+        assert "os" in parsed
+        assert "gpus" in parsed
+
+    def test_output_flag_quiet_still_writes_file(self, tmp_path) -> None:
+        """--output with --quiet still writes the file even with no terminal output."""
+        from envforge_agent.cli import cli
+        from click.testing import CliRunner
+
+        output_file = tmp_path / "report.json"
+
+        with patch("envforge_agent.cli.ReportBuilder") as mock_builder:
+            mock_report = DiagnosticReport.model_validate(load_fixture("linux_gpu.json"))
+            mock_builder.return_value.build.return_value = mock_report
+
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["diagnose", "--output", str(output_file), "--quiet"]
+            )
+
+        assert result.exit_code == 0
+        assert output_file.exists(), "File must still be written in quiet mode"
+        parsed = json.loads(output_file.read_text(encoding="utf-8"))
+        assert "agent_version" in parsed
+
+    def test_output_file_contains_all_report_fields(self, tmp_path) -> None:
+        """The saved JSON contains all expected DiagnosticReport top-level fields."""
+        from envforge_agent.cli import cli
+        from click.testing import CliRunner
+
+        output_file = tmp_path / "report.json"
+
+        with patch("envforge_agent.cli.ReportBuilder") as mock_builder:
+            mock_report = DiagnosticReport.model_validate(load_fixture("linux_gpu.json"))
+            mock_builder.return_value.build.return_value = mock_report
+
+            runner = CliRunner()
+            runner.invoke(cli, ["diagnose", "--output", str(output_file)])
+
+        parsed = json.loads(output_file.read_text(encoding="utf-8"))
+        for field in ["agent_version", "os", "cpu", "ram", "gpus", "cuda", "python_installations"]:
+            assert field in parsed, f"Missing field: {field}"
+
+    def test_without_output_flag_json_printed_to_stdout(self) -> None:
+        """Without --output, the JSON report is echoed to stdout (pipe-friendly)."""
+        from envforge_agent.cli import cli
+        from click.testing import CliRunner
+
+        with patch("envforge_agent.cli.ReportBuilder") as mock_builder:
+            mock_report = DiagnosticReport.model_validate(load_fixture("linux_gpu.json"))
+            mock_builder.return_value.build.return_value = mock_report
+
+            runner = CliRunner()
+            result = runner.invoke(cli, ["diagnose", "--quiet"])
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert "agent_version" in parsed
+        assert "os" in parsed


### PR DESCRIPTION
## Description
Adds a dedicated test module `cli/tests/test_diagnose_output.py` with 4 unit 
tests covering the `--output` flag behaviour of the `envforge diagnose` command.
All tests mock `ReportBuilder` and use pytest's `tmp_path` fixture — no live 
system calls, no network required.

## Related Issues
Closes #106

## Changes Made
- Added `cli/tests/test_diagnose_output.py` (new file, 97 lines)
- No existing files modified

## Verification
- [x] Added unit tests
- [x] Ran `pytest tests/` successfully
- [x] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

All 4 tests pass cleanly:

| Test | Result |
|------|--------|
| `test_output_flag_creates_json_file` | ✅ PASSED |
| `test_output_flag_quiet_still_writes_file` | ✅ PASSED |
| `test_output_file_contains_all_report_fields` | ✅ PASSED |
| `test_without_output_flag_json_printed_to_stdout` | ✅ PASSED |

## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted

## Screenshots 
<img width="1457" height="594" alt="image" src="https://github.com/user-attachments/assets/c917c813-15a3-4b1b-88d9-d822aa505abc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite for `diagnose` CLI `--output` flag functionality
  * Validates JSON file output, quiet mode behavior, report fields, and stdout output

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->