### PR TITLE
fix(ai): handle db failures in session history fetch (#83)

### DIFF
--- a/backend/app/ai/service.py
+++ b/backend/app/ai/service.py
@@ -195,10 +195,10 @@ class AITroubleshootService:
             )
             result = await db.execute(stmt)
             return list(result.scalars().all())
-        
+
         except OperationalError as exc:
             logger.critical(
-                "Critical database connectivity failure for session %s: %s", 
+                "Critical database connectivity failure for session %s: %s",
                 session_id, exc
             )
             raise HTTPException(
@@ -207,7 +207,7 @@ class AITroubleshootService:
             )
         except SQLAlchemyError as exc:
             logger.error(
-                "Transient database error fetching session history for %s: %s", 
+                "Transient database error fetching session history for %s: %s",
                 session_id, exc
             )
             return []

--- a/backend/app/ai/service.py
+++ b/backend/app/ai/service.py
@@ -14,7 +14,9 @@ import uuid
 from collections.abc import AsyncIterator
 from datetime import datetime
 
+from fastapi import HTTPException, status
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError, OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.models import (
@@ -193,8 +195,21 @@ class AITroubleshootService:
             )
             result = await db.execute(stmt)
             return list(result.scalars().all())
-        except Exception as exc:
-            logger.error("Failed to fetch session history for %s: %s", session_id, exc)
+        
+        except OperationalError as exc:
+            logger.critical(
+                "Critical database connectivity failure for session %s: %s", 
+                session_id, exc
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Database service is temporarily unavailable. Unable to process history request."
+            )
+        except SQLAlchemyError as exc:
+            logger.error(
+                "Transient database error fetching session history for %s: %s", 
+                session_id, exc
+            )
             return []
 
     # ── Private helpers ───────────────────────────────────────────────────


### PR DESCRIPTION
## Description
Refactored `_fetch_session_history` in `backend/app/ai/service.py` to stop using broad exception blocks. 

- Catches `OperationalError` to raise a `500 Internal Server Error` if the PostgreSQL database is entirely unreachable.
- Catches generic `SQLAlchemyError` for transient query issues to log them and safely return an empty list.

Fixes #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for database history fetch failures: critical connectivity issues now return a clear "temporarily unavailable" response, transient database errors are logged, and the session history gracefully falls back to an empty list.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->