### PR TITLE
OpenAI rate limit fix

### DIFF
--- a/backend/app/ai/providers/openai.py
+++ b/backend/app/ai/providers/openai.py
@@ -90,9 +90,11 @@ class OpenAIProvider(LLMProvider):
 
                 return response_model.model_validate_json(content)
             except httpx.HTTPStatusError as e:
-                raise LLMProviderError("openai", f"OpenAI API error occurred: {e.response.text}")
+                raise LLMProviderError("openai", f"OpenAI API error occured: {e.response.text}")
+            except LLMProviderError:
+                raise
             except Exception as e:
-                raise LLMProviderError("openai", f"Unexpected connection error under OpenAI provider: {str(e)}")
+                raise LLMProviderError("openai", f"Unexpected connection error under OpenAI provider: {str(e)}",) from e
 
     def stream(
         self,

--- a/backend/app/ai/providers/openai.py
+++ b/backend/app/ai/providers/openai.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from collections.abc import AsyncIterator
@@ -123,36 +124,77 @@ class OpenAIProvider(LLMProvider):
 
         async def generator() -> AsyncIterator[str]:
             async with httpx.AsyncClient(timeout=60.0) as client:
-                async with client.stream(
-                    "POST",
-                    f"{self.base_url}/chat/completions",
-                    json=payload,
-                    headers=self.headers,
-                ) as response:
-                    if response.status_code != 200:
-                        error_body = await response.aread()
+                max_retries = 3
+
+                for attempt in range(max_retries):
+                    try:
+                        async with client.stream(
+                            "POST",
+                            f"{self.base_url}/chat/completions",
+                            json=payload,
+                            headers=self.headers,
+                        ) as response:
+                            
+                            if response.status_code == 429:
+                                retry_after = response.headers.get("Retry-After")
+
+                                if retry_after and retry_after.isdigit():
+                                    delay = int(retry_after)
+                                else:
+                                    delay = 2 ** attempt
+
+                                logger.warning(
+                                    "OpenAI rate limited. Retrying in %s seconds...",
+                                    delay,
+                                )
+
+                                await asyncio.sleep(delay)
+                                continue
+                
+                            if response.status_code != 200:
+                                error_body = await response.aread()
+
+                                raise LLMProviderError(
+                                    "openai",
+                                    f"HTTP {response.status_code}: {error_body.decode(errors='replace')[:500]}",
+                                )
+
+                            async for line in response.aiter_lines():
+                                if not line or not line.startswith("data: "):
+                                    continue
+
+                                data_str = line[6:].strip()
+
+                                if data_str == "[DONE]":
+                                    break
+
+                                try:
+                                    data = json.loads(data_str)
+
+                                    choices = data.get("choices", [])
+
+                                    if choices:
+                                        delta = choices[0].get("delta", {})
+                                        content = delta.get("content", "")
+
+                                        if content:
+                                            yield content
+
+                                except json.JSONDecodeError:
+                                    continue
+
+                            return
+
+                    except httpx.HTTPError as e:
                         raise LLMProviderError(
                             "openai",
-                            f"HTTP {response.status_code}: {error_body.decode(errors='replace')[:500]}",
-                        )
+                            f"Streaming connection error: {str(e)}",
+                        ) from e
 
-                    async for line in response.aiter_lines():
-                        if not line or not line.startswith("data: "):
-                            continue
-
-                        data_str = line[6:].strip()
-                        if data_str == "[DONE]":
-                            break
-
-                        try:
-                            data = json.loads(data_str)
-                            choices = data.get("choices", [])
-                            if choices:
-                                delta = choices[0].get("delta", {})
-                                content = delta.get("content", "")
-                                if content:
-                                    yield content
-                        except json.JSONDecodeError:
-                            continue
+                raise LLMProviderError(
+                    "openai",
+                    "OpenAI streaming failed after maximum retry attempts.",
+                )
 
         return generator()
+    

--- a/backend/app/ai/providers/openai.py
+++ b/backend/app/ai/providers/openai.py
@@ -2,6 +2,8 @@ import asyncio
 import json
 import logging
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from typing import TypeVar
 
 import httpx
