### PR TITLE
feat(cli): add --timeout option to envforge diagnose command

### DIFF
--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -73,7 +73,15 @@ def cli() -> None:
     help="Output diagnostics in SARIF 2.1.0 format for CI/CD pipeline integrations.",
 )
 
-def diagnose(output: str | None, send: bool, api_url: str, quiet: bool, sarif: bool) -> None:
+@click.option(
+    "--timeout", "-t",
+    type=int,
+    default=30,
+    show_default=True,
+    help="Timeout in seconds for each detector subprocess call. Default: 30s.",
+)
+
+def diagnose(output: str | None, send: bool, api_url: str, quiet: bool, sarif: bool, timeout: int) -> None:
     """
     Collect a full diagnostic report of this machine's ML environment.
 
@@ -87,7 +95,7 @@ def diagnose(output: str | None, send: bool, api_url: str, quiet: bool, sarif: b
             expand=False,
         ))
 
-    report = ReportBuilder().build()
+    report = ReportBuilder(timeout=timeout).build()
 
     if not quiet:
         _print_report_summary(report)

--- a/cli/envforge_agent/detectors/cuda_detector.py
+++ b/cli/envforge_agent/detectors/cuda_detector.py
@@ -23,13 +23,13 @@ from pathlib import Path
 from envforge_agent.schemas import CUDAInfo
 
 
-def detect_cuda() -> CUDAInfo:
+def detect_cuda(timeout: int = 30) -> CUDAInfo:
     """
     Detect CUDA installation details.
     Returns CUDAInfo with all None fields if CUDA is not installed.
     Never raises.
     """
-    version = _detect_cuda_version()
+    version = _detect_cuda_version(timeout=timeout)
     toolkit_path = _detect_toolkit_path(version)
     cudnn_version = _detect_cudnn(toolkit_path)
     nccl_version = _detect_nccl(toolkit_path)
@@ -44,9 +44,9 @@ def detect_cuda() -> CUDAInfo:
 
 # ── CUDA version ──────────────────────────────────────────────────────────────
 
-def _detect_cuda_version() -> str | None:
+def _detect_cuda_version(timeout: int = 30) -> str | None:
     # Method 1: nvcc --version (most reliable — requires CUDA toolkit installed)
-    version = _nvcc_version()
+    version = _nvcc_version(timeout=timeout)
     if version:
         return version
 
@@ -61,19 +61,19 @@ def _detect_cuda_version() -> str | None:
         return version
 
     # Method 4: nvidia-smi CUDA version (driver-level, may differ from toolkit)
-    version = _nvidia_smi_cuda_version()
+    version = _nvidia_smi_cuda_version(timeout=timeout)
     if version:
         return version
 
     return None
 
 
-def _nvcc_version() -> str | None:
+def _nvcc_version(timeout: int = 30) -> str | None:
     """Parse CUDA version from `nvcc --version`."""
     try:
         result = subprocess.run(
             ["nvcc", "--version"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True, text=True, timeout=timeout,
         )
         if result.returncode != 0:
             return None
@@ -125,13 +125,13 @@ def _cuda_path_env_version() -> str | None:
     return None
 
 
-def _nvidia_smi_cuda_version() -> str | None:
+def _nvidia_smi_cuda_version(timeout: int = 30) -> str | None:
     """Get CUDA version from nvidia-smi (driver-reported, not toolkit)."""
     # Method A: Try specific query-gpu first
     try:
         result = subprocess.run(
             ["nvidia-smi", "--query-gpu=cuda_version", "--format=csv,noheader"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True, text=True, timeout=timeout,
         )
         if result.returncode == 0:
             ver = result.stdout.strip().splitlines()[0].strip()

--- a/cli/envforge_agent/detectors/gpu_detector.py
+++ b/cli/envforge_agent/detectors/gpu_detector.py
@@ -14,24 +14,24 @@ from typing import NamedTuple
 from envforge_agent.schemas import GPUInfo
 
 
-def detect_gpus() -> list[GPUInfo]:
+def detect_gpus(timeout: int = 30) -> list[GPUInfo]:
     """
     Detect all GPUs (NVIDIA or AMD).
     """
     try:
-        gpus = _detect_via_nvidia_smi()
+        gpus = _detect_via_nvidia_smi(timeout=timeout)
         if gpus:
             return gpus
     except Exception:
         pass
 
     try:
-        return _detect_via_rocm_smi()
+        return _detect_via_rocm_smi(timeout=timeout)
     except Exception:
         return []
 
 
-def _detect_via_nvidia_smi() -> list[GPUInfo]:
+def _detect_via_nvidia_smi(timeout: int = 30) -> list[GPUInfo]:
     """
     Run nvidia-smi with CSV query and parse output.
 
