### PR TITLE
Feat/custom template dir

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -7,7 +7,8 @@ All configuration is sourced from environment variables or a local `.env` file.
 shares the same env-loading bootstrap before `Settings` is read.
 """
 from functools import lru_cache
-from typing import Literal
+from pathlib import Path
+from typing import Literal, Optional
 
 from dotenv import load_dotenv
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -29,6 +30,7 @@ class Settings(BaseSettings):
     secret_key: str = "dev-secret-key-change-in-production"
     app_name: str = "EnvForage"
     app_version: str = "1.0.0"
+    custom_template_dir: Optional[Path] = None
 
     # ── Database ──────────────────────────────────────────────
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/envforge"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -8,7 +8,7 @@ shares the same env-loading bootstrap before `Settings` is read.
 """
 from functools import lru_cache
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Literal
 
 from dotenv import load_dotenv
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -30,7 +30,7 @@ class Settings(BaseSettings):
     secret_key: str = "dev-secret-key-change-in-production"
     app_name: str = "EnvForage"
     app_version: str = "1.0.0"
-    custom_template_dir: Optional[Path] = None
+    custom_template_dir: Path | None = None
 
     # ── Database ──────────────────────────────────────────────
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/envforge"

--- a/backend/app/templates/engine.py
+++ b/backend/app/templates/engine.py
@@ -7,7 +7,8 @@ This module never executes generated code; it only renders text.
 from collections.abc import Sequence
 from pathlib import Path
 
-from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
+from jinja2 import FileSystemLoader, StrictUndefined, select_autoescape
+from jinja2.sandbox import SandboxedEnvironment
 
 from app.templates.models import RenderResult, TemplateContext
 from app.templates.safety import validate_rendered_output
@@ -40,8 +41,8 @@ PROFILE_VERIFY_TEMPLATES: dict[str, str] = {
     "opencv-beginner":     "verify_opencv.sh",
 }
 
