### PR TITLE
feat(templates): add dynamic GPU channels to conda environment.yml

### DIFF
--- a/backend/app/templates/jinja/config/environment.yml.j2
+++ b/backend/app/templates/jinja/config/environment.yml.j2
@@ -12,8 +12,12 @@
 
 name: {{ profile.name }}
 channels:
+{% if cuda_version %}  - pytorch
+  - nvidia
+{% elif rocm_version %}  - pytorch
+{% endif %}  - conda-forge
   - defaults
-  - conda-forge
+  
 dependencies:
   - python={{ python_version }}
 {% set pip_ns = namespace(has_pip_packages=false) %}

--- a/backend/app/templates/models.py
+++ b/backend/app/templates/models.py
@@ -29,6 +29,7 @@ class TemplateContext:
             },
             "python_version": self.resolved.python_version,
             "cuda_version": self.resolved.cuda_version,
+            "rocm_version": self.resolved.rocm_version,
             "target_os": self.resolved.target_os,
             "packages": [
                 {

--- a/backend/tests/unit/templates/test_conda_template.py
+++ b/backend/tests/unit/templates/test_conda_template.py
@@ -187,4 +187,3 @@ def test_conda_template_cpu_only_no_gpu_channels():
     result = renderer.render("environment.yml", context)
     assert _extract_channels(result.content) == ["conda-forge", "defaults"]
 
-    

--- a/backend/tests/unit/templates/test_conda_template.py
+++ b/backend/tests/unit/templates/test_conda_template.py
@@ -131,8 +131,23 @@ def test_conda_template_name_field_matches_profile():
     result = renderer.render("environment.yml", context)
     assert "name: pytorch-cuda" in result.content
 
+def _extract_channels(rendered: str) -> list[str]:
+    """Extract ordered channel list from rendered environment.yml content."""
+    lines = rendered.splitlines()
+    try:
+        i = lines.index("channels:") + 1
+    except ValueError:
+        return []
+    out: list[str] = []
+    for line in lines[i:]:
+        if not line.startswith("  - "):
+            break
+        out.append(line.replace("  - ", "", 1).strip())
+    return out
+
+
 def test_conda_template_cuda_adds_pytorch_nvidia_channels():
-    """When cuda_version is set, channels must include pytorch and nvidia."""
+    """When cuda_version is set, channels must include pytorch and nvidia in correct order."""
     context = make_context(
         profile_name="cuda-env",
         python_version="3.11",
@@ -140,10 +155,7 @@ def test_conda_template_cuda_adds_pytorch_nvidia_channels():
     )
     renderer = TemplateRenderer()
     result = renderer.render("environment.yml", context)
-    assert "- pytorch" in result.content
-    assert "- nvidia" in result.content
-    assert "- conda-forge" in result.content
-    assert "- defaults" in result.content
+    assert _extract_channels(result.content) == ["pytorch", "nvidia", "conda-forge", "defaults"]
 
 
 def test_conda_template_rocm_adds_pytorch_channel():
@@ -161,9 +173,7 @@ def test_conda_template_rocm_adds_pytorch_channel():
     )
     renderer = TemplateRenderer()
     result = renderer.render("environment.yml", context)
-    assert "- pytorch" in result.content
-    assert "- nvidia" not in result.content
-    assert "- conda-forge" in result.content
+    assert _extract_channels(result.content) == ["pytorch", "conda-forge", "defaults"]
 
 
 def test_conda_template_cpu_only_no_gpu_channels():
@@ -175,9 +185,4 @@ def test_conda_template_cpu_only_no_gpu_channels():
     )
     renderer = TemplateRenderer()
     result = renderer.render("environment.yml", context)
-    assert "- pytorch" not in result.content
-    assert "- nvidia" not in result.content
-    assert "- conda-forge" in result.content
-    assert "- defaults" in result.content
-
-    
+    assert _extract_channels(result.content) == ["conda-forge", "defaults"]

--- a/backend/tests/unit/templates/test_conda_template.py
+++ b/backend/tests/unit/templates/test_conda_template.py
@@ -186,3 +186,5 @@ def test_conda_template_cpu_only_no_gpu_channels():
     renderer = TemplateRenderer()
     result = renderer.render("environment.yml", context)
     assert _extract_channels(result.content) == ["conda-forge", "defaults"]