@@ -134,13 +136,29 @@ class OpenAIProvider(LLMProvider):
                             json=payload,
                             headers=self.headers,
                         ) as response:
-                            
+
                             if response.status_code == 429:
                                 retry_after = response.headers.get("Retry-After")
 
-                                if retry_after and retry_after.isdigit():
-                                    delay = int(retry_after)
-                                else:
+                                delay = None
+
+                                if retry_after:
+                                    if retry_after.isdigit():
+                                        delay = max(0, int(retry_after))
+                                    else:
+                                        try:
+                                            retry_at = parsedate_to_datetime(retry_after)
+                                            now = datetime.now(UTC)
+
+                                            delay = max(
+                                                0,
+                                                int((retry_at - now).total_seconds()),
+                                            )
+
+                                        except (TypeError, ValueError, OverflowError):
+                                            delay = None
+
+                                if delay is None:
                                     delay = 2 ** attempt
 
                                 logger.warning(
@@ -150,7 +168,7 @@ class OpenAIProvider(LLMProvider):
 
                                 await asyncio.sleep(delay)
                                 continue
-                
+
                             if response.status_code != 200:
                                 error_body = await response.aread()
 
@@ -160,36 +178,41 @@ class OpenAIProvider(LLMProvider):
                                 )
 
                             async for line in response.aiter_lines():
-                                if not line or not line.startswith("data: "):
+                                line = line.strip()
+
+                                if not line.startswith("data:"):
                                     continue
 
-                                data_str = line[6:].strip()
+                                data_str = line.removeprefix("data:").strip()
+
+                                if not data_str:
+                                    continue
 
                                 if data_str == "[DONE]":
                                     break
 
                                 try:
                                     data = json.loads(data_str)
-
-                                    choices = data.get("choices", [])
-
-                                    if choices:
-                                        delta = choices[0].get("delta", {})
-                                        content = delta.get("content", "")
-
-                                        if content:
-                                            yield content
-
                                 except json.JSONDecodeError:
+                                    logger.debug("Skipping malformed stream chunk: %s", data_str)
                                     continue
+
+                                choices = data.get("choices", [])
+
+                                if choices:
+                                    delta = choices[0].get("delta", {})
+                                    content = delta.get("content", "")
+
+                                    if content:
+                                        yield content
 
                             return
 
                     except httpx.HTTPError as e:
-                        raise LLMProviderError(
-                            "openai",
-                            f"Streaming connection error: {str(e)}",
-                        ) from e
+                        if attempt == max_retries - 1:
+                            raise LLMProviderError("openai", str(e)) from e
+                        await asyncio.sleep(2 ** attempt)
+                        continue
 
                 raise LLMProviderError(
                     "openai",
@@ -197,4 +220,3 @@ class OpenAIProvider(LLMProvider):
                 )
 
         return generator()
-    

--- a/backend/scripts/validate_profiles.py
+++ b/backend/scripts/validate_profiles.py
@@ -1,4 +1,5 @@
 """CLI utility to validate EnvForge profile configurations against schemas and logic rules."""
+# ruff: noqa: E402
 import os
 import sys
 from pathlib import Path

