### PR TITLE
feat: add Apple Silicon and MPS support for macOS

### DIFF
--- a/backend/app/api/v1/diagnose.py
+++ b/backend/app/api/v1/diagnose.py
@@ -40,7 +40,7 @@ async def diagnose(
         target_os = "WSL"
     elif report.os and "windows" in report.os.name.lower():
         target_os = "WIN"
-    elif report.os and "macos" in report.os.name.lower():
+    elif report.os and ("macos" in report.os.name.lower() or "darwin" in report.os.name.lower()):
         target_os = "MACOS"
     else:
         target_os = "LINUX"

--- a/backend/app/api/v1/diagnose.py
+++ b/backend/app/api/v1/diagnose.py
@@ -34,12 +34,14 @@ async def diagnose(
     a compatibility analysis: which profiles are compatible,
     and what issues were found.
     """
-    # Map OS to OSTarget: "LINUX", "WSL", "WIN"
+    # Map OS to OSTarget: "LINUX", "WSL", "WIN", "MACOS"
     target_os: OSTarget
     if report.os and report.os.wsl_version:
         target_os = "WSL"
     elif report.os and "windows" in report.os.name.lower():
         target_os = "WIN"
+    elif report.os and "macos" in report.os.name.lower():
+        target_os = "MACOS"
     else:
         target_os = "LINUX"
 

--- a/backend/app/compatibility/matrix/mps.py
+++ b/backend/app/compatibility/matrix/mps.py
@@ -1,0 +1,157 @@
+"""
+Apple Metal Performance Shaders (MPS) compatibility matrix.
+
+MPS is available on all Apple Silicon Macs (M1/M2/M3/M4 and variants) running
+macOS 12.3 or later. This module defines compatible framework versions for MPS.
+
+Sources:
+  - PyTorch MPS: https://pytorch.org/docs/stable/notes/mps.html
+  - TensorFlow Metal: https://github.com/apple/tensorflow_metal
+"""
+from __future__ import annotations
+
+from app.compatibility.errors import UnknownVersionError
+
+# ── PyTorch + MPS ─────────────────────────────────────────────────────────
+
+# PyTorch version -> minimum macOS version required for MPS
+PYTORCH_MPS_REQUIREMENTS = {
+    "2.0.0": "12.3",
+    "2.0.1": "12.3",
+    "2.1.0": "12.3",
+    "2.1.1": "12.3",
+    "2.1.2": "12.3",
+    "2.2.0": "12.3",
+    "2.2.1": "12.3",
+    "2.3.0": "12.3",
+    "2.3.1": "12.3",
+    "2.4.0": "12.3",
+    "2.5.0": "12.3",
+}
+
+# TensorFlow + Metal compatibility
+# tensorflow-metal is only available for TensorFlow 2.11+
+TENSORFLOW_METAL_REQUIREMENTS = {
+    "2.11.0": "12.1",
+    "2.11.1": "12.1",
+    "2.12.0": "12.1",
+    "2.12.1": "12.1",
+    "2.13.0": "12.1",
+    "2.13.1": "12.1",
+    "2.14.0": "12.1",
+    "2.14.1": "12.1",
+    "2.15.0": "12.1",
+    "2.15.1": "12.1",
+    "2.16.0": "12.1",
+}
+
+
+def get_pytorch_mps_min_version(pytorch_version: str) -> str | None:
+    """
+    Get the minimum macOS version required for a given PyTorch version with MPS.
+    
+    Args:
+        pytorch_version: PyTorch version string (e.g. "2.1.0")
+    
+    Returns:
+        Minimum macOS version as string (e.g. "12.3"), or None if version not supported
+    """
+    return PYTORCH_MPS_REQUIREMENTS.get(pytorch_version)
+
+
+def get_tensorflow_metal_min_version(tensorflow_version: str) -> str | None:
+    """
+    Get the minimum macOS version required for TensorFlow Metal support.
+    
+    Args:
+        tensorflow_version: TensorFlow version string (e.g. "2.13.0")
+    
+    Returns:
+        Minimum macOS version as string (e.g. "12.1"), or None if version not supported
+    """
+    return TENSORFLOW_METAL_REQUIREMENTS.get(tensorflow_version)
+
+
+def validate_pytorch_mps_support(
+    pytorch_version: str,
+    macos_version: str,
+) -> tuple[bool, str]:
+    """
+    Validate if PyTorch with MPS is supported on the given macOS version.
+    
+    Args:
+        pytorch_version: PyTorch version (e.g. "2.1.0")
+        macos_version: macOS version (e.g. "13.0")
+    
+    Returns:
+        (is_supported, reason) tuple
+    """
+    min_version = get_pytorch_mps_min_version(pytorch_version)
+    
+    if min_version is None:
+        return False, f"PyTorch {pytorch_version} is not in the MPS compatibility matrix"
+    
+    # Simple version comparison (major.minor)
+    user_major, user_minor = _parse_version(macos_version)
+    min_major, min_minor = _parse_version(min_version)
+    
+    if (user_major, user_minor) >= (min_major, min_minor):
+        return True, f"PyTorch {pytorch_version} with MPS is supported on macOS {macos_version}"
+    else:
+        return False, (
+            f"PyTorch {pytorch_version} with MPS requires macOS {min_version} or later. "
+            f"You have macOS {macos_version}."
+        )
+
+
+def validate_tensorflow_metal_support(
+    tensorflow_version: str,
+    macos_version: str,
+) -> tuple[bool, str]:
+    """
+    Validate if TensorFlow Metal is supported on the given macOS version.
+    
+    Args:
+        tensorflow_version: TensorFlow version (e.g. "2.13.0")
+        macos_version: macOS version (e.g. "13.0")
+    
+    Returns:
+        (is_supported, reason) tuple
+    """
+    min_version = get_tensorflow_metal_min_version(tensorflow_version)
+    
+    if min_version is None:
+        return False, (
+            f"TensorFlow {tensorflow_version} is not supported with Metal. "
+            f"TensorFlow 2.11+ supports tensorflow-metal."
+        )
+    
+    # Simple version comparison
+    user_major, user_minor = _parse_version(macos_version)
+    min_major, min_minor = _parse_version(min_version)
+    
+    if (user_major, user_minor) >= (min_major, min_minor):
+        return True, f"TensorFlow {tensorflow_version} with Metal is supported on macOS {macos_version}"
+    else:
+        return False, (
+            f"TensorFlow {tensorflow_version} with Metal requires macOS {min_version} or later. "
+            f"You have macOS {macos_version}."
+        )
+
+
+def _parse_version(version_str: str) -> tuple[int, int]:
+    """
+    Parse version string to (major, minor) tuple.
+    
+    Examples:
+        "12.3" -> (12, 3)
+        "13" -> (13, 0)
+        "13.0.1" -> (13, 0)
+    """
+    parts = version_str.split(".")
+    try:
+        major = int(parts[0]) if len(parts) > 0 else 0
+        minor = int(parts[1]) if len(parts) > 1 else 0
+        return (major, minor)
+    except (ValueError, IndexError):
+        return (0, 0)

--- a/backend/app/compatibility/matrix/mps.py
+++ b/backend/app/compatibility/matrix/mps.py
@@ -10,8 +10,6 @@ Sources:
 """
 from __future__ import annotations
 
-from app.compatibility.errors import UnknownVersionError
-
 # ── PyTorch + MPS ─────────────────────────────────────────────────────────
 
 # PyTorch version -> minimum macOS version required for MPS

--- a/backend/app/compatibility/matrix/os_rules.py
+++ b/backend/app/compatibility/matrix/os_rules.py
@@ -6,7 +6,7 @@ generated, not package version compatibility.
 """
 from typing import Literal
 
-OSTarget = Literal["LINUX", "WSL", "WIN"]
+OSTarget = Literal["LINUX", "WSL", "WIN", "MACOS"]
 
 # ── Script format rules ────────────────────────────────────────────────────────
 
@@ -15,6 +15,7 @@ OS_SCRIPT_FORMATS: dict[str, list[str]] = {
     "LINUX": ["setup.sh", "requirements.txt", "Dockerfile", "docker-compose.yml", "devcontainer.json"],
     "WSL":   ["setup.sh", "requirements.txt", "Dockerfile", "docker-compose.yml", "devcontainer.json"],
     "WIN": ["setup.ps1", "requirements.txt", "Dockerfile", "docker-compose.yml", "devcontainer.json"],
+    "MACOS": ["setup.sh", "requirements.txt"],
 }
 
 # ── CUDA / GPU rules ──────────────────────────────────────────────────────────
@@ -32,6 +33,24 @@ WSL_GPU_NOTE = (
     "WSL2 GPU access requires NVIDIA drivers installed on the Windows host. "
     "Do NOT install CUDA toolkit inside WSL if drivers are already on Windows. "
     "See: https://docs.nvidia.com/cuda/wsl-user-guide/"
+)
+
+# macOS MPS notes
+MACOS_MPS_NOTE = (
+    "Metal Performance Shaders (MPS) acceleration is available on Apple Silicon Macs. "
+    "The generated setup script includes verification commands to check MPS availability. "
+    "See: https://pytorch.org/docs/stable/notes/mps.html"
+)
+
+TENSORFLOW_METAL_NOTE = (
+    "TensorFlow Metal acceleration is available on macOS. "
+    "Install tensorflow-metal alongside TensorFlow for GPU acceleration. "
+    "See: https://github.com/apple/tensorflow_metal"
+)
+
+MACOS_ARM64_CPU_NOTE = (
+    "You are running macOS on Apple Silicon (ARM64 architecture). "
+    "Consider using frameworks with native ARM64 support for optimal performance."
 )
 
 
@@ -52,6 +71,18 @@ def get_os_notes(
 
     if target_os == "WIN" and "tensorflow" in frameworks and cuda_required:
         notes.append(TENSORFLOW_WINDOWS_GPU_NOTE)
+
+    if target_os == "MACOS":
+        # Always suggest awareness of Apple Silicon benefits
+        notes.append(MACOS_ARM64_CPU_NOTE)
+        
+        # Add MPS-specific notes for PyTorch
+        if "torch" in frameworks or "pytorch" in frameworks:
+            notes.append(MACOS_MPS_NOTE)
+        
+        # Add Metal-specific notes for TensorFlow
+        if "tensorflow" in frameworks:
+            notes.append(TENSORFLOW_METAL_NOTE)
 
     return notes
 

--- a/backend/app/compatibility/models.py
+++ b/backend/app/compatibility/models.py
@@ -5,7 +5,7 @@ Pure dataclasses — no I/O, no database, no side effects.
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-OSTarget = Literal["LINUX", "WSL", "WIN"]
+OSTarget = Literal["LINUX", "WSL", "WIN", "MACOS"]
 
 
 @dataclass(frozen=True)

--- a/backend/app/schemas/script.py
+++ b/backend/app/schemas/script.py
@@ -5,7 +5,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-OSTarget = Literal["LINUX", "WSL", "WIN"]
+OSTarget = Literal["LINUX", "WSL", "WIN", "MACOS"]
 OutputFormat = Literal["setup.sh", "setup.ps1", "requirements.txt", "Dockerfile", "docker-compose.yml", "devcontainer.json", "pyproject.toml"]
 
 

--- a/backend/app/schemas/seed_profile.py
+++ b/backend/app/schemas/seed_profile.py
@@ -60,6 +60,6 @@ class ProfilesYamlSchema(BaseModel):
 
 class GenerationRequest(BaseModel):
     """Schema for validating a generation request payload."""
-    target_os: Literal["Linux", "Windows", "WSL"]
+    target_os: Literal["Linux", "Windows", "WSL", "macOS"]
     framework: str = Field(..., min_length=1, max_length=64)
     cuda_version: str = Field(..., min_length=1, max_length=16)

--- a/backend/app/schemas/seed_profile.py
+++ b/backend/app/schemas/seed_profile.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
-ALLOWED_OS = frozenset({"LINUX", "WSL", "WIN"})
+ALLOWED_OS = frozenset({"LINUX", "WSL", "WIN", "MACOS"})
 
 
 class ProfilePackageSeedSchema(BaseModel):

--- a/backend/app/templates/engine.py
+++ b/backend/app/templates/engine.py
@@ -16,8 +16,9 @@ from app.templates.safety import validate_rendered_output
 TEMPLATES_DIR = Path(__file__).parent / "jinja"
 
 # ── Template name → output filename mapping ────────────────────────────────────
+# Note: "setup.sh" is OS-aware and will be resolved based on target_os in render()
 TEMPLATE_MAP: dict[str, str] = {
-    "setup.sh":           "setup/setup_linux.sh.j2",
+    "setup.sh":           "setup/setup_linux.sh.j2",  # Default; overridden by OS in render()
     "setup.ps1":          "setup/setup_windows.ps1.j2",
     "requirements.txt":   "config/requirements.j2",
     "Dockerfile":         "config/dockerfile.j2",
@@ -25,19 +26,32 @@ TEMPLATE_MAP: dict[str, str] = {
     "devcontainer.json":  "config/devcontainer.j2",
     "verify.sh":          "verify/verify_generic.sh.j2",
     "verify_torch.sh":    "verify/verify_torch.sh.j2",
+    "verify_torch_mps.sh": "verify/verify_torch_mps.sh.j2",
     "verify_tf.sh":       "verify/verify_tf.sh.j2",
+    "verify_tf_metal.sh": "verify/verify_tf_metal.sh.j2",
     "verify_opencv.sh":   "verify/verify_opencv.sh.j2",
     "environment.yml":    "config/environment.yml.j2",
     "pyproject.toml":     "config/pyproject.toml.j2",
 }
 
+# ── OS-specific setup template mapping ──────────────────────────────────────────
+OS_SETUP_TEMPLATES: dict[str, str] = {
+    "LINUX": "setup/setup_linux.sh.j2",
+    "WSL": "setup/setup_linux.sh.j2",
+    "WIN": "setup/setup_windows.ps1.j2",
+    "MACOS": "setup/setup_macos.sh.j2",
+}
+
 # ── Profile-specific verify template mapping ───────────────────────────────────
 PROFILE_VERIFY_TEMPLATES: dict[str, str] = {
     "pytorch-cuda":        "verify_torch.sh",
+    "pytorch-mps":         "verify_torch_mps.sh",
     "tf-gpu":              "verify_tf.sh",
+    "tensorflow-metal":    "verify_tf_metal.sh",
     "yolov8":              "verify_torch.sh",
     "stable-diffusion":    "verify_torch.sh",
     "opencv-beginner":     "verify_opencv.sh",
+    "llm-finetune":        "verify_torch.sh",
 }
 
 def _build_jinja_env() -> Environment:
@@ -79,12 +93,22 @@ class TemplateRenderer:
             SafetyViolationError: If rendered content contains forbidden patterns
             jinja2.UndefinedError: If template references undefined variable
         """
-        template_path = TEMPLATE_MAP.get(output_filename)
-        if template_path is None:
-            raise KeyError(
-                f"Unknown output format: '{output_filename}'. "
-                f"Known: {list(TEMPLATE_MAP.keys())}"
-            )
+        # Handle OS-specific setup.sh template selection
+        if output_filename == "setup.sh":
+            target_os = context.resolved.target_os
+            template_path = OS_SETUP_TEMPLATES.get(target_os)
+            if template_path is None:
+                raise KeyError(
+                    f"Unknown OS target for setup.sh: '{target_os}'. "
+                    f"Known: {list(OS_SETUP_TEMPLATES.keys())}"
+                )
+        else:
+            template_path = TEMPLATE_MAP.get(output_filename)
+            if template_path is None:
+                raise KeyError(
+                    f"Unknown output format: '{output_filename}'. "
+                    f"Known: {list(TEMPLATE_MAP.keys())}"
+                )
 
         template = _JINJA_ENV.get_template(template_path)
         rendered = template.render(**context.to_dict())

--- a/backend/app/templates/jinja/setup/setup_macos.sh.j2
+++ b/backend/app/templates/jinja/setup/setup_macos.sh.j2
@@ -127,9 +127,9 @@ info "Package installation complete ✓"
 # ── MPS Verification (PyTorch) ────────────────────────────────────────────────
 {% if 'torch' in [pkg.name for pkg in packages] %}
 info "Verifying MPS acceleration for PyTorch..."
-TORCH_IMPORT=$(python3 -c "import torch; print('OK')" 2>/dev/null || echo "FAIL")
+TORCH_IMPORT=$(python -c "import torch; print('OK')" 2>/dev/null || echo "FAIL")
 if [[ "$TORCH_IMPORT" == "OK" ]]; then
-    MPS_AVAILABLE=$(python3 -c "import torch; print(torch.backends.mps.is_available())" 2>/dev/null || echo "False")
+    MPS_AVAILABLE=$(python -c "import torch; print(torch.backends.mps.is_available())" 2>/dev/null || echo "False")
     if [[ "$MPS_AVAILABLE" == "True" ]]; then
         info "✓ PyTorch MPS is available and ready for acceleration"
     else
@@ -145,9 +145,9 @@ fi
 # ── Metal Verification (TensorFlow) ───────────────────────────────────────────
 {% if 'tensorflow' in [pkg.name for pkg in packages] %}
 info "Verifying Metal acceleration for TensorFlow..."
-TF_IMPORT=$(python3 -c "import tensorflow as tf; print('OK')" 2>/dev/null || echo "FAIL")
+TF_IMPORT=$(python -c "import tensorflow as tf; print('OK')" 2>/dev/null || echo "FAIL")
 if [[ "$TF_IMPORT" == "OK" ]]; then
-    METAL_DEVICES=$(python3 -c "import tensorflow as tf; print(len(tf.config.list_physical_devices('GPU')))" 2>/dev/null || echo "0")
+    METAL_DEVICES=$(python -c "import tensorflow as tf; print(len(tf.config.list_physical_devices('GPU')))" 2>/dev/null || echo "0")
     if [[ "$METAL_DEVICES" -gt 0 ]]; then
         info "✓ TensorFlow Metal GPUs detected: $METAL_DEVICES device(s)"
     else

--- a/backend/app/templates/jinja/setup/setup_macos.sh.j2
+++ b/backend/app/templates/jinja/setup/setup_macos.sh.j2
@@ -1,0 +1,187 @@
+#!/bin/bash
+# ==============================================================================
+# EnvForge Generated Setup Script — macOS Apple Silicon
+# Profile  : {{ profile.name }}
+# OS Target: {{ target_os }}
+# Python   : {{ python_version }}
+# GPU      : Apple Metal Performance Shaders (MPS)
+# Generated: {{ generated_at }}
+# EnvForge : v{{ envforge_version }}
+#
+# ⚠ WARNING: Review this script before running.
+#   EnvForge generates safe, version-pinned scripts, but you are responsible
+#   for your system. Run in a virtual environment.
+#
+# This script is optimized for Apple Silicon Macs (M1/M2/M3/M4+).
+# For MPS acceleration, frameworks are installed from PyPI (native ARM64).
+#
+# Usage:
+#   chmod +x setup.sh && ./setup.sh
+# ==============================================================================
+
+set -euo pipefail   # Exit on error, unset vars, pipe failures
+
+# ── Color output ──────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+info()    { echo -e "${GREEN}[EnvForge]${NC} $1"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error()   { echo -e "${RED}[ERROR]${NC} $1" >&2; exit 1; }
+debug()   { echo -e "${BLUE}[DEBUG]${NC} $1"; }
+
+# ── Pre-flight checks ─────────────────────────────────────────────────────────
+info "Starting pre-flight checks for macOS Apple Silicon..."
+
+# Check architecture
+ARCH=$(uname -m)
+if [[ "$ARCH" != "arm64" ]]; then
+    error "This setup script is for Apple Silicon (arm64). Your architecture is: $ARCH"
+fi
+info "Architecture: $ARCH (Apple Silicon) ✓"
+
+# Check OS
+OS=$(uname -s)
+if [[ "$OS" != "Darwin" ]]; then
+    error "This setup script is for macOS. Your OS is: $OS"
+fi
+info "Operating System: macOS ✓"
+
+# macOS version check
+MACOS_VER=$(sw_vers -productVersion)
+MACOS_MAJOR=$(echo $MACOS_VER | cut -d'.' -f1)
+MACOS_MINOR=$(echo $MACOS_VER | cut -d'.' -f2)
+info "macOS Version: $MACOS_VER"
+
+# MPS requires macOS 12.3 or later
+if [[ $MACOS_MAJOR -lt 12 ]] || ([[ $MACOS_MAJOR -eq 12 ]] && [[ $MACOS_MINOR -lt 3 ]]); then
+    error "MPS requires macOS 12.3 or later. You have $MACOS_VER"
+fi
+info "macOS version supports MPS ✓"
+
+# Python version check
+REQUIRED_PYTHON="{{ python_version }}"
+PYTHON_BIN=""
+for py in python{{ python_version }} python3 python; do
+    if command -v "$py" >/dev/null 2>&1; then
+        PY_VER=$("$py" --version 2>&1 | cut -d' ' -f2 | cut -d'.' -f1,2)
+        if [[ "$PY_VER" == "$REQUIRED_PYTHON" ]]; then
+            PYTHON_BIN="$py"
+            break
+        fi
+    fi
+done
+
+if [[ -z "$PYTHON_BIN" ]]; then
+    error "Python {{ python_version }} not found. Install via: brew install python@{{ python_version }}"
+fi
+info "Python $($PYTHON_BIN --version) found ✓"
+
+# pip check
+if ! "$PYTHON_BIN" -m pip --version >/dev/null 2>&1; then
+    error "pip not found for $PYTHON_BIN. Install pip: https://pip.pypa.io/en/stable/installation/"
+fi
+
+# ── Virtual environment ───────────────────────────────────────────────────────
+VENV_DIR=".venv"
+if [[ ! -d "$VENV_DIR" ]]; then
+    info "Creating virtual environment in $VENV_DIR..."
+    "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+# Activate virtual environment
+source "$VENV_DIR/bin/activate"
+info "Virtual environment activated: $VENV_DIR"
+
+# Upgrade pip inside venv
+pip install --quiet --upgrade pip
+
+{% if use_uv %}
+# ── Bootstrap uv ─────────────────────────────────────────────────────────────
+info "Bootstrapping uv package manager..."
+if ! command -v uv >/dev/null 2>&1; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    export PATH="$HOME/.local/bin:$PATH"
+    info "uv installed successfully."
+else
+    info "uv already installed: $(uv --version)"
+fi
+{% endif %}
+
+# ── Package installation ──────────────────────────────────────────────────────
+info "Installing packages for macOS Apple Silicon..."
+
+# For macOS, all packages are native ARM64 from PyPI
+# No special index needed (unlike CUDA environments)
+
+{% if use_uv %}
+uv pip install \
+{% else %}
+pip install \
+{% endif %}
+{% for pkg in packages %}
+    "{{ pkg.pip_spec }}" \
+{% endfor %}
+    --quiet
+
+info "Package installation complete ✓"
+
+# ── MPS Verification (PyTorch) ────────────────────────────────────────────────
+{% if 'torch' in [pkg.name for pkg in packages] %}
+info "Verifying MPS acceleration for PyTorch..."
+TORCH_IMPORT=$(python3 -c "import torch; print('OK')" 2>/dev/null || echo "FAIL")
+if [[ "$TORCH_IMPORT" == "OK" ]]; then
+    MPS_AVAILABLE=$(python3 -c "import torch; print(torch.backends.mps.is_available())" 2>/dev/null || echo "False")
+    if [[ "$MPS_AVAILABLE" == "True" ]]; then
+        info "✓ PyTorch MPS is available and ready for acceleration"
+    else
+        warn "PyTorch is installed but MPS is not available"
+        warn "  This may be due to: macOS version < 12.3, or hardware compatibility"
+        warn "  PyTorch will fall back to CPU, which may be slower"
+    fi
+else
+    warn "Could not verify PyTorch/MPS (import failed — is it installed?)"
+fi
+{% endif %}
+
+# ── Metal Verification (TensorFlow) ───────────────────────────────────────────
+{% if 'tensorflow' in [pkg.name for pkg in packages] %}
+info "Verifying Metal acceleration for TensorFlow..."
+TF_IMPORT=$(python3 -c "import tensorflow as tf; print('OK')" 2>/dev/null || echo "FAIL")
+if [[ "$TF_IMPORT" == "OK" ]]; then
+    METAL_DEVICES=$(python3 -c "import tensorflow as tf; print(len(tf.config.list_physical_devices('GPU')))" 2>/dev/null || echo "0")
+    if [[ "$METAL_DEVICES" -gt 0 ]]; then
+        info "✓ TensorFlow Metal GPUs detected: $METAL_DEVICES device(s)"
+    else
+        warn "TensorFlow is installed but Metal GPUs not detected"
+        warn "  Make sure tensorflow-metal is installed"
+    fi
+else
+    warn "Could not verify TensorFlow (import failed — is it installed?)"
+fi
+{% endif %}
+
+# ── Post-install summary ──────────────────────────────────────────────────────
+info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+info "✓ EnvForge setup complete!"
+info ""
+info "  Profile : {{ profile.name }}"
+info "  Python  : $(python --version)"
+info "  Platform: macOS $MACOS_VER (Apple Silicon)"
+info "  GPU     : Metal Performance Shaders (MPS)"
+{% if use_uv %}
+info "  Installer: uv (fast)"
+{% else %}
+info "  Installer: pip"
+{% endif %}
+info "  Venv    : $PWD/$VENV_DIR"
+info ""
+info "  Activate with:  source $VENV_DIR/bin/activate"
+info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+{% if warnings %}
+
+info "⚠ Platform-specific notes:"
+{% for warning in warnings %}
+warn "  {{ warning }}"
+{% endfor %}
+{% endif %}
+
+info "Setup script finished successfully!"

--- a/backend/app/templates/jinja/setup/setup_macos.sh.j2
+++ b/backend/app/templates/jinja/setup/setup_macos.sh.j2
@@ -125,7 +125,7 @@ pip install \
 info "Package installation complete ✓"
 
 # ── MPS Verification (PyTorch) ────────────────────────────────────────────────
-{% if 'torch' in [pkg.name for pkg in packages] %}
+{% if 'torch' in packages | map(attribute='name') | list %}
 info "Verifying MPS acceleration for PyTorch..."
 TORCH_IMPORT=$(python -c "import torch; print('OK')" 2>/dev/null || echo "FAIL")
 if [[ "$TORCH_IMPORT" == "OK" ]]; then
@@ -143,7 +143,7 @@ fi
 {% endif %}
 
 # ── Metal Verification (TensorFlow) ───────────────────────────────────────────
-{% if 'tensorflow' in [pkg.name for pkg in packages] %}
+{% if 'tensorflow' in packages | map(attribute='name') | list %}
 info "Verifying Metal acceleration for TensorFlow..."
 TF_IMPORT=$(python -c "import tensorflow as tf; print('OK')" 2>/dev/null || echo "FAIL")
 if [[ "$TF_IMPORT" == "OK" ]]; then

--- a/backend/app/templates/jinja/verify/verify_tf_metal.sh.j2
+++ b/backend/app/templates/jinja/verify/verify_tf_metal.sh.j2
@@ -1,0 +1,163 @@
+#!/bin/bash
+# ==============================================================================
+# EnvForge Environment Verification — TensorFlow Metal (Apple Silicon)
+# Profile  : {{ profile.name }}
+# Generated: {{ generated_at }}
+# ==============================================================================
+set -euo pipefail
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'; NC='\033[0m'
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+fail() { echo -e "${RED}[FAIL]${NC} $1"; FAILED=$((FAILED+1)); }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+
+FAILED=0
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " EnvForge Verification — {{ profile.name }} (Metal)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Check 1: macOS environment
+OS=$(uname -s)
+ARCH=$(uname -m)
+if [[ "$OS" != "Darwin" ]] || [[ "$ARCH" != "arm64" ]]; then
+    fail "Not running on macOS Apple Silicon (arm64). Detected: $OS $ARCH"
+else
+    pass "macOS Apple Silicon environment"
+fi
+
+# Check 2: macOS version (Metal requires 12.1+)
+MACOS_VER=$(sw_vers -productVersion)
+MACOS_MAJOR=$(echo $MACOS_VER | cut -d'.' -f1)
+MACOS_MINOR=$(echo $MACOS_VER | cut -d'.' -f2)
+if [[ $MACOS_MAJOR -gt 12 ]] || ([[ $MACOS_MAJOR -eq 12 ]] && [[ $MACOS_MINOR -ge 1 ]]); then
+    pass "macOS version: $MACOS_VER (Metal compatible)"
+else
+    fail "macOS $MACOS_VER does not support Metal (requires 12.1+)"
+fi
+
+# Check 3: Python version
+PY_VER=$(python3 --version 2>&1 | cut -d' ' -f2 | cut -d'.' -f1,2)
+if [[ "$PY_VER" == "{{ python_version }}" ]]; then
+    pass "Python {{ python_version }} ($(python3 --version))"
+else
+    fail "Python version mismatch: expected {{ python_version }}, got $PY_VER"
+fi
+
+# Check 4: TensorFlow import
+if python3 -c "import tensorflow as tf; print(f'TensorFlow {tf.__version__}')" 2>/dev/null; then
+    pass "TensorFlow import successful"
+else
+    fail "TensorFlow import failed — is it installed?"
+fi
+
+# Check 5: tensorflow-metal installation
+TF_METAL=$(python3 -c "import tensorflow_metal; print(tensorflow_metal.__version__)" 2>/dev/null || echo "NOT_INSTALLED")
+if [[ "$TF_METAL" != "NOT_INSTALLED" ]]; then
+    pass "tensorflow-metal is installed (v$TF_METAL)"
+else
+    warn "tensorflow-metal not found"
+    warn "  GPU acceleration may not be available"
+    warn "  Install with: pip install tensorflow-metal"
+fi
+
+# Check 6: GPU device detection
+GPU_COUNT=$(python3 -c "import tensorflow as tf; print(len(tf.config.list_physical_devices('GPU')))" 2>/dev/null || echo "0")
+if [[ "$GPU_COUNT" -gt 0 ]]; then
+    pass "Metal GPUs detected: $GPU_COUNT device(s)"
+    
+    # List GPU details
+    GPU_INFO=$(python3 << 'EOF' 2>/dev/null || echo "")
+import tensorflow as tf
+gpus = tf.config.list_physical_devices('GPU')
+for i, gpu in enumerate(gpus):
+    print(f"  GPU {i}: {gpu}")
+EOF
+)
+    if [[ ! -z "$GPU_INFO" ]]; then
+        echo "$GPU_INFO" | while read line; do
+            echo "    $line"
+        done
+    fi
+else
+    fail "No GPU devices detected by TensorFlow"
+    warn "Metal acceleration may not be available"
+fi
+
+# Check 7: Try to create a tensor on GPU
+if [[ "$GPU_COUNT" -gt 0 ]]; then
+    TENSOR_TEST=$(python3 << 'EOF' 2>/dev/null || echo "FAIL")
+import tensorflow as tf
+try:
+    with tf.device('/GPU:0'):
+        x = tf.random.normal([10, 10])
+        y = tf.matmul(x, x)
+    print("OK")
+except Exception as e:
+    print(f"ERROR: {e}")
+EOF
+)
+    if [[ "$TENSOR_TEST" == "OK" ]]; then
+        pass "Can create and compute tensors on Metal GPU"
+    else
+        fail "Cannot compute on Metal GPU: $TENSOR_TEST"
+    fi
+fi
+
+# Check 8: Logging level (suppress Metal warnings in verbose mode)
+echo ""
+echo "Note: TensorFlow may show Metal plugin warnings on startup."
+echo "This is normal and does not indicate a problem."
+echo ""
+
+# Check 9: Compare CPU vs GPU performance (optional benchmark)
+info_perf() { echo -e "\033[0;34m[INFO]${NC} $1"; }
+info_perf "Optional: Running Metal performance check..."
+
+PERF_CHECK=$(python3 << 'EOF' 2>/dev/null || echo "SKIP")
+import tensorflow as tf
+import time
+
+# Suppress TensorFlow logging
+tf.get_logger().setLevel('ERROR')
+
+size = 100
+x = tf.random.normal([size, size])
+
+# CPU
+with tf.device('/CPU:0'):
+    t0 = time.time()
+    y_cpu = tf.matmul(x, x)
+    t_cpu = time.time() - t0
+
+# GPU
+gpus = tf.config.list_physical_devices('GPU')
+if len(gpus) > 0:
+    with tf.device('/GPU:0'):
+        t0 = time.time()
+        y_gpu = tf.matmul(x, x)
+        t_gpu = time.time() - t0
+    print(f"CPU: {t_cpu*1000:.2f}ms | GPU: {t_gpu*1000:.2f}ms | Speedup: {t_cpu/t_gpu:.2f}x")
+else:
+    print("No GPU available")
+EOF
+)
+
+if [[ "$PERF_CHECK" != "SKIP" ]]; then
+    info_perf "Performance: $PERF_CHECK"
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [[ $FAILED -eq 0 ]]; then
+    echo -e "${GREEN}✓ All checks passed — Metal is ready!${NC}"
+    echo ""
+    echo "  Usage in TensorFlow:"
+    echo "    with tf.device('/GPU:0'):"
+    echo "        output = model(input)"
+    echo ""
+    echo "    (or use automatic device placement — TensorFlow will use GPU automatically)"
+    exit 0
+else
+    echo -e "${RED}✗ $FAILED check(s) failed${NC}"
+    exit 1
+fi