@@ -45,7 +45,7 @@ def _detect_via_nvidia_smi() -> list[GPUInfo]:
         ],
         capture_output=True,
         text=True,
-        timeout=15,
+        timeout=timeout,
     )
 
     if result.returncode != 0:
@@ -86,7 +86,7 @@ def _detect_via_nvidia_smi() -> list[GPUInfo]:
     return gpus
 
 
-def _detect_via_rocm_smi() -> list[GPUInfo]:
+def _detect_via_rocm_smi(timeout: int = 30) -> list[GPUInfo]:
     """
     Run rocm-smi and parse JSON output.
     """
@@ -95,7 +95,7 @@ def _detect_via_rocm_smi() -> list[GPUInfo]:
             ["rocm-smi", "--showproductname", "--showvram", "--showdriverversion", "--json"],
             capture_output=True,
             text=True,
-            timeout=15,
+            timeout=timeout,
         )
     except FileNotFoundError:
         return []

--- a/cli/envforge_agent/report.py
+++ b/cli/envforge_agent/report.py
@@ -29,6 +29,14 @@ class ReportBuilder:
     zero/None values in the report.
     """
 
+    def __init__(self, timeout: int = 30) -> None:
+        """
+        Args:
+            timeout: Seconds before each detector subprocess call is aborted.
+                     Timed-out detectors return safe defaults (None / empty).
+        """
+        self._timeout = timeout
+
     def build(self) -> DiagnosticReport:
         """
         Run all detectors and return a validated DiagnosticReport.
@@ -38,8 +46,8 @@ class ReportBuilder:
         os_info = detect_os()
         cpu_info = detect_cpu()
         ram_info = detect_ram()
-        gpus = detect_gpus()
-        cuda_info = detect_cuda()
+        gpus = detect_gpus(timeout=self._timeout)
+        cuda_info = detect_cuda(timeout=self._timeout)
         rocm_info = detect_rocm()
         installations, active_python = detect_python()
 


### PR DESCRIPTION
## Description
Adds a configurable `--timeout` / `-t` option to `envforge diagnose` so
users on slow machines, network-mounted filesystems, or misconfigured WSL2
environments can control how long each detector subprocess waits before
giving up. Previously, subprocess calls like `nvidia-smi` and `nvcc` had
hardcoded timeouts and could not be tuned by the user.

## Related Issues
Closes #135

## Changes Made
- `cli/envforge_agent/cli.py` — added `--timeout / -t` Click option to the `diagnose` command (default: 30s); passed to `ReportBuilder`
- `cli/envforge_agent/report.py` — `ReportBuilder.__init__` now accepts `timeout: int = 30` and passes it to GPU and CUDA detectors
- `cli/envforge_agent/detectors/gpu_detector.py` — `detect_gpus()`, `_detect_via_nvidia_smi()`, `_detect_via_rocm_smi()` all accept and use `timeout` parameter
- `cli/envforge_agent/detectors/cuda_detector.py` — `detect_cuda()`, `_detect_cuda_version()`, `_nvcc_version()`, `_nvidia_smi_cuda_version()` all accept and use `timeout` parameter

## Usage
```bash
envforge diagnose --timeout 10   # limit each subprocess to 10s
envforge diagnose -t 5           # shorthand
envforge diagnose                 # default 30s unchanged
```

## Verification
- [ ] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [x] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

Verified `--timeout 10` runs correctly and `--help` shows the new flag:
-t, --timeout INTEGER  Timeout in seconds for each detector subprocess call.
Default: 30s.  [default: 30]

## Documentation
- [ ] Updated `docs/FEATURES.md`
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted

## Screenshots 

<img width="1448" height="507" alt="image" src="https://github.com/user-attachments/assets/835aa868-ea7d-4dd9-82ec-8aac61eae41a" />