--- a/backend/tests/unit/ai/test_ollama_provider.py
+++ b/backend/tests/unit/ai/test_ollama_provider.py
@@ -1,0 +1,273 @@
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from app.ai.providers.base import LLMProviderError
+from app.ai.providers.ollama import OllamaProvider
+
+
+class MockResponse(BaseModel):
+    message: str
+
+
+# -----------------------------
+# INIT TESTS
+# -----------------------------
+
+def test_empty_base_url():
+    with pytest.raises(LLMProviderError):
+        OllamaProvider(base_url="")
+
+
+def test_empty_model():
+    with pytest.raises(LLMProviderError):
+        OllamaProvider(model="")
+
+
+# -----------------------------
+# COMPLETE SUCCESS TEST
+# -----------------------------
+
+@pytest.mark.asyncio
+async def test_complete_success():
+
+    provider = OllamaProvider()
+
+    mock_response = Mock()
+
+    mock_response.json.return_value = {
+        "response": json.dumps({"message": "Hello"})
+    }
+
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    with patch("httpx.AsyncClient") as mock_async_client:
+
+        mock_async_client.return_value.__aenter__.return_value = mock_client
+
+        result = await provider.complete(
+            "system",
+            "user",
+            MockResponse,
+        )
+
+        assert result.message == "Hello"
+
+
+# -----------------------------
+# EMPTY RESPONSE TEST
+# -----------------------------
+
+@pytest.mark.asyncio
+async def test_complete_empty_response():
+
+    provider = OllamaProvider()
+
+    mock_response = Mock()
+
+    mock_response.json.return_value = {
+        "response": ""
+    }
+
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    with patch("httpx.AsyncClient") as mock_async_client:
+
+        mock_async_client.return_value.__aenter__.return_value = mock_client
+
+        with pytest.raises(LLMProviderError):
+
+            await provider.complete(
+                "system",
+                "user",
+                MockResponse,
+            )
+
+
+# -----------------------------
+# INVALID JSON TEST
+# -----------------------------
+
+@pytest.mark.asyncio
+async def test_complete_invalid_json():
+
+    provider = OllamaProvider()
+
+    mock_response = Mock()
+
+    mock_response.json.return_value = {
+        "response": "not valid json"
+    }
+
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    with patch("httpx.AsyncClient") as mock_async_client:
+
+        mock_async_client.return_value.__aenter__.return_value = mock_client
+
+        with pytest.raises(LLMProviderError):
+
+            await provider.complete(
+                "system",
+                "user",
+                MockResponse,
+            )
+
+
+# -----------------------------
+# CONNECTION ERROR TEST
+# -----------------------------
+
+@pytest.mark.asyncio
+async def test_complete_connection_error():
+
+    provider = OllamaProvider()
+
+    mock_client = AsyncMock()
+
+    mock_client.post.side_effect = httpx.ConnectError(
+        "Connection failed"
+    )
+
+    with patch("httpx.AsyncClient") as mock_async_client:
+
+        mock_async_client.return_value.__aenter__.return_value = mock_client
+
+        with pytest.raises(LLMProviderError):
+
+            await provider.complete(
+                "system",
+                "user",
+                MockResponse,
+            )
+
+
+# -----------------------------
+# STREAM SUCCESS TEST
+# -----------------------------
+
+@pytest.mark.asyncio
+async def test_stream_success():
+
+    provider = OllamaProvider()
+
+    stream_lines = [
+        json.dumps({"response": "Hello"}),
+        json.dumps({"response": " World"}),
+    ]
+
+    mock_response = Mock()
+
+    async def mock_aiter_lines():
+        for line in stream_lines:
+            yield line
+
+    mock_response.aiter_lines = mock_aiter_lines
+    mock_response.raise_for_status.return_value = None
+
+    mock_stream = AsyncMock()
+    mock_stream.__aenter__.return_value = mock_response
+
+    mock_client = Mock()
+    mock_client.stream.return_value = mock_stream
+
+    with patch("httpx.AsyncClient") as mock_async_client:
+
+        mock_async_client.return_value.__aenter__.return_value = mock_client
+
+        chunks = []
+
+        async for chunk in provider.stream(
+            "system",
+            "user",
+            MockResponse,
+        ):
+            chunks.append(chunk)
+
+        assert "".join(chunks) == "Hello World"
+
+
+# -----------------------------
+# STREAM MALFORMED JSON TEST
+# -----------------------------
+
+@pytest.mark.asyncio
+async def test_stream_skips_invalid_json():
+
+    provider = OllamaProvider()
+
+    stream_lines = [
+        "invalid json",
+        json.dumps({"response": "Hello"}),
+    ]
+
+    mock_response = Mock()
+
+    async def mock_aiter_lines():
+        for line in stream_lines:
+            yield line
+
+    mock_response.aiter_lines = mock_aiter_lines
+    mock_response.raise_for_status.return_value = None
+
+    mock_stream = AsyncMock()
+    mock_stream.__aenter__.return_value = mock_response
+
+    mock_client = Mock()
+    mock_client.stream.return_value = mock_stream
+
+    with patch("httpx.AsyncClient") as mock_async_client:
+
+        mock_async_client.return_value.__aenter__.return_value = mock_client
+
+        chunks = []
+
+        async for chunk in provider.stream(
+            "system",
+            "user",
+            MockResponse,
+        ):
+            chunks.append(chunk)
+
+        assert "".join(chunks) == "Hello"
+
+
+# -----------------------------
+# STREAM CONNECTION ERROR
+# -----------------------------
+
+@pytest.mark.asyncio
+async def test_stream_connection_error():
+
+    provider = OllamaProvider()
+
+    mock_client = Mock()
+
+    mock_client.stream.side_effect = httpx.ConnectError(
+        "Connection failed"
+    )
+
+    with patch("httpx.AsyncClient") as mock_async_client:
+
+        mock_async_client.return_value.__aenter__.return_value = mock_client
+
+        with pytest.raises(LLMProviderError):
+
+            async for _ in provider.stream(
+                "system",
+                "user",
+                MockResponse,
+            ):
+                pass

