### PR TITLE
feat: add envforge audit subcommand (#181)

### DIFF
--- a/cli/envforge_agent/audit/__init__.py
+++ b/cli/envforge_agent/audit/__init__.py
@@ -1,0 +1,16 @@
+"""envforge audit — compare two environments and surface drift."""
+from .command import audit_command
+from .differ import diff
+from .models import AuditResult, DiffEntry, Package
+from .sources import LocalEnvironment, LockfileSource, Source
+
+__all__ = [
+    "audit_command",
+    "diff",
+    "AuditResult",
+    "DiffEntry",
+    "Package",
+    "Source",
+    "LocalEnvironment",
+    "LockfileSource",
+]

--- a/cli/envforge_agent/audit/command.py
+++ b/cli/envforge_agent/audit/command.py
@@ -63,5 +63,10 @@ def audit_command(source_a: str, source_b: str) -> None:
         err_console.print(f"[ERROR] {exc}")
         sys.exit(2)
 
-    result = diff(src_a, src_b)
+    try:
+        result = diff(src_a, src_b)
+    except (RuntimeError, FileNotFoundError) as exc:
+        err_console.print(f"[ERROR] {exc}")
+        sys.exit(1)
+
     format_text(result, console)

--- a/cli/envforge_agent/audit/command.py
+++ b/cli/envforge_agent/audit/command.py
@@ -1,0 +1,67 @@
+"""Click subcommand: `envforge audit <source-a> <source-b>`."""
+from __future__ import annotations
+from pathlib import Path
+import sys
+
+import click
+from rich.console import Console
+
+from .differ import diff
+from .formatters import format_text
+from .sources import LocalEnvironment, LockfileSource, Source
+
+
+console = Console()
+err_console = Console(stderr=True, style="bold red")
+
+
+def _resolve_source(spec: str) -> Source:
+    """Convert a CLI source string into a Source instance.
+
+    Accepted forms:
+        "local"             -> the active Python environment
+        path to a file      -> LockfileSource (must exist on disk)
+    """
+    if spec == "local":
+        return LocalEnvironment()
+
+    path = Path(spec)
+    if path.exists() and path.is_file():
+        return LockfileSource(path)
+
+    raise click.BadParameter(
+        f"Could not interpret source '{spec}'. "
+        f"Use 'local' or a path to a lockfile."
+    )
+
+
+@click.command("audit")
+@click.argument("source_a", required=True)
+@click.argument("source_b", required=True)
+def audit_command(source_a: str, source_b: str) -> None:
+    """Compare two environments and report drift.
+
+    SOURCE_A and SOURCE_B can each be either:
+
+    \b
+        local                 the active Python environment (via pip list)
+        path/to/lockfile.txt  a requirements.txt-style lockfile
+
+    Examples:
+
+    \b
+        envforge audit local requirements.txt
+        envforge audit requirements.lock requirements.txt
+    """
+    try:
+        src_a = _resolve_source(source_a)
+        src_b = _resolve_source(source_b)
+    except click.BadParameter as exc:
+        err_console.print(f"[ERROR] {exc.message}")
+        sys.exit(2)
+    except FileNotFoundError as exc:
+        err_console.print(f"[ERROR] {exc}")
+        sys.exit(2)
+
+    result = diff(src_a, src_b)
+    format_text(result, console)

--- a/cli/envforge_agent/audit/command.py
+++ b/cli/envforge_agent/audit/command.py
@@ -59,13 +59,10 @@ def audit_command(source_a: str, source_b: str) -> None:
     except click.BadParameter as exc:
         err_console.print(f"[ERROR] {exc.message}")
         sys.exit(2)
-    except FileNotFoundError as exc:
-        err_console.print(f"[ERROR] {exc}")
-        sys.exit(2)
 
     try:
         result = diff(src_a, src_b)
-    except (RuntimeError, FileNotFoundError) as exc:
+    except RuntimeError as exc:
         err_console.print(f"[ERROR] {exc}")
         sys.exit(1)
 

--- a/cli/envforge_agent/audit/differ.py
+++ b/cli/envforge_agent/audit/differ.py
@@ -1,0 +1,82 @@
+"""
+Diff algorithm for envforge audit.
+
+Compares two Source instances and produces an AuditResult. Severity is
+classified using a semver-style heuristic; the existing compatibility engine
+will be wired in as a follow-up to refine which deltas are likely breaking.
+"""
+from __future__ import annotations
+from typing import Dict
+
+from .models import AuditResult, DiffEntry
+from .sources import Source
+
+
+def _classify_version_change(a: str, b: str) -> str:
+    """Classify a version change by semver-style severity.
+
+    Returns one of: "major", "minor", "patch", "other".
+    Non-numeric or unparseable version strings fall through to "other".
+    """
+    try:
+        a_parts = [int(x) for x in a.split(".")[:3]]
+        b_parts = [int(x) for x in b.split(".")[:3]]
+    except ValueError:
+        return "other"
+
+    while len(a_parts) < 3:
+        a_parts.append(0)
+    while len(b_parts) < 3:
+        b_parts.append(0)
+
+    if a_parts[0] != b_parts[0]:
+        return "major"
+    if a_parts[1] != b_parts[1]:
+        return "minor"
+    if a_parts[2] != b_parts[2]:
+        return "patch"
+    return "other"
+
+
+def _to_dict(source: Source) -> Dict[str, str]:
+    return {p.name: p.version for p in source.packages()}
+
+
+def diff(source_a: Source, source_b: Source) -> AuditResult:
+    """Compare two sources; return an AuditResult listing every difference."""
+    a_packages = _to_dict(source_a)
+    b_packages = _to_dict(source_b)
+
+    all_names = sorted(set(a_packages) | set(b_packages))
+
+    differences = []
+    common_count = 0
+
+    for name in all_names:
+        a_ver = a_packages.get(name)
+        b_ver = b_packages.get(name)
+
+        if a_ver is None:
+            differences.append(DiffEntry(
+                package=name, a_version=None, b_version=b_ver, severity="added"
+            ))
+        elif b_ver is None:
+            differences.append(DiffEntry(
+                package=name, a_version=a_ver, b_version=None, severity="removed"
+            ))
+        elif a_ver == b_ver:
+            common_count += 1
+        else:
+            differences.append(DiffEntry(
+                package=name,
+                a_version=a_ver,
+                b_version=b_ver,
+                severity=_classify_version_change(a_ver, b_ver),
+            ))
+
+    return AuditResult(
+        source_a=source_a.name,
+        source_b=source_b.name,
+        differences=differences,
+        common_count=common_count,
+    )

--- a/cli/envforge_agent/audit/formatters.py
+++ b/cli/envforge_agent/audit/formatters.py
@@ -65,7 +65,10 @@ def format_text(result: AuditResult, console: Console) -> None:
     for entry in result.differences:
         counts[entry.severity] = counts.get(entry.severity, 0) + 1
 
-    summary = ", ".join(f"{count} {sev}" for sev, count in sorted(counts.items()))
+    summary = ", ".join(
+        f"{counts[sev]} {sev}"
+        for sev in sorted(counts, key=lambda s: SEVERITY_ORDER.get(s, 99))
+    )
     console.print(
         f"\n[bold]Summary:[/] {len(result.differences)} differences "
         f"({summary}); {result.common_count} matching packages."

--- a/cli/envforge_agent/audit/formatters.py
+++ b/cli/envforge_agent/audit/formatters.py
@@ -1,0 +1,72 @@
+"""
+Output formatters for envforge audit.
+
+MVP includes only the text formatter (Rich-styled console output).
+JSON and SARIF formatters will be added in follow-up PRs.
+"""
+from __future__ import annotations
+from rich.console import Console
+from rich.table import Table
+from rich import box
+
+from .models import AuditResult
+
+
+SEVERITY_STYLES = {
+    "major": "bold red",
+    "minor": "yellow",
+    "patch": "green",
+    "added": "cyan",
+    "removed": "magenta",
+    "other": "white",
+}
+
+SEVERITY_ORDER = {
+    "major": 0, "minor": 1, "patch": 2, "added": 3, "removed": 4, "other": 5,
+}
+
+
+def format_text(result: AuditResult, console: Console) -> None:
+    """Print the audit result as a Rich-styled table on the given console."""
+    console.print(
+        f"\n[bold]Audit:[/] {result.source_a} -> {result.source_b}\n"
+    )
+
+    if not result.has_drift():
+        console.print(
+            f"[bold green]No drift detected[/] "
+            f"({result.common_count} packages match)"
+        )
+        return
+
+    table = Table(box=box.ROUNDED, show_header=True, header_style="bold")
+    table.add_column("Package")
+    table.add_column(result.source_a, justify="left")
+    table.add_column(result.source_b, justify="left")
+    table.add_column("Severity")
+
+    sorted_diffs = sorted(
+        result.differences,
+        key=lambda d: (SEVERITY_ORDER.get(d.severity, 99), d.package),
+    )
+
+    for entry in sorted_diffs:
+        style = SEVERITY_STYLES.get(entry.severity, "white")
+        table.add_row(
+            entry.package,
+            entry.a_version or "-",
+            entry.b_version or "-",
+            f"[{style}]{entry.severity}[/]",
+        )
+
+    console.print(table)
+
+    counts = {}
+    for entry in result.differences:
+        counts[entry.severity] = counts.get(entry.severity, 0) + 1
+
+    summary = ", ".join(f"{count} {sev}" for sev, count in sorted(counts.items()))
+    console.print(
+        f"\n[bold]Summary:[/] {len(result.differences)} differences "
+        f"({summary}); {result.common_count} matching packages."
+    )

--- a/cli/envforge_agent/audit/models.py
+++ b/cli/envforge_agent/audit/models.py
@@ -1,0 +1,49 @@
+"""Data types for envforge audit."""
+from __future__ import annotations
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+def _normalize_name(name: str) -> str:
+    """PEP 503 normalization: lowercase, collapse runs of _-. to single hyphen."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+@dataclass(frozen=True)
+class Package:
+    """Resolved package entry: name (normalized per PEP 503) + version string.
+
+    Normalization ensures `Pillow` and `pillow` compare as the same package,
+    and `pytest-asyncio` and `pytest_asyncio` are also unified.
+    """
+    name: str
+    version: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", _normalize_name(self.name))
+
+
+@dataclass
+class DiffEntry:
+    """A single difference between two sources for one package.
+
+    severity is one of: "added", "removed", "major", "minor", "patch", "other".
+    "added" means the package is only in source B; "removed" only in source A.
+    """
+    package: str
+    a_version: Optional[str]
+    b_version: Optional[str]
+    severity: str
+
+
+@dataclass
+class AuditResult:
+    """Outcome of comparing two sources."""
+    source_a: str
+    source_b: str
+    differences: List[DiffEntry] = field(default_factory=list)
+    common_count: int = 0
+
+    def has_drift(self) -> bool:
+        return len(self.differences) > 0

--- a/cli/envforge_agent/audit/sources.py
+++ b/cli/envforge_agent/audit/sources.py
@@ -28,23 +28,53 @@ class Source:
 
 
 class LocalEnvironment(Source):
-    """Active Python environment, enumerated via `pip list --format=json`."""
+    """Active Python environment, enumerated via `pip list --format=json`.
+
+    Wraps the subprocess call with a timeout and converts any failure mode
+    (timeout, non-zero exit, missing interpreter, malformed output) into a
+    RuntimeError with a clear message, so the command layer can surface a
+    clean error instead of a raw traceback.
+    """
 
     name = "local"
+    PIP_LIST_TIMEOUT_SECONDS = 30
 
     def __init__(self, python_executable: Optional[str] = None) -> None:
         self.python = python_executable or sys.executable
 
     def packages(self) -> Iterator[Package]:
-        result = subprocess.run(
-            [self.python, "-m", "pip", "list", "--format=json"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        for entry in json.loads(result.stdout):
-            yield Package(name=entry["name"], version=entry["version"])
+        try:
+            result = subprocess.run(
+                [self.python, "-m", "pip", "list", "--format=json"],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=self.PIP_LIST_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"`pip list` did not complete within {self.PIP_LIST_TIMEOUT_SECONDS}s. "
+                f"The active Python environment may be unresponsive."
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip() or "<no stderr>"
+            raise RuntimeError(
+                f"`pip list` failed with exit code {exc.returncode}: {stderr}"
+            ) from exc
+        except (FileNotFoundError, OSError) as exc:
+            raise RuntimeError(
+                f"Could not execute Python interpreter at '{self.python}': {exc}"
+            ) from exc
 
+        try:
+            entries = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"`pip list` returned malformed JSON output."
+            ) from exc
+
+        for entry in entries:
+            yield Package(name=entry["name"], version=entry["version"])
 
 class LockfileSource(Source):
     """Requirements-format lockfile (one `package==version` per line).

--- a/cli/envforge_agent/audit/sources.py
+++ b/cli/envforge_agent/audit/sources.py
@@ -97,10 +97,17 @@ class LockfileSource(Source):
             line = raw_line.split("#", 1)[0].strip()
             if not line or line.startswith("-"):
                 continue
-            if "==" not in line:
+
+            # Detect '===' (PEP 440 arbitrary equality) before '==' so we
+            # don't misparse 'pkg===1.0' as 'pkg==' + '=1.0'.
+            if "===" in line:
+                separator = "==="
+            elif "==" in line:
+                separator = "=="
+            else:
                 continue
 
-            name_part, version_part = line.split("==", 1)
+            name_part, version_part = line.split(separator, 1)
             name = name_part.split("[", 1)[0].split(";", 1)[0].strip()
             version = version_part.split(";", 1)[0].strip()
             if name and version:

--- a/cli/envforge_agent/audit/sources.py
+++ b/cli/envforge_agent/audit/sources.py
@@ -1,0 +1,77 @@
+"""
+Source abstractions for envforge audit.
+
+A Source represents one environment we can compare. The MVP supports two:
+    LocalEnvironment: the active Python interpreter, enumerated via `pip list`
+    LockfileSource:   a requirements.txt-style file on disk
+
+Future sources (poetry.lock, uv.lock, remote envforge envs via #85's REST API)
+slot in by subclassing Source and yielding Package instances.
+"""
+from __future__ import annotations
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterator, Optional, Union
+
+from .models import Package
+
+
+class Source:
+    """Base class for audit sources. Subclasses yield Package instances."""
+
+    name: str = "source"
+
+    def packages(self) -> Iterator[Package]:
+        raise NotImplementedError
+
+
+class LocalEnvironment(Source):
+    """Active Python environment, enumerated via `pip list --format=json`."""
+
+    name = "local"
+
+    def __init__(self, python_executable: Optional[str] = None) -> None:
+        self.python = python_executable or sys.executable
+
+    def packages(self) -> Iterator[Package]:
+        result = subprocess.run(
+            [self.python, "-m", "pip", "list", "--format=json"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        for entry in json.loads(result.stdout):
+            yield Package(name=entry["name"], version=entry["version"])
+
+
+class LockfileSource(Source):
+    """Requirements-format lockfile (one `package==version` per line).
+
+    Handles inline `#` comments, blank lines, flag lines (`-r`, `--index-url`),
+    extras (`pkg[extra]==1.0`), and environment markers
+    (`pkg==1.0; python_version<'3.10'`) by stripping them. Lines without `==`
+    are skipped since they can't be meaningfully diffed.
+    """
+
+    def __init__(self, path: Union[Path, str]) -> None:
+        self.path = Path(path)
+        self.name = f"lockfile:{self.path.name}"
+
+    def packages(self) -> Iterator[Package]:
+        if not self.path.exists():
+            raise FileNotFoundError(f"Lockfile not found: {self.path}")
+
+        for raw_line in self.path.read_text(encoding="utf-8").splitlines():
+            line = raw_line.split("#", 1)[0].strip()
+            if not line or line.startswith("-"):
+                continue
+            if "==" not in line:
+                continue
+
+            name_part, version_part = line.split("==", 1)
+            name = name_part.split("[", 1)[0].split(";", 1)[0].strip()
+            version = version_part.split(";", 1)[0].strip()
+            if name and version:
+                yield Package(name=name, version=version)

--- a/cli/envforge_agent/audit/sources.py
+++ b/cli/envforge_agent/audit/sources.py
@@ -90,16 +90,24 @@ class LockfileSource(Source):
         self.name = f"lockfile:{self.path.name}"
 
     def packages(self) -> Iterator[Package]:
-        if not self.path.exists():
-            raise FileNotFoundError(f"Lockfile not found: {self.path}")
+        try:
+            content = self.path.read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"Lockfile not found: {self.path}") from exc
+        except UnicodeDecodeError as exc:
+            raise RuntimeError(
+                f"Lockfile is not valid UTF-8: {self.path} ({exc.reason})"
+            ) from exc
+        except (PermissionError, IsADirectoryError, OSError) as exc:
+            raise RuntimeError(
+                f"Could not read lockfile {self.path}: {exc}"
+            ) from exc
 
-        for raw_line in self.path.read_text(encoding="utf-8").splitlines():
+        for raw_line in content.splitlines():
             line = raw_line.split("#", 1)[0].strip()
             if not line or line.startswith("-"):
                 continue
 
-            # Detect '===' (PEP 440 arbitrary equality) before '==' so we
-            # don't misparse 'pkg===1.0' as 'pkg==' + '=1.0'.
             if "===" in line:
                 separator = "==="
             elif "==" in line:

--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -26,6 +26,7 @@ from envforge_agent.report import ReportBuilder
 from envforge_agent.schemas import DiagnosticReport
 
 from envforge_agent.utils import _map_os_to_target, _extract_python_version
+from envforge_agent.audit import audit_command
 
 console = Console()
 err_console = Console(stderr=True, style="bold red")
@@ -494,4 +495,4 @@ def fix(report: str, profile: str, api_url: str, dry_run: bool) -> None:
         err_console.print(f"API error {e.response.status_code}: {e.response.text}")
         sys.exit(1)
 
-
+cli.add_command(audit_command)

--- a/cli/tests/test_audit.py
+++ b/cli/tests/test_audit.py
@@ -178,8 +178,9 @@ class TestAuditCommand:
 
         result = CliRunner().invoke(audit_command, [str(a), str(b)])
         assert result.exit_code == 0
-        assert "django" in result.output
-        assert "major" in result.output
+        normalized = result.output.lower()
+        assert "django" in normalized
+        assert "major" in normalized
 
     def test_audit_identical_lockfiles_reports_no_drift(self, tmp_path: Path):
         a = tmp_path / "a.txt"
@@ -194,6 +195,7 @@ class TestAuditCommand:
     def test_audit_invalid_source_errors(self):
         result = CliRunner().invoke(audit_command, ["/does/not/exist.txt", "local"])
         assert result.exit_code == 2
+        assert "could not interpret source" in result.output.lower()
         
 class TestLocalEnvironmentErrors:
     @patch("envforge_agent.audit.sources.subprocess.run")
@@ -217,3 +219,9 @@ class TestLocalEnvironmentErrors:
         )
         with pytest.raises(RuntimeError, match=r"malformed JSON"):
             list(LocalEnvironment().packages())
+            
+    @patch("envforge_agent.audit.sources.subprocess.run")
+    def test_missing_interpreter_raises_runtime_error(self, mock_run):
+        mock_run.side_effect = FileNotFoundError("python not found")
+        with pytest.raises(RuntimeError, match=r"Could not execute Python interpreter"):
+            list(LocalEnvironment(python_executable="/bad/python").packages())

--- a/cli/tests/test_audit.py
+++ b/cli/tests/test_audit.py
@@ -6,9 +6,13 @@ from typing import List
 import pytest
 from click.testing import CliRunner
 
+import subprocess
+from unittest.mock import patch
+
 from envforge_agent.audit import (
     audit_command,
     diff,
+    LocalEnvironment,
     LockfileSource,
     Package,
 )
@@ -175,3 +179,26 @@ class TestAuditCommand:
     def test_audit_invalid_source_errors(self):
         result = CliRunner().invoke(audit_command, ["/does/not/exist.txt", "local"])
         assert result.exit_code == 2
+        
+class TestLocalEnvironmentErrors:
+    @patch("envforge_agent.audit.sources.subprocess.run")
+    def test_timeout_raises_runtime_error(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="pip", timeout=30)
+        with pytest.raises(RuntimeError, match=r"did not complete"):
+            list(LocalEnvironment().packages())
+
+    @patch("envforge_agent.audit.sources.subprocess.run")
+    def test_pip_failure_raises_runtime_error(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd="pip", stderr="permission denied"
+        )
+        with pytest.raises(RuntimeError, match=r"failed with exit code 1"):
+            list(LocalEnvironment().packages())
+
+    @patch("envforge_agent.audit.sources.subprocess.run")
+    def test_malformed_pip_output_raises_runtime_error(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="not valid json", stderr=""
+        )
+        with pytest.raises(RuntimeError, match=r"malformed JSON"):
+            list(LocalEnvironment().packages())

--- a/cli/tests/test_audit.py
+++ b/cli/tests/test_audit.py
@@ -97,6 +97,14 @@ class TestLockfileSource:
     def test_raises_on_missing_file(self):
         with pytest.raises(FileNotFoundError):
             list(LockfileSource("/does/not/exist.txt").packages())
+    
+    def test_handles_arbitrary_equality(self, tmp_path: Path):
+        """PEP 440 === (arbitrary equality) should parse correctly,
+        not as == with a leading '=' in the version."""
+        lockfile = tmp_path / "req.txt"
+        lockfile.write_text("mypackage===1.0.local+build\n")
+        packages = list(LockfileSource(lockfile).packages())
+        assert packages == [Package(name="mypackage", version="1.0.local+build")]
 
 
 class _StubSource:

--- a/cli/tests/test_audit.py
+++ b/cli/tests/test_audit.py
@@ -1,0 +1,177 @@
+"""Unit tests for envforge audit (#181 MVP)."""
+from __future__ import annotations
+from pathlib import Path
+from typing import List
+
+import pytest
+from click.testing import CliRunner
+
+from envforge_agent.audit import (
+    audit_command,
+    diff,
+    LockfileSource,
+    Package,
+)
+from envforge_agent.audit.differ import _classify_version_change
+from envforge_agent.audit.models import _normalize_name
+
+
+class TestPackageNormalization:
+    def test_lowercases_name(self):
+        assert Package(name="Pillow", version="10.0.0").name == "pillow"
+
+    def test_collapses_separators(self):
+        assert Package(name="pytest_asyncio", version="0.21").name == "pytest-asyncio"
+        assert Package(name="my.pkg", version="1.0").name == "my-pkg"
+
+    def test_collapses_multiple_runs(self):
+        assert _normalize_name("Foo___Bar...Baz") == "foo-bar-baz"
+
+
+class TestVersionClassification:
+    def test_major_change(self):
+        assert _classify_version_change("1.0.0", "2.0.0") == "major"
+
+    def test_minor_change(self):
+        assert _classify_version_change("1.0.0", "1.1.0") == "minor"
+
+    def test_patch_change(self):
+        assert _classify_version_change("1.0.0", "1.0.1") == "patch"
+
+    def test_non_numeric_falls_to_other(self):
+        assert _classify_version_change("1.0.0", "1.0.0-rc1") == "other"
+
+    def test_short_versions_handled(self):
+        assert _classify_version_change("1", "1.0.1") == "patch"
+
+
+class TestLockfileSource:
+    def test_parses_pinned_packages(self, tmp_path: Path):
+        lockfile = tmp_path / "req.txt"
+        lockfile.write_text("django==4.2.0\nrequests==2.31.0\n")
+        packages = list(LockfileSource(lockfile).packages())
+        assert Package(name="django", version="4.2.0") in packages
+        assert Package(name="requests", version="2.31.0") in packages
+        assert len(packages) == 2
+
+    def test_skips_comments_and_blank_lines(self, tmp_path: Path):
+        lockfile = tmp_path / "req.txt"
+        lockfile.write_text(
+            "# This is a comment\n\ndjango==4.2.0  # inline comment\n\n"
+        )
+        packages = list(LockfileSource(lockfile).packages())
+        assert packages == [Package(name="django", version="4.2.0")]
+
+    def test_skips_flag_lines(self, tmp_path: Path):
+        lockfile = tmp_path / "req.txt"
+        lockfile.write_text(
+            "-r requirements-dev.txt\n"
+            "--index-url https://pypi.org/simple\n"
+            "django==4.2.0\n"
+        )
+        packages = list(LockfileSource(lockfile).packages())
+        assert packages == [Package(name="django", version="4.2.0")]
+
+    def test_skips_unpinned_lines(self, tmp_path: Path):
+        lockfile = tmp_path / "req.txt"
+        lockfile.write_text("django>=4.0\nrequests==2.31.0\n")
+        packages = list(LockfileSource(lockfile).packages())
+        assert packages == [Package(name="requests", version="2.31.0")]
+
+    def test_handles_extras(self, tmp_path: Path):
+        lockfile = tmp_path / "req.txt"
+        lockfile.write_text("django[bcrypt]==4.2.0\n")
+        packages = list(LockfileSource(lockfile).packages())
+        assert packages == [Package(name="django", version="4.2.0")]
+
+    def test_handles_environment_markers(self, tmp_path: Path):
+        lockfile = tmp_path / "req.txt"
+        lockfile.write_text("django==4.2.0; python_version<'3.10'\n")
+        packages = list(LockfileSource(lockfile).packages())
+        assert packages == [Package(name="django", version="4.2.0")]
+
+    def test_raises_on_missing_file(self):
+        with pytest.raises(FileNotFoundError):
+            list(LockfileSource("/does/not/exist.txt").packages())
+
+
+class _StubSource:
+    """Test double — yields a fixed list of packages."""
+
+    def __init__(self, name: str, packages: List[Package]) -> None:
+        self.name = name
+        self._packages = packages
+
+    def packages(self):
+        return iter(self._packages)
+
+
+class TestDiff:
+    def test_identical_environments_have_no_drift(self):
+        a = _StubSource("a", [Package("django", "4.2.0"), Package("requests", "2.31.0")])
+        b = _StubSource("b", [Package("django", "4.2.0"), Package("requests", "2.31.0")])
+        result = diff(a, b)
+        assert not result.has_drift()
+        assert result.common_count == 2
+
+    def test_detects_added_packages(self):
+        a = _StubSource("a", [Package("django", "4.2.0")])
+        b = _StubSource("b", [Package("django", "4.2.0"), Package("requests", "2.31.0")])
+        result = diff(a, b)
+        added = [d for d in result.differences if d.severity == "added"]
+        assert len(added) == 1
+        assert added[0].package == "requests"
+        assert added[0].a_version is None
+        assert added[0].b_version == "2.31.0"
+
+    def test_detects_removed_packages(self):
+        a = _StubSource("a", [Package("django", "4.2.0"), Package("legacy", "1.0.0")])
+        b = _StubSource("b", [Package("django", "4.2.0")])
+        result = diff(a, b)
+        removed = [d for d in result.differences if d.severity == "removed"]
+        assert len(removed) == 1
+        assert removed[0].package == "legacy"
+
+    def test_classifies_version_changes(self):
+        a = _StubSource("a", [
+            Package("django", "4.2.0"),
+            Package("requests", "2.31.0"),
+            Package("numpy", "1.24.0"),
+        ])
+        b = _StubSource("b", [
+            Package("django", "5.0.0"),
+            Package("requests", "2.32.0"),
+            Package("numpy", "1.24.1"),
+        ])
+        result = diff(a, b)
+        by_pkg = {d.package: d.severity for d in result.differences}
+        assert by_pkg["django"] == "major"
+        assert by_pkg["requests"] == "minor"
+        assert by_pkg["numpy"] == "patch"
+
+
+class TestAuditCommand:
+    def test_audit_with_two_lockfiles(self, tmp_path: Path):
+        a = tmp_path / "a.txt"
+        a.write_text("django==4.2.0\n")
+        b = tmp_path / "b.txt"
+        b.write_text("django==5.0.0\n")
+
+        result = CliRunner().invoke(audit_command, [str(a), str(b)])
+        assert result.exit_code == 0
+        assert "django" in result.output
+        assert "major" in result.output
+
+    def test_audit_identical_lockfiles_reports_no_drift(self, tmp_path: Path):
+        a = tmp_path / "a.txt"
+        a.write_text("django==4.2.0\n")
+        b = tmp_path / "b.txt"
+        b.write_text("django==4.2.0\n")
+
+        result = CliRunner().invoke(audit_command, [str(a), str(b)])
+        assert result.exit_code == 0
+        assert "no drift" in result.output.lower()
+
+    def test_audit_invalid_source_errors(self):
+        result = CliRunner().invoke(audit_command, ["/does/not/exist.txt", "local"])
+        assert result.exit_code == 2

--- a/cli/tests/test_audit.py
+++ b/cli/tests/test_audit.py
@@ -95,8 +95,15 @@ class TestLockfileSource:
         assert packages == [Package(name="django", version="4.2.0")]
 
     def test_raises_on_missing_file(self):
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(RuntimeError, match=r"not found"):
             list(LockfileSource("/does/not/exist.txt").packages())
+
+    def test_raises_on_invalid_utf8(self, tmp_path: Path):
+        lockfile = tmp_path / "req.txt"
+        # Write bytes that are NOT valid UTF-8 (lone continuation bytes)
+        lockfile.write_bytes(b"django==4.2.0\n\xff\xfe garbage\n")
+        with pytest.raises(RuntimeError, match=r"not valid UTF-8"):
+            list(LockfileSource(lockfile).packages())
     
     def test_handles_arbitrary_equality(self, tmp_path: Path):
         """PEP 440 === (arbitrary equality) should parse correctly,


### PR DESCRIPTION
## Description

First PR of a three-part series for #181. Splitting the audit feature into three reviewable PRs rather than one large one:

1. **This PR — MVP foundation:** CLI subcommand, `LocalEnvironment` + `LockfileSource`, text output, semver severity, tests
2. **Next PR:** `--json` and `--sarif` output formats
3. **PR after that:** `ConfigFileSource`, `RemoteApiSource` (once #85 lands), drift score, and compatibility-engine-based severity

If you'd rather see different cuts (e.g. all output formats in one PR, sources in another), happy to restructure.

---

`envforge audit <source-a> <source-b>` prints a Rich-formatted table of differences classified by severity (major / minor / patch / added / removed).

```bash
# Compare local install against a lockfile
envforge audit local requirements.txt

# Compare two lockfiles
envforge audit requirements.lock requirements.txt
```

For an identical pair, output is `No drift detected (N packages match)`. For drift:

```
Audit: lockfile:a.txt -> lockfile:b.txt

╭──────────┬─────────────────┬─────────────────┬──────────╮
│ Package  │ lockfile:a.txt  │ lockfile:b.txt  │ Severity │
├──────────┼─────────────────┼─────────────────┼──────────┤
│ django   │ 4.2.0           │ 5.0.0           │ major    │
│ requests │ 2.31.0          │ 2.32.0          │ minor    │
│ numpy    │ 1.24.0          │ 1.24.1          │ patch    │
╰──────────┴─────────────────┴─────────────────┴──────────╯

Summary: 3 differences (1 major, 1 minor, 1 patch); 0 matching packages.
```

### Source types in this PR

| Spec | Source class | Description |
|---|---|---|
| `local` | `LocalEnvironment` | Active Python interpreter via `pip list --format=json` |
| path to file | `LockfileSource` | requirements.txt-format pinned lines |

`LockfileSource` handles realistic content: inline `#` comments, blank lines, flag lines (`-r requirements-dev.txt`, `--index-url`), package extras (`pkg[extra]==1.0`), and environment markers (`pkg==1.0; python_version<'3.10'`). Unpinned lines are skipped since they can't be meaningfully diffed.

### Scope: this PR vs follow-ups

The issue's full scope splits cleanly into multiple PRs. This one is the foundation.

**In this PR:** CLI subcommand, two source types, text output, semver severity, 22 unit tests.

**Intentional follow-ups (each its own PR):**
- `ConfigFileSource` and `RemoteApiSource` (the latter depends on #85)
- JSON output via `--json`
- SARIF output via `--sarif`
- Drift score + compatibility-engine-based severity (currently semver heuristic)
- `--strict` flag for non-zero exit on drift (CI use cases)

Happy to file the follow-up issues separately if preferred.

## Related Issues

Implements #181 (first MVP PR; the issue stays open for the remaining scope above).

## Changes Made

- New subpackage `cli/envforge_agent/audit/` (6 files):
  - `models.py` — `Package` (PEP 503 normalized), `DiffEntry`, `AuditResult`
  - `sources.py` — `Source` base + `LocalEnvironment` + `LockfileSource`
  - `differ.py` — `diff()` function + semver severity classification
  - `formatters.py` — Rich text output with severity-styled table
  - `command.py` — Click subcommand
  - `__init__.py` — public exports
- One-line registration in `cli/envforge_agent/cli.py` via `cli.add_command(audit_command)`
- New `cli/tests/test_audit.py` — 22 unit tests
- No new runtime dependencies (uses Click + Rich + stdlib, already in `cli/pyproject.toml`)

## Verification

- [x] Added unit tests (22 tests in `cli/tests/test_audit.py`)
- [x] Ran `pytest tests/` successfully (all 22 pass)
- [x] Manually tested via CLI — `envforge --help` lists the new `audit` subcommand, and end-to-end command behavior is covered by `TestAuditCommand` via Click's `CliRunner`
- [ ] (If applicable) Generated scripts pass `SafetyFilter` — N/A, `audit` is read-only and doesn't generate scripts

Test coverage:
- Package name normalization (PEP 503: case + separator collapsing)
- Version severity classification (major / minor / patch / non-numeric fallback / short versions)
- Lockfile parsing edge cases (comments, blank lines, flag lines, unpinned, extras, environment markers, missing file)
- Diff correctness (identical, added, removed, version-changed)
- End-to-end command invocation via `CliRunner` (success, identical, error cases)

## Documentation

- [ ] Updated `docs/FEATURES.md` — happy to add a section in this PR or a follow-up; let me know your preference
- [ ] Updated `CHANGELOG.md` — same as above
- [x] Code is fully documented and type-hinted (module docstrings + function docstrings + type hints throughout)

Submitted under GSSoC'26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an audit subcommand to compare environment drift between two sources (active environment or lockfiles).
  * Detects and categorizes added, removed, and version-changed packages with severity (major/minor/patch).
  * Shows formatted, colorized output with per-package differences, severity breakdown, and count of matching packages.

* **Tests**
  * Added extensive tests covering parsing, classification, CLI behavior, and local-environment error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->