### PR TITLE
security: replace Jinja2 Environment with SandboxedEnvironment to pre…

### DIFF
--- a/backend/app/templates/engine.py
+++ b/backend/app/templates/engine.py
@@ -7,7 +7,8 @@ This module never executes generated code; it only renders text.
 from collections.abc import Sequence
 from pathlib import Path
 
-from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
+from jinja2 import FileSystemLoader, StrictUndefined, select_autoescape
+from jinja2.sandbox import SandboxedEnvironment
 
 from app.templates.models import RenderResult, TemplateContext
 from app.templates.safety import validate_rendered_output
@@ -40,8 +41,8 @@ PROFILE_VERIFY_TEMPLATES: dict[str, str] = {
     "opencv-beginner":     "verify_opencv.sh",
 }
 
-def _build_jinja_env() -> Environment:
-    return Environment(
+def _build_jinja_env() -> SandboxedEnvironment:
+    return SandboxedEnvironment(
         loader=FileSystemLoader(str(TEMPLATES_DIR)),
         undefined=StrictUndefined,
         autoescape=select_autoescape(enabled_extensions=(), default_for_string=False),

--- a/backend/tests/unit/templates/test_sandbox.py
+++ b/backend/tests/unit/templates/test_sandbox.py
@@ -36,7 +36,7 @@ def test_sandbox_environment_active():
 def test_sandbox_blocks_unsafe_attributes():
     """Verify that accessing dangerous python class internals is restricted."""
     env = _JINJA_ENV
-    
+
     # Attempting template injection with dangerous attributes
     unsafe_templates = [
         "{{ ''.__class__ }}",
@@ -44,7 +44,7 @@ def test_sandbox_blocks_unsafe_attributes():
         "{{ ().__class__.__bases__[0].__subclasses__() }}",
         "{{ self.__init__.__globals__ }}",
     ]
-    
+
     for t_str in unsafe_templates:
         template = env.from_string(t_str)
         with pytest.raises(SecurityError) as exc_info:
@@ -55,12 +55,12 @@ def test_sandbox_blocks_unsafe_attributes():
 def test_sandbox_allows_safe_filters_and_rendering():
     """Verify that safe built-in filters (default, replace) execute perfectly."""
     env = _JINJA_ENV
-    
+
     # Test 'default' filter
     template_default = env.from_string("{{ value | default('fallback') }}")
     assert template_default.render() == "fallback"
     assert template_default.render(value="custom") == "custom"
-    
+
     # Test 'replace' filter
     template_replace = env.from_string("{{ value | replace('.', '-') }}")
     assert template_replace.render(value="3.11") == "3-11"

--- a/backend/tests/unit/templates/test_sandbox.py
+++ b/backend/tests/unit/templates/test_sandbox.py
@@ -1,0 +1,78 @@
+"""Unit tests to verify template engine sandboxing restrictions and functionality."""
+import pytest
+from jinja2.sandbox import SandboxedEnvironment, SecurityError
+
+from app.compatibility.models import ResolvedEnvironment
+from app.templates.engine import _JINJA_ENV, TemplateRenderer
+from app.templates.models import TemplateContext
+
+
+def make_context(
+    profile_name="myenv",
+    python_version="3.10",
+    cuda_version=None,
+    packages=None,
+):
+    if packages is None:
+        packages = []
+    resolved = ResolvedEnvironment(
+        python_version=python_version,
+        cuda_version=cuda_version,
+        target_os="LINUX",
+        packages=packages,
+    )
+    return TemplateContext(
+        profile_id="test-id",
+        profile_name=profile_name,
+        resolved=resolved,
+    )
+
+
+def test_sandbox_environment_active():
+    """Verify that _JINJA_ENV is an instance of SandboxedEnvironment."""
+    assert isinstance(_JINJA_ENV, SandboxedEnvironment)
+
+
+def test_sandbox_blocks_unsafe_attributes():
+    """Verify that accessing dangerous python class internals is restricted."""
+    env = _JINJA_ENV
+    
+    # Attempting template injection with dangerous attributes
+    unsafe_templates = [
+        "{{ ''.__class__ }}",
+        "{{ [].__class__.__mro__ }}",
+        "{{ ().__class__.__bases__[0].__subclasses__() }}",
+        "{{ self.__init__.__globals__ }}",
+    ]
+    
+    for t_str in unsafe_templates:
+        template = env.from_string(t_str)
+        with pytest.raises(SecurityError) as exc_info:
+            template.render()
+        assert "access to attribute" in str(exc_info.value) or "is blocked" in str(exc_info.value)
+
+
+def test_sandbox_allows_safe_filters_and_rendering():
+    """Verify that safe built-in filters (default, replace) execute perfectly."""
+    env = _JINJA_ENV
+    
+    # Test 'default' filter
+    template_default = env.from_string("{{ value | default('fallback') }}")
+    assert template_default.render() == "fallback"
+    assert template_default.render(value="custom") == "custom"
+    
+    # Test 'replace' filter
+    template_replace = env.from_string("{{ value | replace('.', '-') }}")
+    assert template_replace.render(value="3.11") == "3-11"
+
+
+def test_sandbox_integration_with_renderer():
+    """Verify that TemplateRenderer works cleanly under the sandboxed environment."""
+    context = make_context(
+        profile_name="sandbox-test",
+        python_version="3.10",
+    )
+    renderer = TemplateRenderer()
+    result = renderer.render("environment.yml", context)
+    assert "sandbox-test" in result.content
+    assert "python=3.10" in result.content


### PR DESCRIPTION
## Description
Replaces `jinja2.Environment` with `jinja2.sandbox.SandboxedEnvironment` in `backend/app/templates/engine.py` to block SSTI and RCE vectors. The sandboxed environment intercepts all unsafe attribute lookups (`__class__`, `__globals__`, `__subclasses__`) at the engine level while keeping all existing filters (`default`, `replace`) fully functional.

## Related Issues
Closes #196

## Changes Made
- Replaced `Environment` with `SandboxedEnvironment` in `_build_jinja_env()` and updated its return type annotation
- Added `backend/tests/unit/templates/test_sandbox.py` with 4 tests covering SSTI payload blocking, safe filter execution, and template renderer integration

## Verification
- [x] Added unit tests
- [x] Ran `pytest tests/` successfully — 184 backend + 75 CLI passed, 3 skipped
- [x] Manually tested via the API / CLI
- [x] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted

## AI Assistance Disclosure
I used AI assistance for: test structure and security payload patterns. All code reviewed, understood, and verified locally before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated template engine to use a sandboxed environment with enhanced security restrictions that prevent unsafe operations during template rendering.

* **Tests**
  * Added comprehensive test coverage validating sandbox activation, security restrictions, safe filter functionality, and template rendering under sandbox constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->