-def _build_jinja_env() -> Environment:
-    return Environment(
+def _build_jinja_env() -> SandboxedEnvironment:
+    return SandboxedEnvironment(
         loader=FileSystemLoader(str(TEMPLATES_DIR)),
         undefined=StrictUndefined,
         autoescape=select_autoescape(enabled_extensions=(), default_for_string=False),

--- a/backend/app/templates/engine.py
+++ b/backend/app/templates/engine.py
@@ -7,9 +7,11 @@ This module never executes generated code; it only renders text.
 from collections.abc import Sequence
 from pathlib import Path
 
-from jinja2 import FileSystemLoader, StrictUndefined, select_autoescape
+from functools import lru_cache
+from jinja2 import ChoiceLoader, FileSystemLoader, StrictUndefined, select_autoescape
 from jinja2.sandbox import SandboxedEnvironment
 
+from app.config import get_settings
 from app.templates.models import RenderResult, TemplateContext
 from app.templates.safety import validate_rendered_output
 
@@ -41,9 +43,15 @@ PROFILE_VERIFY_TEMPLATES: dict[str, str] = {
     "opencv-beginner":     "verify_opencv.sh",
 }
 
-def _build_jinja_env() -> SandboxedEnvironment:
+@lru_cache(maxsize=16)
+def _get_jinja_env(custom_template_dir: Path | None) -> SandboxedEnvironment:
+    loaders = []
+    if custom_template_dir:
+        loaders.append(FileSystemLoader(str(custom_template_dir)))
+    loaders.append(FileSystemLoader(str(TEMPLATES_DIR)))
+
     return SandboxedEnvironment(
-        loader=FileSystemLoader(str(TEMPLATES_DIR)),
+        loader=ChoiceLoader(loaders),
         undefined=StrictUndefined,
         autoescape=select_autoescape(enabled_extensions=(), default_for_string=False),
         trim_blocks=True,
@@ -51,7 +59,7 @@ def _build_jinja_env() -> SandboxedEnvironment:
     )
 
 
-_JINJA_ENV = _build_jinja_env()
+_JINJA_ENV = _get_jinja_env(None)
 
 
 class TemplateRenderer:
@@ -87,7 +95,9 @@ class TemplateRenderer:
                 f"Known: {list(TEMPLATE_MAP.keys())}"
             )
 
-        template = _JINJA_ENV.get_template(template_path)
+        settings = get_settings()
+        env = _get_jinja_env(settings.custom_template_dir)
+        template = env.get_template(template_path)
         rendered = template.render(**context.to_dict())
         safe_content = validate_rendered_output(rendered, template_name=template_path)
 

--- a/backend/app/templates/engine.py
+++ b/backend/app/templates/engine.py
@@ -5,9 +5,9 @@ All rendered output passes through SafetyFilter before being returned.
 This module never executes generated code; it only renders text.
 """
 from collections.abc import Sequence
+from functools import lru_cache
 from pathlib import Path
 
-from functools import lru_cache
 from jinja2 import ChoiceLoader, FileSystemLoader, StrictUndefined, select_autoescape
 from jinja2.sandbox import SandboxedEnvironment
 

--- a/backend/tests/unit/templates/test_custom_templates.py
+++ b/backend/tests/unit/templates/test_custom_templates.py
@@ -34,7 +34,7 @@ def test_default_rendering_without_custom_dir():
     """Verify that when no custom_template_dir is defined, default templates render normally."""
     context = make_context(profile_name="default-test", python_version="3.10")
     renderer = TemplateRenderer()
-    
+
     result = renderer.render("environment.yml", context)
     assert "default-test" in result.content
     assert "python=3.10" in result.content
@@ -46,23 +46,23 @@ def test_custom_template_override_precedence(tmp_path):
     custom_dir = tmp_path / "custom_templates"
     config_dir = custom_dir / "config"
     config_dir.mkdir(parents=True)
-    
+
     custom_template = config_dir / "environment.yml.j2"
     custom_template.write_text(
         "name: OVERRIDDEN_{{ profile.name }}\ncustom_indicator: yes",
         encoding="utf-8"
     )
-    
+
     # 2. Mock get_settings() inside engine.py to return our custom_template_dir
     mock_settings = MagicMock(spec=Settings)
     mock_settings.custom_template_dir = custom_dir
-    
+
     context = make_context(profile_name="myenv")
     renderer = TemplateRenderer()
-    
+
     with patch("app.templates.engine.get_settings", return_value=mock_settings):
         result = renderer.render("environment.yml", context)
-        
+
     assert "OVERRIDDEN_myenv" in result.content
     assert "custom_indicator: yes" in result.content
     # The default template contents should NOT be present
@@ -74,22 +74,22 @@ def test_custom_templates_subject_to_sandbox_hardening(tmp_path):
     custom_dir = tmp_path / "custom_templates"
     config_dir = custom_dir / "config"
     config_dir.mkdir(parents=True)
-    
+
     # Create an unsafe custom template attempting SSTI
     unsafe_template = config_dir / "environment.yml.j2"
     unsafe_template.write_text(
         "name: {{ ''.__class__ }}",
         encoding="utf-8"
     )
-    
+
     mock_settings = MagicMock(spec=Settings)
     mock_settings.custom_template_dir = custom_dir
-    
+
     context = make_context(profile_name="myenv")
     renderer = TemplateRenderer()
-    
+
     with patch("app.templates.engine.get_settings", return_value=mock_settings):
         with pytest.raises(SecurityError) as exc_info:
             renderer.render("environment.yml", context)
-            
+
     assert "access to attribute" in str(exc_info.value) or "is blocked" in str(exc_info.value)

--- a/backend/tests/unit/templates/test_custom_templates.py
+++ b/backend/tests/unit/templates/test_custom_templates.py
@@ -1,6 +1,7 @@
 """Unit tests to verify custom template directory overrides and ChoiceLoader integration."""
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 from jinja2.sandbox import SecurityError
 
 from app.compatibility.models import ResolvedEnvironment

--- a/backend/tests/unit/templates/test_custom_templates.py
+++ b/backend/tests/unit/templates/test_custom_templates.py
@@ -1,0 +1,95 @@
+"""Unit tests to verify custom template directory overrides and ChoiceLoader integration."""
+import pytest
+from unittest.mock import patch, MagicMock
+from jinja2.sandbox import SecurityError
+
+from app.compatibility.models import ResolvedEnvironment
+from app.config import Settings
+from app.templates.engine import TemplateRenderer
+from app.templates.models import TemplateContext
+
+
+def make_context(
+    profile_name="myenv",
+    python_version="3.10",
+    cuda_version=None,
+    packages=None,
+):
+    if packages is None:
+        packages = []
+    resolved = ResolvedEnvironment(
+        python_version=python_version,
+        cuda_version=cuda_version,
+        target_os="LINUX",
+        packages=packages,
+    )
+    return TemplateContext(
+        profile_id="test-id",
+        profile_name=profile_name,
+        resolved=resolved,
+    )
+
+
+def test_default_rendering_without_custom_dir():
+    """Verify that when no custom_template_dir is defined, default templates render normally."""
+    context = make_context(profile_name="default-test", python_version="3.10")
+    renderer = TemplateRenderer()
+    
+    result = renderer.render("environment.yml", context)
+    assert "default-test" in result.content
+    assert "python=3.10" in result.content
+
+
+def test_custom_template_override_precedence(tmp_path):
+    """Verify that a template in custom_template_dir takes precedence over the default one."""
+    # 1. Set up a mock custom template folder and write a custom environment.yml.j2
+    custom_dir = tmp_path / "custom_templates"
+    config_dir = custom_dir / "config"
+    config_dir.mkdir(parents=True)
+    
+    custom_template = config_dir / "environment.yml.j2"
+    custom_template.write_text(
+        "name: OVERRIDDEN_{{ profile.name }}\ncustom_indicator: yes",
+        encoding="utf-8"
+    )
+    
+    # 2. Mock get_settings() inside engine.py to return our custom_template_dir
+    mock_settings = MagicMock(spec=Settings)
+    mock_settings.custom_template_dir = custom_dir
+    
+    context = make_context(profile_name="myenv")
+    renderer = TemplateRenderer()
+    
+    with patch("app.templates.engine.get_settings", return_value=mock_settings):
+        result = renderer.render("environment.yml", context)
+        
+    assert "OVERRIDDEN_myenv" in result.content
+    assert "custom_indicator: yes" in result.content
+    # The default template contents should NOT be present
+    assert "channels:" not in result.content
+
+
+def test_custom_templates_subject_to_sandbox_hardening(tmp_path):
+    """Verify that overridden templates from custom_template_dir are still fully sandboxed."""
+    custom_dir = tmp_path / "custom_templates"
+    config_dir = custom_dir / "config"
+    config_dir.mkdir(parents=True)
+    
+    # Create an unsafe custom template attempting SSTI
+    unsafe_template = config_dir / "environment.yml.j2"
+    unsafe_template.write_text(
+        "name: {{ ''.__class__ }}",
+        encoding="utf-8"
+    )
+    
+    mock_settings = MagicMock(spec=Settings)
+    mock_settings.custom_template_dir = custom_dir
+    
+    context = make_context(profile_name="myenv")
+    renderer = TemplateRenderer()
+    
+    with patch("app.templates.engine.get_settings", return_value=mock_settings):
+        with pytest.raises(SecurityError) as exc_info:
+            renderer.render("environment.yml", context)
+            
+    assert "access to attribute" in str(exc_info.value) or "is blocked" in str(exc_info.value)

--- a/backend/tests/unit/templates/test_sandbox.py
+++ b/backend/tests/unit/templates/test_sandbox.py
@@ -36,7 +36,7 @@ def test_sandbox_environment_active():
 def test_sandbox_blocks_unsafe_attributes():
     """Verify that accessing dangerous python class internals is restricted."""
     env = _JINJA_ENV
-    
+
     # Attempting template injection with dangerous attributes
     unsafe_templates = [
         "{{ ''.__class__ }}",
@@ -44,7 +44,7 @@ def test_sandbox_blocks_unsafe_attributes():
         "{{ ().__class__.__bases__[0].__subclasses__() }}",
         "{{ self.__init__.__globals__ }}",
     ]
-    
+
     for t_str in unsafe_templates:
         template = env.from_string(t_str)
         with pytest.raises(SecurityError) as exc_info:
@@ -55,12 +55,12 @@ def test_sandbox_blocks_unsafe_attributes():
 def test_sandbox_allows_safe_filters_and_rendering():
     """Verify that safe built-in filters (default, replace) execute perfectly."""
     env = _JINJA_ENV
-    
+
     # Test 'default' filter
     template_default = env.from_string("{{ value | default('fallback') }}")
     assert template_default.render() == "fallback"
     assert template_default.render(value="custom") == "custom"
-    
+
     # Test 'replace' filter
     template_replace = env.from_string("{{ value | replace('.', '-') }}")
     assert template_replace.render(value="3.11") == "3-11"

--- a/backend/tests/unit/templates/test_sandbox.py
+++ b/backend/tests/unit/templates/test_sandbox.py
@@ -1,0 +1,78 @@
+"""Unit tests to verify template engine sandboxing restrictions and functionality."""
+import pytest
+from jinja2.sandbox import SandboxedEnvironment, SecurityError
+
+from app.compatibility.models import ResolvedEnvironment
+from app.templates.engine import _JINJA_ENV, TemplateRenderer
+from app.templates.models import TemplateContext
+
+
+def make_context(
+    profile_name="myenv",
+    python_version="3.10",
+    cuda_version=None,
+    packages=None,
+):
+    if packages is None:
+        packages = []
+    resolved = ResolvedEnvironment(
+        python_version=python_version,
+        cuda_version=cuda_version,
+        target_os="LINUX",
+        packages=packages,
+    )
+    return TemplateContext(
+        profile_id="test-id",
+        profile_name=profile_name,
+        resolved=resolved,
+    )
+
+
+def test_sandbox_environment_active():
+    """Verify that _JINJA_ENV is an instance of SandboxedEnvironment."""
+    assert isinstance(_JINJA_ENV, SandboxedEnvironment)
+
+
+def test_sandbox_blocks_unsafe_attributes():
+    """Verify that accessing dangerous python class internals is restricted."""
+    env = _JINJA_ENV
+    
+    # Attempting template injection with dangerous attributes
+    unsafe_templates = [
+        "{{ ''.__class__ }}",
+        "{{ [].__class__.__mro__ }}",
+        "{{ ().__class__.__bases__[0].__subclasses__() }}",
+        "{{ self.__init__.__globals__ }}",
+    ]
+    
+    for t_str in unsafe_templates:
+        template = env.from_string(t_str)
+        with pytest.raises(SecurityError) as exc_info:
+            template.render()
+        assert "access to attribute" in str(exc_info.value) or "is blocked" in str(exc_info.value)
+
+
+def test_sandbox_allows_safe_filters_and_rendering():
+    """Verify that safe built-in filters (default, replace) execute perfectly."""
+    env = _JINJA_ENV
+    
+    # Test 'default' filter
+    template_default = env.from_string("{{ value | default('fallback') }}")
+    assert template_default.render() == "fallback"
+    assert template_default.render(value="custom") == "custom"
+    
+    # Test 'replace' filter
+    template_replace = env.from_string("{{ value | replace('.', '-') }}")
+    assert template_replace.render(value="3.11") == "3-11"
+
+
+def test_sandbox_integration_with_renderer():
+    """Verify that TemplateRenderer works cleanly under the sandboxed environment."""
+    context = make_context(
+        profile_name="sandbox-test",
+        python_version="3.10",
+    )
+    renderer = TemplateRenderer()
+    result = renderer.render("environment.yml", context)
+    assert "sandbox-test" in result.content
+    assert "python=3.10" in result.content


### PR DESCRIPTION
## Description
Implements custom template directory overrides via Jinja2's `ChoiceLoader`, allowing users to supply their own templates (e.g. customized `setup.sh` or `Dockerfile`) that take precedence over built-in ones. Uses `@lru_cache(maxsize=16)` keyed on `custom_template_dir` to avoid import-time freezing while preventing redundant environment rebuilds. Fully preserves the `SandboxedEnvironment` security hardening from #196.

## Related Issues
Closes #195

## Changes Made
- Added `custom_template_dir: Optional[Path] = None` to Pydantic `Settings` in `config.py` for automatic env var parsing
- Updated `engine.py` with `ChoiceLoader` + `_get_jinja_env(custom_template_dir)` lazy cached builder; retained `_JINJA_ENV = _get_jinja_env(None)` for backward compatibility
- Added `backend/tests/unit/templates/test_custom_templates.py` with 3 tests: default fallback, custom override precedence, and sandbox hardening preserved on custom templates

## Verification
- [x] Added unit tests
- [x] Ran `pytest tests/` successfully — 187 backend tests passed, 0 failures
- [x] Manually tested via the API / CLI
- [x] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted

## AI Assistance Disclosure
I used AI assistance for: test structure and mock patterns. All code reviewed, understood, and verified locally before submission.