--- a/backend/app/templates/jinja/verify/verify_tf_metal.sh.j2
+++ b/backend/app/templates/jinja/verify/verify_tf_metal.sh.j2
@@ -27,13 +27,15 @@ else
 fi
 
 # Check 2: macOS version (Metal requires 12.1+)
-MACOS_VER=$(sw_vers -productVersion)
-MACOS_MAJOR=$(echo $MACOS_VER | cut -d'.' -f1)
-MACOS_MINOR=$(echo $MACOS_VER | cut -d'.' -f2)
-if [[ $MACOS_MAJOR -gt 12 ]] || ([[ $MACOS_MAJOR -eq 12 ]] && [[ $MACOS_MINOR -ge 1 ]]); then
-    pass "macOS version: $MACOS_VER (Metal compatible)"
-else
-    fail "macOS $MACOS_VER does not support Metal (requires 12.1+)"
+if [[ "$OS" == "Darwin" ]]; then
+    MACOS_VER=$(sw_vers -productVersion)
+    MACOS_MAJOR=$(echo "$MACOS_VER" | cut -d'.' -f1)
+    MACOS_MINOR=$(echo "$MACOS_VER" | cut -d'.' -f2)
+    if [[ $MACOS_MAJOR -gt 12 ]] || ([[ $MACOS_MAJOR -eq 12 ]] && [[ $MACOS_MINOR -ge 1 ]]); then
+        pass "macOS version: $MACOS_VER (Metal compatible)"
+    else
+        fail "macOS $MACOS_VER does not support Metal (requires 12.1+)"
+    fi
 fi
 
 # Check 3: Python version

