### PR TITLE
feat: add ML .gitignore template generation

### DIFF
--- a/backend/app/schemas/script.py
+++ b/backend/app/schemas/script.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 OSTarget = Literal["LINUX", "WSL", "WIN"]
-OutputFormat = Literal["setup.sh", "setup.ps1", "requirements.txt", "Dockerfile", "docker-compose.yml", "devcontainer.json", "pyproject.toml"]
+OutputFormat = Literal["setup.sh", "setup.ps1", "requirements.txt", "Dockerfile", "docker-compose.yml", "devcontainer.json", "pyproject.toml", ".gitignore"]
 
 
 class GenerationRequest(BaseModel):

--- a/backend/app/templates/engine.py
+++ b/backend/app/templates/engine.py
@@ -29,6 +29,7 @@ TEMPLATE_MAP: dict[str, str] = {
     "verify_opencv.sh":   "verify/verify_opencv.sh.j2",
     "environment.yml":    "config/environment.yml.j2",
     "pyproject.toml":     "config/pyproject.toml.j2",
+    ".gitignore":         "config/gitignore.j2",
 }
 
 # ── Profile-specific verify template mapping ───────────────────────────────────

--- a/backend/app/templates/jinja/config/gitignore.j2
+++ b/backend/app/templates/jinja/config/gitignore.j2
@@ -1,0 +1,42 @@
+# ==============================================================================
+# EnvForge Generated .gitignore
+# Profile  : {{ profile.name }}
+# Generated: {{ generated_at }}
+# EnvForge : v{{ envforge_version }}
+# ==============================================================================
+
+# Python
+__pycache__/
+*.py[cod]
+*.so
+
+# Virtual Environments
+.venv/
+venv/
+env/
+
+# ML Models
+*.pt
+*.pth
+*.h5
+*.ckpt
+*.onnx
+
+# Data
+data/
+datasets/
+
+# Logs
+logs/
+*.log
+
+# Jupyter
+.ipynb_checkpoints/
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/backend/tests/unit/templates/test_gitignore_template.py
+++ b/backend/tests/unit/templates/test_gitignore_template.py
@@ -1,0 +1,33 @@
+from app.compatibility.models import ResolvedEnvironment
+from app.templates.engine import TemplateRenderer
+from app.templates.models import TemplateContext
+
+
+def make_context(
+    profile_name="ml-env",
+    python_version="3.11",
+):
+    resolved = ResolvedEnvironment(
+        python_version=python_version,
+        cuda_version=None,
+        target_os="LINUX",
+        packages=[],
+    )
+
+    return TemplateContext(
+        profile_id="test-id",
+        profile_name=profile_name,
+        resolved=resolved,
+    )
+
+
+def test_gitignore_template_renders():
+    context = make_context()
+
+    renderer = TemplateRenderer()
+    result = renderer.render(".gitignore", context)
+
+    assert "__pycache__/" in result.content
+    assert ".venv/" in result.content
+    assert "*.pt" in result.content
+    assert "data/" in result.content

--- a/docs/features/script-generation.md
+++ b/docs/features/script-generation.md
@@ -76,6 +76,7 @@ GenerationResponse { job_id, scripts[], resolved_packages[], warnings[], downloa
 | `"Dockerfile"` | `jinja/config/dockerfile.j2` | Docker image |
 | `"devcontainer.json"` | `jinja/config/devcontainer.j2` | VS Code dev container |
 | `"verify_torch.sh"` | `jinja/verify/verify_torch.sh.j2` | PyTorch CUDA check |
+| `".gitignore"` | `jinja/config/gitignore.j2` | ML-focused .gitignore template |
 
 ---
 


### PR DESCRIPTION
Closes #185

## Summary
Adds ML-focused `.gitignore` template generation support.

## Changes
- Added `gitignore.j2` template for ML projects
- Registered template in `TEMPLATE_MAP`
- Added `.gitignore` output support in schemas/
- Added unit test for rendering validation
- Updated script-generation feature documentation

## Testing
- `pytest tests/unit/templates/test_gitignore_template.py` passes locally

## Notes
- Follows CONTRIBUTING.md template guidelines