+
+    

--- a/backend/tests/unit/templates/test_conda_template.py
+++ b/backend/tests/unit/templates/test_conda_template.py
@@ -131,3 +131,53 @@ def test_conda_template_name_field_matches_profile():
     result = renderer.render("environment.yml", context)
     assert "name: pytorch-cuda" in result.content
 
+def test_conda_template_cuda_adds_pytorch_nvidia_channels():
+    """When cuda_version is set, channels must include pytorch and nvidia."""
+    context = make_context(
+        profile_name="cuda-env",
+        python_version="3.11",
+        cuda_version="12.1",
+    )
+    renderer = TemplateRenderer()
+    result = renderer.render("environment.yml", context)
+    assert "- pytorch" in result.content
+    assert "- nvidia" in result.content
+    assert "- conda-forge" in result.content
+    assert "- defaults" in result.content
+
+
+def test_conda_template_rocm_adds_pytorch_channel():
+    """When rocm_version is set, channels must include pytorch but not nvidia."""
+    context = make_context(
+        profile_name="rocm-env",
+        python_version="3.11",
+    )
+    context.resolved = context.resolved.__class__(
+        python_version=context.resolved.python_version,
+        cuda_version=None,
+        target_os=context.resolved.target_os,
+        rocm_version="5.6",
+        packages=context.resolved.packages,
+    )
+    renderer = TemplateRenderer()
+    result = renderer.render("environment.yml", context)
+    assert "- pytorch" in result.content
+    assert "- nvidia" not in result.content
+    assert "- conda-forge" in result.content
+
+
+def test_conda_template_cpu_only_no_gpu_channels():
+    """Without cuda or rocm, channels must only have conda-forge and defaults."""
+    context = make_context(
+        profile_name="cpu-env",
+        python_version="3.10",
+        cuda_version=None,
+    )
+    renderer = TemplateRenderer()
+    result = renderer.render("environment.yml", context)
+    assert "- pytorch" not in result.content
+    assert "- nvidia" not in result.content
+    assert "- conda-forge" in result.content
+    assert "- defaults" in result.content
+
+    


### PR DESCRIPTION
## Description
The `environment.yml.j2` template previously generated a static channels
list (`defaults`, `conda-forge`) regardless of GPU configuration. This meant
conda users on CUDA or ROCm systems would silently get CPU-only PyTorch builds
with no correct channels. This PR makes the channels section dynamic based on
the resolved GPU configuration.

## Related Issues
Closes #134

## Changes Made
- `backend/app/templates/models.py` — added `rocm_version` to `TemplateContext.to_dict()` so the Jinja2 template can access it
- `backend/app/templates/jinja/config/environment.yml.j2` — updated `channels:` block to conditionally include GPU-specific channels
- `backend/tests/unit/templates/test_conda_template.py` — added 3 new tests covering all three channel scenarios

## Channel Logic
| Scenario | Channels Generated |
|----------|-------------------|
| `cuda_version` set | `pytorch`, `nvidia`, `conda-forge`, `defaults` |
| `rocm_version` set | `pytorch`, `conda-forge`, `defaults` |
| CPU only (neither set) | `conda-forge`, `defaults` |

## Verification
- [ ] Added unit tests
- [x] Ran `pytest tests/` successfully
- [x] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

All 12 tests pass (9 existing + 3 new):
12 passed, 12 warnings in 0.90s

## Documentation
- [ ] Updated `docs/FEATURES.md`
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted

## Screenshots 
<img width="1464" height="396" alt="image" src="https://github.com/user-attachments/assets/3fd68149-3e3f-489c-9409-e6628e38c4ec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conda environment configuration now dynamically selects package channels based on GPU selection (CUDA, ROCm, or CPU-only), ensuring correct packages are available for your setup.
  * Template rendering now recognizes ROCm version when determining channels.

* **Tests**
  * Added unit tests validating channel selection and ordering for CUDA, ROCm, and CPU-only configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->