--- a/backend/app/templates/jinja/verify/verify_torch_mps.sh.j2
+++ b/backend/app/templates/jinja/verify/verify_torch_mps.sh.j2
@@ -27,13 +27,15 @@ else
 fi
 
 # Check 2: macOS version (MPS requires 12.3+)
-MACOS_VER=$(sw_vers -productVersion)
-MACOS_MAJOR=$(echo $MACOS_VER | cut -d'.' -f1)
-MACOS_MINOR=$(echo $MACOS_VER | cut -d'.' -f2)
-if [[ $MACOS_MAJOR -gt 12 ]] || ([[ $MACOS_MAJOR -eq 12 ]] && [[ $MACOS_MINOR -ge 3 ]]); then
-    pass "macOS version: $MACOS_VER (MPS compatible)"
-else
-    fail "macOS $MACOS_VER does not support MPS (requires 12.3+)"
+if [[ "$OS" == "Darwin" ]]; then
+    MACOS_VER=$(sw_vers -productVersion)
+    MACOS_MAJOR=$(echo "$MACOS_VER" | cut -d'.' -f1)
+    MACOS_MINOR=$(echo "$MACOS_VER" | cut -d'.' -f2)
+    if [[ $MACOS_MAJOR -gt 12 ]] || ([[ $MACOS_MAJOR -eq 12 ]] && [[ $MACOS_MINOR -ge 3 ]]); then
+        pass "macOS version: $MACOS_VER (MPS compatible)"
+    else
+        fail "macOS $MACOS_VER does not support MPS (requires 12.3+)"
+    fi
 fi
 
 # Check 3: Python version

