### PR TITLE
fix(backend runs as root): changed backend Dockerfile to run as non-root user

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Create a non-root user and group
+RUN groupadd --system envforge && \
+    useradd --system --gid envforge --no-create-home envforge
+
 # Copy dependency specs first (layer caching)
 COPY pyproject.toml ./
 
@@ -17,6 +21,10 @@ RUN pip install --no-cache-dir --upgrade pip \
 
 # Copy application code
 COPY . .
+RUN chown -R envforge:envforge /app
+
+# Switch to non-root user
+USER envforge
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Description
Run the backend FastAPI container as a dedicated non-root user (`envforge`) 
to reduce the blast radius of a potential container compromise.

## Related Issues
Fixes #148

## Changes Made
- Added `groupadd` / `useradd` step to create a system-level `envforge` user and group
- Transferred ownership of `/app` to `envforge` via `chown -R`
- Added `USER envforge` directive before `CMD` so the runtime process runs unprivileged

## Verification
- [ ] Added unit tests
- [x] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

**Container verification steps:**
- Built image with `docker build -t envforge-backend .`
- Confirmed running user with `docker run --rm envforge-backend whoami` → `envforge`
- Confirmed app starts cleanly with `docker run --rm -p 8000:8000 envforge-backend`
- Verified `/app` is owned by `envforge` via `docker run --rm envforge-backend ls -la /app`

## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted

## Screenshots
<img width="1674" height="149" alt="image" src="https://github.com/user-attachments/assets/727d86d8-14ea-40c5-992e-71907ed77e88" />

<img width="1737" height="229" alt="image" src="https://github.com/user-attachments/assets/b1a8f5e8-83cf-4fd4-8137-464198ee15a1" />

<img width="1635" height="740" alt="image" src="https://github.com/user-attachments/assets/c66e7e66-9953-4e55-9d1c-e1c81b5cc33b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container security by implementing non-root user execution in the Docker image.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->