### PR TITLE
test: add integration tests for envforge fix command (#197)

### DIFF
--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -1,0 +1,17 @@
+"""
+Shared pytest fixtures for envforge-agent CLI tests.
+
+Mocks check_macos_support() as a no-op so the CLI test suite
+can run on macOS developer machines without sys.exit(1).
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch
+
+
+@pytest.fixture(autouse=True)
+def bypass_macos_check():
+    """Prevent check_macos_support() from calling sys.exit(1) on macOS."""
+    with patch("envforge_agent.cli.check_macos_support"):
+        yield

--- a/cli/tests/test_fix.py
+++ b/cli/tests/test_fix.py
@@ -1,0 +1,232 @@
+"""
+Integration tests for the `envforge fix` CLI command.
+
+Tests mock the backend API using unittest.mock.patch("httpx.post")
+consistent with the existing test_agent.py patterns.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from envforge_agent.cli import cli
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def valid_report(tmp_path) -> Path:
+    """Write a valid DiagnosticReport JSON to a temp file."""
+    raw = (FIXTURES_DIR / "linux_gpu.json").read_text(encoding="utf-8")
+    report_file = tmp_path / "report.json"
+    report_file.write_text(raw, encoding="utf-8")
+    return report_file
+
+
+@pytest.fixture
+def mock_api_success() -> MagicMock:
+    """Mock a successful API response from /api/v1/scripts/generate."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {
+        "job_id": "test-job-123",
+        "resolved_packages": ["torch==2.3.0", "torchvision==0.18.0"],
+        "scripts": [
+            {
+                "filename": "setup.sh",
+                "content": "#!/bin/bash\npip install torch==2.3.0"
+            }
+        ],
+        "download_url": "/api/v1/scripts/download/test-job-123"
+    }
+    return mock_resp
+
+
+class TestFixHappyPath:
+    """Happy path tests for envforge fix."""
+
+    def test_fix_displays_script_content(self, valid_report, mock_api_success):
+        """Standard run should print script content in a rich panel."""
+        runner = CliRunner()
+        with patch("httpx.post", return_value=mock_api_success):
+            result = runner.invoke(cli, [
+                "fix",
+                "--report", str(valid_report),
+                "--profile", "pytorch-cuda",
+            ])
+
+        assert result.exit_code == 0
+        assert "setup.sh" in result.output
+        assert "test-job-123" in result.output
+
+    def test_fix_dry_run_lists_filenames_only(self, valid_report, mock_api_success):
+        """--dry-run should list script filenames without printing content."""
+        runner = CliRunner()
+        with patch("httpx.post", return_value=mock_api_success):
+            result = runner.invoke(cli, [
+                "fix",
+                "--report", str(valid_report),
+                "--profile", "pytorch-cuda",
+                "--dry-run",
+            ])
+
+        assert result.exit_code == 0
+        assert "setup.sh" in result.output
+        # Full script content should NOT appear in dry-run
+        assert "pip install torch" not in result.output
+
+    def test_fix_shows_resolved_packages(self, valid_report, mock_api_success):
+        """Output should include resolved packages from API response."""
+        runner = CliRunner()
+        with patch("httpx.post", return_value=mock_api_success):
+            result = runner.invoke(cli, [
+                "fix",
+                "--report", str(valid_report),
+                "--profile", "pytorch-cuda",
+            ])
+
+        assert result.exit_code == 0
+        assert "torch==2.3.0" in result.output
+
+    def test_fix_sends_correct_payload(self, valid_report, mock_api_success):
+        """API request payload must contain profile_id, target_os, python_version."""
+        runner = CliRunner()
+        with patch("httpx.post", return_value=mock_api_success) as mock_post:
+            runner.invoke(cli, [
+                "fix",
+                "--report", str(valid_report),
+                "--profile", "pytorch-cuda",
+            ])
+
+        assert mock_post.called
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs[1]["json"] if "json" in call_kwargs[1] else call_kwargs[0][1]
+        assert payload["profile_id"] == "pytorch-cuda"
+        assert "target_os" in payload
+        assert "python_version" in payload
+
+    def test_fix_uses_custom_api_url(self, valid_report, mock_api_success):
+        """--api-url flag should override the default localhost URL."""
+        runner = CliRunner()
+        with patch("httpx.post", return_value=mock_api_success) as mock_post:
+            runner.invoke(cli, [
+                "fix",
+                "--report", str(valid_report),
+                "--profile", "pytorch-cuda",
+                "--api-url", "http://myserver:9000",
+            ])
+
+        called_url = mock_post.call_args[0][0]
+        assert "myserver:9000" in called_url
+
+
+class TestFixAPIErrors:
+    """Tests for API error handling in envforge fix."""
+
+    def test_fix_exits_on_connect_error(self, valid_report):
+        """ConnectError should print a helpful message and exit 1."""
+        import httpx
+        runner = CliRunner()
+        with patch("httpx.post", side_effect=httpx.ConnectError("refused")):
+            result = runner.invoke(cli, [
+                "fix",
+                "--report", str(valid_report),
+                "--profile", "pytorch-cuda",
+            ])
+
+        assert result.exit_code == 1
+        assert "connect" in result.output.lower() or "connect" in (result.stderr or "").lower()
+
+    def test_fix_exits_on_http_error(self, valid_report):
+        """4xx/5xx API responses should exit with code 1."""
+        import httpx
+        runner = CliRunner()
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_resp.text = "Bad Request"
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "400", request=MagicMock(), response=mock_resp
+        )
+
+        with patch("httpx.post", return_value=mock_resp):
+            result = runner.invoke(cli, [
+                "fix",
+                "--report", str(valid_report),
+                "--profile", "pytorch-cuda",
+            ])
+
+        assert result.exit_code == 1
+
+    def test_fix_exits_on_500_error(self, valid_report):
+        """500 server error should exit with code 1."""
+        import httpx
+        runner = CliRunner()
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_resp.text = "Internal Server Error"
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "500", request=MagicMock(), response=mock_resp
+        )
+
+        with patch("httpx.post", return_value=mock_resp):
+            result = runner.invoke(cli, [
+                "fix",
+                "--report", str(valid_report),
+                "--profile", "pytorch-cuda",
+            ])
+
+        assert result.exit_code == 1
+
+
+class TestFixMalformedReport:
+    """Tests for invalid/malformed report file handling."""
+
+    def test_fix_exits_on_invalid_json(self, tmp_path):
+        """Malformed JSON should print parse error and exit 1."""
+        bad_report = tmp_path / "bad.json"
+        bad_report.write_text("{ this is not valid json }", encoding="utf-8")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "fix",
+            "--report", str(bad_report),
+            "--profile", "pytorch-cuda",
+        ])
+
+        assert result.exit_code == 1
+
+    def test_fix_exits_on_missing_required_fields(self, tmp_path):
+        """JSON missing required DiagnosticReport fields should exit 1."""
+        bad_report = tmp_path / "incomplete.json"
+        bad_report.write_text(
+            json.dumps({"agent_version": "1.0.0"}),
+            encoding="utf-8"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "fix",
+            "--report", str(bad_report),
+            "--profile", "pytorch-cuda",
+        ])
+
+        assert result.exit_code == 1
+
+    def test_fix_exits_on_nonexistent_report(self, tmp_path):
+        """Nonexistent report path should be caught by Click and exit non-zero."""
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "fix",
+            "--report", str(tmp_path / "nonexistent.json"),
+            "--profile", "pytorch-cuda",
+        ])
+
+        assert result.exit_code != 0


### PR DESCRIPTION
## Description
Adds a comprehensive integration test suite for the `envforge fix` CLI 
command, covering happy path, API error handling, and malformed report 
edge cases. Also introduces `conftest.py` with an autouse fixture to 
mock `check_macos_support()` so the test suite runs cleanly on macOS.

## Related Issues
Closes #197

## Changes Made
- Added `cli/tests/conftest.py` with autouse fixture to bypass 
  `check_macos_support()` on macOS during testing
- Added `cli/tests/test_fix.py` with 11 integration tests covering:
  - Happy path: script display, `--dry-run`, resolved packages output, 
    correct API payload structure, custom `--api-url`
  - API errors: `ConnectError`, 4xx, 5xx HTTP errors
  - Malformed reports: invalid JSON, missing required fields, 
    nonexistent file path

## Verification
- [x] Added unit tests
- [x] Ran `pytest tests/` successfully — 65 passed, 3 skipped (Windows-only)
- [x] Manually tested via the CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated `docs/FEATURES.md`
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted

## Notes
Used `unittest.mock.patch("httpx.post")` consistent with existing 
test patterns — no new dependencies added. The 3 skipped tests are 
pre-existing Windows-only tests unrelated to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for the `fix` CLI command, covering successful operations, API error handling, and malformed input validation.
  * Enhanced test infrastructure to ensure reliable CLI testing across all development environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->