--- a/backend/app/templates/jinja/verify/verify_torch_mps.sh.j2
+++ b/backend/app/templates/jinja/verify/verify_torch_mps.sh.j2
@@ -1,0 +1,130 @@
+#!/bin/bash
+# ==============================================================================
+# EnvForge Environment Verification — PyTorch MPS (Apple Silicon)
+# Profile  : {{ profile.name }}
+# Generated: {{ generated_at }}
+# ==============================================================================
+set -euo pipefail
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'; NC='\033[0m'
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+fail() { echo -e "${RED}[FAIL]${NC} $1"; FAILED=$((FAILED+1)); }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+
+FAILED=0
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " EnvForge Verification — {{ profile.name }} (MPS)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Check 1: macOS environment
+OS=$(uname -s)
+ARCH=$(uname -m)
+if [[ "$OS" != "Darwin" ]] || [[ "$ARCH" != "arm64" ]]; then
+    fail "Not running on macOS Apple Silicon (arm64). Detected: $OS $ARCH"
+else
+    pass "macOS Apple Silicon environment"
+fi
+
+# Check 2: macOS version (MPS requires 12.3+)
+MACOS_VER=$(sw_vers -productVersion)
+MACOS_MAJOR=$(echo $MACOS_VER | cut -d'.' -f1)
+MACOS_MINOR=$(echo $MACOS_VER | cut -d'.' -f2)
+if [[ $MACOS_MAJOR -gt 12 ]] || ([[ $MACOS_MAJOR -eq 12 ]] && [[ $MACOS_MINOR -ge 3 ]]); then
+    pass "macOS version: $MACOS_VER (MPS compatible)"
+else
+    fail "macOS $MACOS_VER does not support MPS (requires 12.3+)"
+fi
+
+# Check 3: Python version
+PY_VER=$(python3 --version 2>&1 | cut -d' ' -f2 | cut -d'.' -f1,2)
+if [[ "$PY_VER" == "{{ python_version }}" ]]; then
+    pass "Python {{ python_version }} ($(python3 --version))"
+else
+    fail "Python version mismatch: expected {{ python_version }}, got $PY_VER"
+fi
+
+# Check 4: PyTorch import
+if python3 -c "import torch; print(f'torch {torch.__version__}')" 2>/dev/null; then
+    pass "PyTorch import successful"
+else
+    fail "PyTorch import failed — is it installed?"
+fi
+
+# Check 5: MPS backend availability
+MPS_AVAIL=$(python3 -c "import torch; print(torch.backends.mps.is_available())" 2>/dev/null || echo "Unknown")
+if [[ "$MPS_AVAIL" == "True" ]]; then
+    pass "MPS backend is available and working"
+    
+    # Check 6: MPS device build
+    MPS_BUILD=$(python3 -c "import torch; print(torch.backends.mps.is_built())" 2>/dev/null || echo "Unknown")
+    if [[ "$MPS_BUILD" == "True" ]]; then
+        pass "MPS is properly built in PyTorch"
+    else
+        warn "MPS available but not properly built (may still work)"
+    fi
+else
+    fail "torch.backends.mps.is_available() returned: $MPS_AVAIL"
+    warn "MPS may not be available on this system"
+    warn "  - Check macOS version (requires 12.3+)"
+    warn "  - Verify Apple Silicon architecture (arm64)"
+    warn "  - Reinstall PyTorch: pip install --upgrade torch torchvision torchaudio"
+fi
+
+# Check 7: Try to create a tensor on MPS device
+if [[ "$MPS_AVAIL" == "True" ]]; then
+    TENSOR_TEST=$(python3 -c "import torch; x = torch.randn(10, device='mps'); print('OK')" 2>/dev/null || echo "FAIL")
+    if [[ "$TENSOR_TEST" == "OK" ]]; then
+        pass "Can create and compute tensors on MPS device"
+    else
+        fail "Cannot create tensors on MPS device — MPS may not be fully functional"
+    fi
+fi
+
+# Check 8: Compare CPU vs MPS performance (optional benchmark)
+echo ""
+info_perf() { echo -e "\033[0;34m[INFO]${NC} $1"; }
+info_perf "Optional: Running MPS performance check..."
+
+PERF_CHECK=$(python3 << 'EOF' 2>/dev/null || echo "SKIP")
+import torch
+import time
+
+# Small benchmark
+size = 1000
+x = torch.randn(size, size)
+
+# CPU
+t0 = time.time()
+y_cpu = torch.matmul(x, x)
+t_cpu = time.time() - t0
+
+# MPS
+if torch.backends.mps.is_available():
+    x_mps = x.to('mps')
+    t0 = time.time()
+    y_mps = torch.matmul(x_mps, x_mps)
+    t_mps = time.time() - t0
+    print(f"CPU: {t_cpu*1000:.2f}ms | MPS: {t_mps*1000:.2f}ms | Speedup: {t_cpu/t_mps:.2f}x")
+else
+    print("MPS not available")
+EOF
+)
+
+if [[ "$PERF_CHECK" != "SKIP" ]]; then
+    info_perf "Performance: $PERF_CHECK"
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [[ $FAILED -eq 0 ]]; then
+    echo -e "${GREEN}✓ All checks passed — MPS is ready!${NC}"
+    echo ""
+    echo "  Usage in PyTorch:"
+    echo "    device = torch.device('mps' if torch.backends.mps.is_available() else 'cpu')"
+    echo "    model = MyModel().to(device)"
+    echo "    output = model(input.to(device))"
+    exit 0
+else
+    echo -e "${RED}✗ $FAILED check(s) failed${NC}"
+    exit 1
+fi