--- a/backend/tests/unit/ai/test_ollama_provider.py
+++ b/backend/tests/unit/ai/test_ollama_provider.py
@@ -271,3 +271,4 @@ async def test_stream_connection_error():
                 MockResponse,
             ):
                 pass
+            

--- a/backend/tests/unit/ai/test_ollama_provider.py
+++ b/backend/tests/unit/ai/test_ollama_provider.py
@@ -271,4 +271,3 @@ async def test_stream_connection_error():
                 MockResponse,
             ):
                 pass
-            

--- a/backend/tests/unit/ai/test_openai_provider.py
+++ b/backend/tests/unit/ai/test_openai_provider.py
@@ -1,0 +1,43 @@
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from app.ai.providers.base import LLMProviderError
+from app.ai.providers.openai import OpenAIProvider
+
+
+class DummyModel(BaseModel):
+    response: str
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_rate_limit_short_circuit():
+    """Verify that OpenAIProvider.stream handles 429s, retries, and short-circuits on the final attempt."""
+    provider = OpenAIProvider(api_key="test_key")
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 429
+    mock_response.headers = httpx.Headers({"Retry-After": "1"})
+
+    mock_stream_ctx = MagicMock()
+    mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_stream_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("httpx.AsyncClient.stream", return_value=mock_stream_ctx) as mock_stream_call,
+        patch("asyncio.sleep", AsyncMock()) as mock_sleep,
+    ):
+        generator = provider.stream(
+            system_prompt="Test system", user_message="Test user", response_model=DummyModel
+        )
+
+        with pytest.raises(LLMProviderError) as exc_info:
+            async for _ in generator:
+                pass
+
+        assert "OpenAI streaming failed after maximum retry attempts" in str(exc_info.value)
+        assert mock_stream_call.call_count == 3
+        assert mock_sleep.call_count == 3
+        mock_sleep.assert_has_calls([call(1), call(1)])


### PR DESCRIPTION
## Description
Added retry handling for OpenAI streaming requests when a 429 rate limit response occurs.

## Related Issues
Fixes #138 

## Changes Made
-Added retry logic for OpenAI streaming requests
-Added Retry-After header handling
-Added exponential backoff fallback
-Added maximum retry protection

## Verification
<!-- Describe how you verified that your changes work. -->
- [ ] Added unit tests
- [x] Ran `pytest tests/` successfully
- [x] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved OpenAI streaming with automatic retries and refined rate‑limit handling for more reliable live responses.
* **Bug Fixes**
  * Stream failures now surface consistently after retries; malformed streamed fragments are skipped instead of breaking output.
* **Tests**
  * Added/expanded unit tests covering provider construction, completion, streaming behavior, rate‑limit retries, and connection/timeout errors.
* **Chores**
  * Minor import and lint adjustments across scripts and detectors; updated test imports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->