### PR TITLE
feat(cli): add CPU core count warning to diagnose command

### DIFF
--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -122,7 +122,11 @@ def _print_report_summary(report: DiagnosticReport) -> None:
     if report.os.wsl_version:
         table.add_row("WSL", report.os.wsl_version)
 
-    table.add_row("CPU", f"{report.cpu.brand} — {report.cpu.cores}C / {report.cpu.threads}T")
+    cpu_str = f"{report.cpu.brand} — {report.cpu.cores}C / {report.cpu.threads}T"
+    if report.cpu.cores < 4:
+        cpu_str += "  [yellow]⚠ WARNING: Under 4 cores — data loading may bottleneck training[/]"
+    table.add_row("CPU", cpu_str)
+    
     ram_str = f"{report.ram.total_gb} GB total, {report.ram.available_gb} GB free"
     if report.ram.total_gb < 8:
         ram_str += "  [bold red][!] CRITICAL: Under 8 GB — heavy ML profiles will fail[/]"


### PR DESCRIPTION
## Description
Adds a threshold-based CPU core count warning to the `envforge diagnose`
summary table. Users on machines with fewer than 4 physical cores now get
a clear warning before attempting ML workloads, since data loading pipelines
in PyTorch and TensorFlow are heavily CPU-bound and perform poorly on
dual-core machines.

## Related Issues
Closes #130

## Changes Made
- Modified `_print_report_summary` in `cli/envforge_agent/cli.py` only
- No other files touched

## Warning Threshold
| CPU Cores | Output |
|-----------|--------|
| < 4 cores | 🟡 `⚠ WARNING: Under 4 cores — data loading may bottleneck training` |
| ≥ 4 cores | Normal output, no warning |

## Verification
- [ ] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [x] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

Tested live — machine has 6 cores so no warning shown (correct). Warning
logic verified manually for < 4 core threshold.

## Documentation
- [ ] Updated `docs/FEATURES.md`
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted

## Screenshots 
<img width="1539" height="691" alt="image" src="https://github.com/user-attachments/assets/c7b49db6-1904-4aaa-b87e-a8dba4286dcf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced CPU diagnostics in system analysis with a warning indicator when fewer than 4 CPU cores are detected, highlighting potential performance bottlenecks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->