--- a/backend/seeds/profiles.yaml
+++ b/backend/seeds/profiles.yaml
@@ -194,3 +194,66 @@ profiles:
       - name: scipy
         version_spec: "1.13.0"
         install_order: 7
+
+  - slug: pytorch-mps
+    name: "PyTorch Metal (Apple Silicon)"
+    description: >
+      PyTorch optimized for Apple Silicon Macs (M1/M2/M3/M4) with Metal Performance
+      Shaders (MPS) acceleration. Includes torchvision and torchaudio. Ideal for
+      deep learning on macOS with native GPU acceleration.
+    tags: [deep-learning, gpu, mps, pytorch, apple-silicon]
+    os_support: [MACOS]
+    cuda_required: false
+    python_versions: ["3.10", "3.11", "3.12", "3.13"]
+    cuda_versions: []
+    status: ACTIVE
+    last_validated: "2026-05-24"
+    packages:
+      - name: torch
+        version_spec: "2.5.0"
+        install_order: 0
+      - name: torchvision
+        version_spec: "0.20.0"
+        install_order: 1
+      - name: torchaudio
+        version_spec: "2.5.0"
+        install_order: 2
+      - name: numpy
+        version_spec: "1.26.4"
+        install_order: 3
+      - name: matplotlib
+        version_spec: "3.8.4"
+        install_order: 4
+      - name: scipy
+        version_spec: "1.13.0"
+        install_order: 5
+
+  - slug: tensorflow-metal
+    name: "TensorFlow Metal (Apple Silicon)"
+    description: >
+      TensorFlow with Metal acceleration for Apple Silicon Macs (M1/M2/M3/M4).
+      Includes tensorflow-metal plugin for native GPU acceleration. Requires
+      TensorFlow 2.11+ for Metal support.
+    tags: [deep-learning, gpu, metal, tensorflow, apple-silicon]
+    os_support: [MACOS]
+    cuda_required: false
+    python_versions: ["3.10", "3.11", "3.12", "3.13"]
+    cuda_versions: []
+    status: ACTIVE
+    last_validated: "2026-05-24"
+    packages:
+      - name: tensorflow
+        version_spec: "2.16.0"
+        install_order: 0
+      - name: tensorflow-metal
+        version_spec: "1.1.0"
+        install_order: 1
+      - name: numpy
+        version_spec: "1.26.4"
+        install_order: 2
+      - name: matplotlib
+        version_spec: "3.8.4"
+        install_order: 3
+      - name: pandas
+        version_spec: "2.2.2"
+        install_order: 4

--- a/backend/tests/unit/compatibility/test_mps_support.py
+++ b/backend/tests/unit/compatibility/test_mps_support.py
@@ -1,0 +1,251 @@
+"""
+Unit tests for Apple Silicon / MPS support in the Compatibility Engine.
+Tests for: backend/app/compatibility/matrix/mps.py
+"""
+import pytest
+
+from app.compatibility.errors import (
+    IncompatibilityError,
+    UnsupportedOSError,
+)
+from app.compatibility.models import PackageConstraint, OSTarget
+from app.compatibility.resolver import CompatibilityResolver
+from app.compatibility.matrix.mps import (
+    get_pytorch_mps_min_version,
+    get_tensorflow_metal_min_version,
+    validate_pytorch_mps_support,
+    validate_tensorflow_metal_support,
+)
+
+
+class TestPytorchMpsMatrix:
+    """Tests for PyTorch + MPS compatibility matrix."""
+
+    def test_pytorch_2_5_mps_available(self):
+        """PyTorch 2.5.0 should be in MPS matrix."""
+        min_version = get_pytorch_mps_min_version("2.5.0")
+        assert min_version == "12.3"
+
+    def test_pytorch_2_1_mps_available(self):
+        """PyTorch 2.1.0 should be in MPS matrix."""
+        min_version = get_pytorch_mps_min_version("2.1.0")
+        assert min_version == "12.3"
+
+    def test_pytorch_unknown_version(self):
+        """Unknown PyTorch version returns None."""
+        min_version = get_pytorch_mps_min_version("1.13.0")
+        assert min_version is None
+
+    def test_pytorch_mps_requires_macos_12_3(self):
+        """All PyTorch versions in matrix require macOS 12.3+."""
+        versions = ["2.0.0", "2.1.0", "2.2.0", "2.3.0", "2.4.0", "2.5.0"]
+        for version in versions:
+            min_version = get_pytorch_mps_min_version(version)
+            assert min_version == "12.3", f"PyTorch {version} should require 12.3"
+
+
+class TestTensorflowMetalMatrix:
+    """Tests for TensorFlow + Metal compatibility matrix."""
+
+    def test_tensorflow_2_16_metal_available(self):
+        """TensorFlow 2.16.0 should be in Metal matrix."""
+        min_version = get_tensorflow_metal_min_version("2.16.0")
+        assert min_version == "12.1"
+
+    def test_tensorflow_2_13_metal_available(self):
+        """TensorFlow 2.13.0 should be in Metal matrix."""
+        min_version = get_tensorflow_metal_min_version("2.13.0")
+        assert min_version == "12.1"
+
+    def test_tensorflow_2_10_not_supported(self):
+        """TensorFlow 2.10 (pre-Metal) returns None."""
+        min_version = get_tensorflow_metal_min_version("2.10.0")
+        assert min_version is None
+
+    def test_tensorflow_metal_requires_macos_12_1(self):
+        """All TensorFlow versions in matrix require macOS 12.1+."""
+        versions = ["2.11.0", "2.12.0", "2.13.0", "2.14.0", "2.15.0", "2.16.0"]
+        for version in versions:
+            min_version = get_tensorflow_metal_min_version(version)
+            assert min_version == "12.1", f"TensorFlow {version} should require 12.1"
+
+
+class TestValidatePytorchMps:
+    """Tests for validate_pytorch_mps_support()."""
+
+    def test_pytorch_mps_macos_13_5_supported(self):
+        """PyTorch 2.5.0 on macOS 13.5 should be supported."""
+        supported, reason = validate_pytorch_mps_support("2.5.0", "13.5.1")
+        assert supported is True
+        assert "supported" in reason.lower()
+
+    def test_pytorch_mps_macos_12_3_minimum(self):
+        """PyTorch 2.1.0 on macOS 12.3 (minimum) should be supported."""
+        supported, reason = validate_pytorch_mps_support("2.1.0", "12.3")
+        assert supported is True
+
+    def test_pytorch_mps_macos_12_2_unsupported(self):
+        """PyTorch 2.1.0 on macOS 12.2 (below minimum) should fail."""
+        supported, reason = validate_pytorch_mps_support("2.1.0", "12.2")
+        assert supported is False
+        assert "12.3" in reason
+
+    def test_pytorch_unknown_version_unsupported(self):
+        """Unknown PyTorch version should return False."""
+        supported, reason = validate_pytorch_mps_support("1.13.0", "13.0")
+        assert supported is False
+        assert "not in" in reason.lower()
+
+
+class TestValidateTensorflowMetal:
+    """Tests for validate_tensorflow_metal_support()."""
+
+    def test_tensorflow_metal_macos_12_1_supported(self):
+        """TensorFlow 2.16.0 on macOS 12.1 (minimum) should be supported."""
+        supported, reason = validate_tensorflow_metal_support("2.16.0", "12.1")
+        assert supported is True
+
+    def test_tensorflow_metal_macos_13_0_supported(self):
+        """TensorFlow 2.13.0 on macOS 13.0 should be supported."""
+        supported, reason = validate_tensorflow_metal_support("2.13.0", "13.0")
+        assert supported is True
+
+    def test_tensorflow_metal_macos_12_0_unsupported(self):
+        """TensorFlow 2.13.0 on macOS 12.0 (below minimum) should fail."""
+        supported, reason = validate_tensorflow_metal_support("2.13.0", "12.0")
+        assert supported is False
+        assert "12.1" in reason
+
+    def test_tensorflow_2_10_not_supported(self):
+        """TensorFlow 2.10.0 (pre-Metal) on macOS 13.0 should fail."""
+        supported, reason = validate_tensorflow_metal_support("2.10.0", "13.0")
+        assert supported is False
+        assert "2.11" in reason
+
+
+class TestResolverMacosSupport:
+    """Tests for Compatibility Resolver with macOS target."""
+
+    def test_resolve_pytorch_mps_macos(self):
+        """Resolver should accept macOS as target_os."""
+        resolver = CompatibilityResolver()
+        result = resolver.resolve(
+            packages=[PackageConstraint("torch", "2.5.0")],
+            python_version="3.11",
+            cuda_version=None,
+            target_os="MACOS",
+            profile_slug="pytorch-mps",
+            os_support=["MACOS"],
+            cuda_required=False,
+        )
+        assert result.target_os == "MACOS"
+        assert result.cuda_version is None
+        assert len(result.packages) > 0
+
+    def test_resolve_tensorflow_metal_macos(self):
+        """Resolver should resolve TensorFlow + Metal for macOS."""
+        resolver = CompatibilityResolver()
+        result = resolver.resolve(
+            packages=[
+                PackageConstraint("tensorflow", "2.16.0"),
+                PackageConstraint("tensorflow-metal", "1.1.0"),
+            ],
+            python_version="3.11",
+            cuda_version=None,
+            target_os="MACOS",
+            profile_slug="tensorflow-metal",
+            os_support=["MACOS"],
+            cuda_required=False,
+        )
+        assert result.target_os == "MACOS"
+        assert len(result.packages) == 2
+
+    def test_resolve_pytorch_mps_unsupported_os(self):
+        """Resolver should reject pytorch-mps on unsupported OS."""
+        resolver = CompatibilityResolver()
+        
+        # pytorch-mps only supports MACOS, not LINUX
+        with pytest.raises(UnsupportedOSError) as exc:
+            resolver.resolve(
+                packages=[PackageConstraint("torch", "2.5.0")],
+                python_version="3.11",
+                cuda_version=None,
+                target_os="LINUX",
+                profile_slug="pytorch-mps",
+                os_support=["MACOS"],
+                cuda_required=False,
+            )
+        assert exc.value.requested_os == "LINUX"
+
+    def test_macos_warnings_include_mps_note(self):
+        """Resolver should include MPS note in warnings for PyTorch on macOS."""
+        resolver = CompatibilityResolver()
+        result = resolver.resolve(
+            packages=[PackageConstraint("torch", "2.5.0")],
+            python_version="3.11",
+            cuda_version=None,
+            target_os="MACOS",
+            profile_slug="pytorch-mps",
+            os_support=["MACOS"],
+            cuda_required=False,
+        )
+        # Should have warnings mentioning MPS or Metal
+        assert len(result.warnings) > 0
+        warning_text = " ".join(result.warnings).lower()
+        assert "mps" in warning_text or "metal" in warning_text
+
+    def test_macos_warnings_include_tensorflow_metal_note(self):
+        """Resolver should include Metal note in warnings for TensorFlow on macOS."""
+        resolver = CompatibilityResolver()
+        result = resolver.resolve(
+            packages=[
+                PackageConstraint("tensorflow", "2.16.0"),
+                PackageConstraint("tensorflow-metal", "1.1.0"),
+            ],
+            python_version="3.11",
+            cuda_version=None,
+            target_os="MACOS",
+            profile_slug="tensorflow-metal",
+            os_support=["MACOS"],
+            cuda_required=False,
+        )
+        # Should have warnings mentioning Metal
+        assert len(result.warnings) > 0
+        warning_text = " ".join(result.warnings).lower()
+        assert "metal" in warning_text
+
+
+class TestOsTargetMacos:
+    """Tests for OSTarget model with MACOS support."""
+
+    def test_os_target_includes_macos(self):
+        """OSTarget type should include MACOS."""
+        from app.compatibility.models import OSTarget
+        from typing import get_args
+        
+        valid_targets = get_args(OSTarget)
+        assert "MACOS" in valid_targets
+        assert "LINUX" in valid_targets
+        assert "WSL" in valid_targets
+        assert "WIN" in valid_targets
+
+    def test_resolved_environment_macos_target(self):
+        """ResolvedEnvironment should accept MACOS target_os."""
+        from app.compatibility.models import ResolvedEnvironment, ResolvedPackage
+        
+        env = ResolvedEnvironment(
+            python_version="3.11",
+            cuda_version=None,
+            target_os="MACOS",
+            rocm_version=None,
+            packages=[
+                ResolvedPackage(name="torch", version="2.5.0", cuda_variant=None),
+            ],
+            warnings=["MPS available"],
+        )
+        assert env.target_os == "MACOS"
+        assert env.cuda_version is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/cli/envforge_agent/detectors/gpu_detector.py
+++ b/cli/envforge_agent/detectors/gpu_detector.py
@@ -1,13 +1,14 @@
 """
 GPU detection module.
 
-Detects NVIDIA GPUs via nvidia-smi.
-Handles: Linux, Windows, WSL2 (driver is on Windows host).
-Never raises — returns empty list if nvidia-smi is not available.
+Detects NVIDIA GPUs via nvidia-smi, AMD GPUs via rocm-smi, and Apple MPS via system detection.
+Handles: Linux, Windows, WSL2 (driver is on Windows host), macOS Apple Silicon.
+Never raises — returns empty list if detection methods are not available.
 """
 from __future__ import annotations
 
 import logging
+import platform
 import re
 import subprocess
 from typing import NamedTuple
@@ -18,8 +19,18 @@ logger = logging.getLogger(__name__)
 
 def detect_gpus(timeout: int = 30) -> list[GPUInfo]:
     """
-    Detect all GPUs (NVIDIA or AMD).
+    Detect all GPUs (NVIDIA, AMD, or Apple MPS).
+    
+    Returns a list of detected GPUs. For Apple Silicon systems with MPS support,
+    returns a single GPUInfo with name="Apple Metal Performance Shaders (MPS)".
     """
+    # On macOS with Apple Silicon, check for MPS first
+    if platform.system() == "Darwin" and platform.machine() == "arm64":
+        mps_gpus = _detect_mps()
+        if mps_gpus:
+            return mps_gpus
+    
+    # Try NVIDIA detection
     try:
         gpus = _detect_via_nvidia_smi(timeout=timeout)
         if gpus:
@@ -27,6 +38,7 @@ def detect_gpus(timeout: int = 30) -> list[GPUInfo]:
     except Exception:
         pass
 
+    # Try AMD ROCm detection
     try:
         return _detect_via_rocm_smi(timeout=timeout)
     except Exception:
@@ -48,7 +60,7 @@ def _detect_via_nvidia_smi(timeout: int = 30) -> list[GPUInfo]:
             ],
             capture_output=True,
             text=True,
-            timeout=15,
+            timeout=timeout,
         )
     except FileNotFoundError:
         logger.debug("nvidia-smi command not found in system path.")
@@ -156,3 +168,139 @@ def _detect_via_rocm_smi(timeout: int = 30) -> list[GPUInfo]:
         )
 
     return gpus
+
+
+def _detect_mps() -> list[GPUInfo]:
+    """
+    Detect Apple Metal Performance Shaders (MPS) capability on Apple Silicon.
+    
+    PRECONDITION: Caller has verified this is Darwin + arm64.
+    
+    MPS requires:
+    - Apple Silicon (M1/M2/M3/M4 or variants)
+    - macOS 12.3 or later
+    - PyTorch or TensorFlow with Metal support (optional check)
+    
+    This function attempts actual capability detection:
+    1. Check macOS version (must be 12.3+)
+    2. If PyTorch is available, verify torch.backends.mps.is_available()
+    3. If neither check succeeds or passes, report MPS as available but with caveats
+    
+    Returns: [GPUInfo] if MPS is likely available, [] otherwise
+    """
+    # Step 1: Check macOS version
+    macos_version = _get_macos_version()
+    if macos_version is None:
+        logger.debug("Could not determine macOS version for MPS capability check")
+        return []
+    
+    major, minor = _parse_macos_version(macos_version)
+    
+    # MPS requires macOS 12.3 or later
+    if (major, minor) < (12, 3):
+        logger.debug(
+            f"MPS not available: macOS {macos_version} is older than 12.3 (minimum required)"
+        )
+        return []
+    
+    # Step 2: Try to verify via PyTorch if available
+    pytorch_mps_available = _check_pytorch_mps_available()
+    if pytorch_mps_available is not None:
+        if pytorch_mps_available:
+            logger.debug("PyTorch confirms MPS is available")
+            return [
+                GPUInfo(
+                    name="Apple Metal Performance Shaders (MPS)",
+                    vram_gb=None,
+                    driver_version=None,
+                    index=0,
+                )
+            ]
+        else:
+            logger.debug("PyTorch available but MPS is not enabled or unavailable")
+            return []
+    
+    # Step 3: No PyTorch, but macOS version is compatible
+    # Report MPS as available with confidence based on version
+    logger.debug(f"MPS likely available on macOS {macos_version} (version check passed)")
+    return [
+        GPUInfo(
+            name="Apple Metal Performance Shaders (MPS)",
+            vram_gb=None,
+            driver_version=None,
+            index=0,
+        )
+    ]
+
+
+def _get_macos_version() -> str | None:
+    """
+    Get macOS version string (e.g., "13.5.1").
+    
+    Returns: Version string, or None if detection fails
+    """
+    try:
+        result = subprocess.run(
+            ["sw_vers", "-productVersion"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception as e:
+        logger.debug(f"sw_vers command failed: {e}")
+    
+    # Fallback: platform.release() returns kernel version (e.g., "22.6.0" for macOS 13.5)
+    try:
+        return platform.release()
+    except Exception:
+        return None
+
+
+def _parse_macos_version(version_str: str) -> tuple[int, int]:
+    """
+    Parse macOS version string to (major, minor) tuple.
+    
+    Examples:
+        "13.5.1" -> (13, 5)
+        "22.6.0" -> (22, 6)  [Darwin kernel version]
+        "12" -> (12, 0)
+    
+    Returns: (major, minor) tuple, or (0, 0) if parsing fails
+    """
+    try:
+        parts = version_str.split(".")
+        major = int(parts[0]) if len(parts) > 0 else 0
+        minor = int(parts[1]) if len(parts) > 1 else 0
+        return (major, minor)
+    except (ValueError, IndexError):
+        return (0, 0)
+
+
+def _check_pytorch_mps_available() -> bool | None:
+    """
+    Check if PyTorch is installed and MPS backend is available.
+    
+    Returns:
+        True if torch.backends.mps.is_available() returns True
+        False if torch is available but MPS is not available
+        None if PyTorch is not installed (can't verify)
+    """
+    try:
+        import torch
+        
+        # PyTorch has mps backend
+        if hasattr(torch.backends, "mps"):
+            result = torch.backends.mps.is_available()
+            logger.debug(f"PyTorch MPS availability check: {result}")
+            return result
+        else:
+            logger.debug("PyTorch installed but torch.backends.mps not found")
+            return False
+    except ImportError:
+        logger.debug("PyTorch not installed; cannot verify MPS capability")
+        return None
+    except Exception as e:
+        logger.debug(f"Error checking PyTorch MPS availability: {e}")
+        return None

--- a/cli/envforge_agent/detectors/gpu_detector.py
+++ b/cli/envforge_agent/detectors/gpu_detector.py
@@ -250,10 +250,11 @@ def _get_macos_version() -> str | None:
             return result.stdout.strip()
     except Exception as e:
         logger.debug(f"sw_vers command failed: {e}")
-    
-    # Fallback: platform.release() returns kernel version (e.g., "22.6.0" for macOS 13.5)
+
+    # Fallback: platform.mac_ver()[0] returns the macOS product version.
     try:
-        return platform.release()
+        version = platform.mac_ver()[0]
+        return version or None
     except Exception:
         return None
 

--- a/cli/envforge_agent/detectors/os_detector.py
+++ b/cli/envforge_agent/detectors/os_detector.py
@@ -2,7 +2,7 @@
 OS detection module.
 
 Detects: OS name, version, architecture, and WSL version.
-Handles: Linux, Windows, WSL2.
+Handles: Linux, Windows, WSL2, macOS (including Apple Silicon).
 """
 from __future__ import annotations
 
@@ -28,6 +28,8 @@ def detect_os() -> OSInfo:
         return _detect_windows(arch)
     elif system == "Linux":
         return _detect_linux(arch)
+    elif system == "Darwin":
+        return _detect_macos(arch)
     else:
         return OSInfo(name=system, version=platform.version(), architecture=arch)
 
@@ -128,3 +130,31 @@ def _detect_wsl() -> str | None:
         pass
 
     return None
+
+
+# ── macOS ─────────────────────────────────────────────────────────────────────
+
+def _detect_macos(arch: str) -> OSInfo:
+    """
+    Detect macOS information.
+
+    Returns macOS version and architecture (arm64 = Apple Silicon, x86_64 = Intel).
+    """
+    try:
+        # Get macOS version via sw_vers command (most reliable)
+        result = subprocess.run(
+            ["sw_vers", "-productVersion"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        version = result.stdout.strip() if result.returncode == 0 else platform.release()
+    except Exception:
+        version = platform.release()
+
+    return OSInfo(
+        name="macOS",
+        version=version,
+        architecture=arch,
+        wsl_version=None,
+    )

--- a/cli/envforge_agent/detectors/os_detector.py
+++ b/cli/envforge_agent/detectors/os_detector.py
@@ -7,9 +7,7 @@ Handles: Linux, Windows, WSL2, macOS (including Apple Silicon).
 from __future__ import annotations
 
 import platform
-import re
 import subprocess
-import sys
 
 from envforge_agent.schemas import OSInfo
 
@@ -148,9 +146,9 @@ def _detect_macos(arch: str) -> OSInfo:
             text=True,
             timeout=5,
         )
-        version = result.stdout.strip() if result.returncode == 0 else (platform.mac_ver()[0] or platform.release())
+        version = result.stdout.strip() if result.returncode == 0 else platform.mac_ver()[0]
     except Exception:
-        version = platform.mac_ver()[0] or platform.release()
+        version = platform.mac_ver()[0]
 
     return OSInfo(
         name="macOS",

--- a/cli/envforge_agent/detectors/os_detector.py
+++ b/cli/envforge_agent/detectors/os_detector.py
@@ -148,9 +148,9 @@ def _detect_macos(arch: str) -> OSInfo:
             text=True,
             timeout=5,
         )
-        version = result.stdout.strip() if result.returncode == 0 else platform.release()
+        version = result.stdout.strip() if result.returncode == 0 else (platform.mac_ver()[0] or platform.release())
     except Exception:
-        version = platform.release()
+        version = platform.mac_ver()[0] or platform.release()
 
     return OSInfo(
         name="macOS",

--- a/cli/tests/unit/test_gpu_detector_mps.py
+++ b/cli/tests/unit/test_gpu_detector_mps.py
@@ -1,0 +1,314 @@
+"""
+Unit tests for GPU detection with Apple Silicon/MPS support.
+Tests for: cli/envforge_agent/detectors/gpu_detector.py
+"""
+from __future__ import annotations
+
+import subprocess
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+
+from envforge_agent.detectors.gpu_detector import (
+    detect_gpus,
+    _detect_via_nvidia_smi,
+    _detect_via_rocm_smi,
+    _detect_mps,
+    _get_macos_version,
+    _parse_macos_version,
+    _check_pytorch_mps_available,
+)
+
+
+class TestDetectGpus(unittest.TestCase):
+    """Integration tests for detect_gpus()."""
+
+    def test_detect_gpus_macos_arm64_with_mps(self):
+        """On macOS arm64, should detect MPS before trying nvidia-smi."""
+        mock_gpu = MagicMock()
+        mock_gpu.name = "MPS GPU"
+        with patch("platform.system", return_value="Darwin"):
+            with patch("platform.machine", return_value="arm64"):
+                with patch(
+                    "envforge_agent.detectors.gpu_detector._detect_mps",
+                    return_value=[mock_gpu],
+                ):
+                    gpus = detect_gpus()
+                    self.assertEqual(len(gpus), 1)
+                    self.assertEqual(gpus[0].name, "MPS GPU")
+
+    def test_detect_gpus_linux_nvidia(self):
+        """On Linux with NVIDIA, should detect via nvidia-smi."""
+        with patch("platform.system", return_value="Linux"):
+            with patch("platform.machine", return_value="x86_64"):
+                with patch(
+                    "envforge_agent.detectors.gpu_detector._detect_via_rocm_smi",
+                    return_value=[],
+                ):
+                    nvidia_output = "0, NVIDIA A100, 40960, 525.105.17"
+                    with patch(
+                        "subprocess.run",
+                        return_value=MagicMock(returncode=0, stdout=nvidia_output),
+                    ):
+                        gpus = detect_gpus()
+                        self.assertEqual(len(gpus), 1)
+                        self.assertIn("A100", gpus[0].name)
+
+    def test_detect_gpus_no_gpu(self):
+        """When no GPU detected, should return empty list."""
+        with patch("platform.system", return_value="Darwin"):
+            with patch("platform.machine", return_value="x86_64"):
+                with patch(
+                    "envforge_agent.detectors.gpu_detector._detect_via_nvidia_smi",
+                    return_value=[],
+                ):
+                    with patch(
+                        "envforge_agent.detectors.gpu_detector._detect_via_rocm_smi",
+                        return_value=[],
+                    ):
+                        gpus = detect_gpus()
+                        self.assertEqual(len(gpus), 0)
+
+
+class TestDetectNvidiaSmi(unittest.TestCase):
+    """Tests for _detect_via_nvidia_smi()."""
+
+    def test_nvidia_smi_success(self):
+        """Parse nvidia-smi output correctly."""
+        output = "0, NVIDIA GeForce RTX 4090, 24576, 531.18"
+        result = MagicMock(returncode=0, stdout=output)
+        
+        with patch("subprocess.run", return_value=result):
+            gpus = _detect_via_nvidia_smi(timeout=30)
+        
+        self.assertEqual(len(gpus), 1)
+        self.assertEqual(gpus[0].name, "NVIDIA GeForce RTX 4090")
+        self.assertAlmostEqual(gpus[0].vram_gb, 24.0, delta=0.1)
+        self.assertEqual(gpus[0].driver_version, "531.18")
+
+    def test_nvidia_smi_multiple_gpus(self):
+        """Parse multiple GPUs from nvidia-smi."""
+        output = "0, NVIDIA A100, 40960, 525.105.17\n1, NVIDIA A100, 40960, 525.105.17"
+        result = MagicMock(returncode=0, stdout=output)
+        
+        with patch("subprocess.run", return_value=result):
+            gpus = _detect_via_nvidia_smi()
+        
+        self.assertEqual(len(gpus), 2)
+
+    def test_nvidia_smi_not_found(self):
+        """When nvidia-smi not in PATH, return empty list."""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            gpus = _detect_via_nvidia_smi()
+        
+        self.assertEqual(len(gpus), 0)
+
+    def test_nvidia_smi_timeout(self):
+        """When nvidia-smi times out, return empty list."""
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 15)):
+            gpus = _detect_via_nvidia_smi(timeout=15)
+        
+        self.assertEqual(len(gpus), 0)
+
+    def test_nvidia_smi_respects_timeout_parameter(self):
+        """Verify timeout parameter is passed to subprocess."""
+        custom_timeout = 45
+        result = MagicMock(returncode=0, stdout="")
+        
+        with patch("subprocess.run", return_value=result) as mock_run:
+            _detect_via_nvidia_smi(timeout=custom_timeout)
+            
+            # Check that the timeout argument was passed
+            mock_run.assert_called_once()
+            call_kwargs = mock_run.call_args[1]
+            self.assertEqual(call_kwargs["timeout"], custom_timeout)
+
+
+class TestDetectMps(unittest.TestCase):
+    """Tests for _detect_mps() — Apple Silicon Metal Performance Shaders."""
+
+    def test_mps_macos_13_available(self):
+        """macOS 13.5.1 with PyTorch should report MPS available."""
+        with patch(
+            "envforge_agent.detectors.gpu_detector._get_macos_version",
+            return_value="13.5.1",
+        ):
+            with patch(
+                "envforge_agent.detectors.gpu_detector._check_pytorch_mps_available",
+                return_value=True,
+            ):
+                gpus = _detect_mps()
+        
+        self.assertEqual(len(gpus), 1)
+        self.assertEqual(gpus[0].name, "Apple Metal Performance Shaders (MPS)")
+        self.assertIsNone(gpus[0].vram_gb)
+
+    def test_mps_macos_old_version_unsupported(self):
+        """macOS 12.2 (older than 12.3) should return no MPS."""
+        with patch(
+            "envforge_agent.detectors.gpu_detector._get_macos_version",
+            return_value="12.2",
+        ):
+            gpus = _detect_mps()
+        
+        self.assertEqual(len(gpus), 0)
+
+    def test_mps_pytorch_not_installed(self):
+        """When PyTorch not installed but macOS 12.3+, infer MPS available."""
+        with patch(
+            "envforge_agent.detectors.gpu_detector._get_macos_version",
+            return_value="12.3",
+        ):
+            with patch(
+                "envforge_agent.detectors.gpu_detector._check_pytorch_mps_available",
+                return_value=None,
+            ):
+                gpus = _detect_mps()
+        
+        # Should still return MPS (version check passed, PyTorch not available yet)
+        self.assertEqual(len(gpus), 1)
+
+    def test_mps_pytorch_not_available(self):
+        """When PyTorch installed but MPS.is_available()=False, return no MPS."""
+        with patch(
+            "envforge_agent.detectors.gpu_detector._get_macos_version",
+            return_value="13.0",
+        ):
+            with patch(
+                "envforge_agent.detectors.gpu_detector._check_pytorch_mps_available",
+                return_value=False,
+            ):
+                gpus = _detect_mps()
+        
+        self.assertEqual(len(gpus), 0)
+
+
+class TestGetMacosVersion(unittest.TestCase):
+    """Tests for _get_macos_version()."""
+
+    def test_get_macos_version_via_sw_vers(self):
+        """Should use sw_vers command first."""
+        result = MagicMock(returncode=0, stdout="13.5.1\n")
+        
+        with patch("subprocess.run", return_value=result):
+            version = _get_macos_version()
+        
+        self.assertEqual(version, "13.5.1")
+
+    def test_get_macos_version_sw_vers_fails_fallback_to_platform(self):
+        """When sw_vers fails, fallback to platform.release()."""
+        with patch("subprocess.run", side_effect=Exception("sw_vers failed")):
+            with patch("platform.release", return_value="22.6.0"):
+                version = _get_macos_version()
+        
+        self.assertEqual(version, "22.6.0")
+
+    def test_get_macos_version_all_fail_returns_none(self):
+        """When all methods fail, return None."""
+        with patch("subprocess.run", side_effect=Exception):
+            with patch("platform.release", side_effect=Exception):
+                version = _get_macos_version()
+        
+        self.assertIsNone(version)
+
+
+class TestParseMacosVersion(unittest.TestCase):
+    """Tests for _parse_macos_version()."""
+
+    def test_parse_version_release_format(self):
+        """Parse standard macOS version (e.g., 13.5.1)."""
+        major, minor = _parse_macos_version("13.5.1")
+        self.assertEqual((major, minor), (13, 5))
+
+    def test_parse_version_darwin_kernel_format(self):
+        """Parse Darwin kernel version (e.g., 22.6.0)."""
+        major, minor = _parse_macos_version("22.6.0")
+        self.assertEqual((major, minor), (22, 6))
+
+    def test_parse_version_major_only(self):
+        """Parse version with only major number."""
+        major, minor = _parse_macos_version("12")
+        self.assertEqual((major, minor), (12, 0))
+
+    def test_parse_version_invalid(self):
+        """Invalid version string returns (0, 0)."""
+        major, minor = _parse_macos_version("invalid")
+        self.assertEqual((major, minor), (0, 0))
+
+
+class TestCheckPytorchMpsAvailable(unittest.TestCase):
+    """Tests for _check_pytorch_mps_available()."""
+
+    def test_pytorch_installed_mps_available(self):
+        """When PyTorch installed and MPS available."""
+        mock_torch = MagicMock()
+        mock_torch.backends.mps.is_available.return_value = True
+        
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            result = _check_pytorch_mps_available()
+        
+        self.assertTrue(result)
+
+    def test_pytorch_installed_mps_not_available(self):
+        """When PyTorch installed but MPS not available."""
+        mock_torch = MagicMock()
+        mock_torch.backends.mps.is_available.return_value = False
+        
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            result = _check_pytorch_mps_available()
+        
+        self.assertFalse(result)
+
+    def test_pytorch_not_installed(self):
+        """When PyTorch not installed, return None."""
+        # This is tricky to test with mocking — in real scenario:
+        # result should be None when import fails
+        import sys
+        if "torch" in sys.modules:
+            del sys.modules["torch"]
+        
+        # Mock the import error
+        with patch("builtins.__import__", side_effect=ImportError):
+            result = _check_pytorch_mps_available()
+        
+        self.assertIsNone(result)
+
+
+class TestIntegrationMpsDetection(unittest.TestCase):
+    """Integration tests for complete MPS detection workflow."""
+
+    def test_full_mps_detection_macos_m1_pytorch_installed(self):
+        """Full detection: macOS 13.5, ARM64, PyTorch with MPS."""
+        with patch("platform.system", return_value="Darwin"):
+            with patch("platform.machine", return_value="arm64"):
+                with patch(
+                    "envforge_agent.detectors.gpu_detector._get_macos_version",
+                    return_value="13.5.1",
+                ):
+                    with patch(
+                        "envforge_agent.detectors.gpu_detector._check_pytorch_mps_available",
+                        return_value=True,
+                    ):
+                        gpus = detect_gpus(timeout=30)
+        
+        self.assertEqual(len(gpus), 1)
+        self.assertEqual(gpus[0].name, "Apple Metal Performance Shaders (MPS)")
+
+    def test_full_detection_intel_mac_no_gpu(self):
+        """Full detection: Intel Mac (x86_64) should return no GPU."""
+        with patch("platform.system", return_value="Darwin"):
+            with patch("platform.machine", return_value="x86_64"):
+                with patch(
+                    "envforge_agent.detectors.gpu_detector._detect_via_nvidia_smi",
+                    return_value=[],
+                ):
+                    with patch(
+                        "envforge_agent.detectors.gpu_detector._detect_via_rocm_smi",
+                        return_value=[],
+                    ):
+                        gpus = detect_gpus()
+        
+        self.assertEqual(len(gpus), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/unit/test_gpu_detector_mps.py
+++ b/cli/tests/unit/test_gpu_detector_mps.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import subprocess
 import unittest
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import patch, MagicMock
 
 from envforge_agent.detectors.gpu_detector import (
     detect_gpus,

--- a/cli/tests/unit/test_gpu_detector_mps.py
+++ b/cli/tests/unit/test_gpu_detector_mps.py
@@ -195,12 +195,12 @@ class TestGetMacosVersion(unittest.TestCase):
         self.assertEqual(version, "13.5.1")
 
     def test_get_macos_version_sw_vers_fails_fallback_to_platform(self):
-        """When sw_vers fails, fallback to platform.release()."""
+        """When sw_vers fails, fallback to platform.mac_ver() product version."""
         with patch("subprocess.run", side_effect=Exception("sw_vers failed")):
-            with patch("platform.release", return_value="22.6.0"):
+            with patch("platform.mac_ver", return_value=("13.5.1", ("", "", ""), "")):
                 version = _get_macos_version()
-        
-        self.assertEqual(version, "22.6.0")
+
+        self.assertEqual(version, "13.5.1")
 
     def test_get_macos_version_all_fail_returns_none(self):
         """When all methods fail, return None."""


### PR DESCRIPTION
## Summary

Adds first-class Apple Silicon / Metal Performance Shaders (MPS) support to EnvForge for macOS users.

This expands accelerator support beyond NVIDIA CUDA and AMD ROCm to support Apple Silicon ML workflows.

## Changes made

### CLI

* Added macOS detection (`Darwin`)
* Added Apple Silicon (`arm64`) detection
* Added MPS capability detection
* Added MPS GPU detection tests

### Backend

* Added `MACOS` as supported `OSTarget`
* Added MPS compatibility matrix
* Updated OS compatibility rules
* Updated seed schema validation to allow macOS profiles
* Added Apple-specific environment profiles:

  * `pytorch-mps`
  * `tensorflow-metal`

### Templates

Added macOS-specific setup and verification templates:

* `setup_macos.sh.j2`
* `verify_torch_mps.sh.j2`
* `verify_tf_metal.sh.j2`

Updated template engine for OS-aware template selection.

## Testing

Feature-specific tests:

* CLI MPS tests: passed
* Backend MPS compatibility tests: passed

Full regression:

* Backend: 191/191 passed
* CLI: 81/81 passed

## Notes

* Validation performed on Windows development environment
* Docker/local seed auth mismatch observed during local setup, but seed validation and test coverage passed
* No physical Apple Silicon hardware validation performed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS / Apple Silicon support with GPU acceleration for PyTorch MPS and TensorFlow Metal.
  * New environment profiles for pytorch-mps and tensorflow-metal.
  * macOS-specific setup and verification scripts for hardware-acceleration validation.
  * Enhanced OS and GPU detection to recognize macOS systems and report MPS/Metal.

* **Bug Fixes**
  * Diagnose/OS-target logic updated to correctly identify macOS.

* **Tests**
  * Added comprehensive tests for macOS, MPS/Metal support, and detection logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->