### PR TITLE
feat: add LangChain RAG environment profile

### DIFF
--- a/backend/seeds/profiles.yaml
+++ b/backend/seeds/profiles.yaml
@@ -194,6 +194,7 @@ profiles:
       - name: scipy
         version_spec: "1.13.0"
         install_order: 7
+
   - slug: langchain-rag
     name: "LangChain RAG"
     description: >

--- a/backend/seeds/profiles.yaml
+++ b/backend/seeds/profiles.yaml
@@ -203,13 +203,13 @@ profiles:
     tags: [langchain, rag, llm, vector-db, cpu]
     os_support: [LINUX, WSL, WIN]
     cuda_required: false
-    python_versions: ["3.10", "3.11", "3.12", "3.13"]
+    python_versions: ["3.10", "3.11", "3.12"]
     cuda_versions: []
     status: ACTIVE
-    last_validated: "2026-05-25"
+    last_validated: "2026-05-26"
     packages:
       - name: langchain
-        version_spec: "0.2.0"
+        version_spec: "0.3.0"
         install_order: 0
       - name: chromadb
         version_spec: "0.5.0"

--- a/backend/seeds/profiles.yaml
+++ b/backend/seeds/profiles.yaml
@@ -194,3 +194,28 @@ profiles:
       - name: scipy
         version_spec: "1.13.0"
         install_order: 7
+  - slug: langchain-rag
+        name: "LangChain RAG"
+        description: >
+          LangChain-based Retrieval-Augmented Generation stack with vector
+          database support. CPU-friendly RAG pipeline for document Q&A.
+        tags: [langchain, rag, llm, vector-db, cpu]
+        os_support: [LINUX, WSL, WIN]
+        cuda_required: false
+        python_versions: ["3.10", "3.11", "3.12", "3.13"]
+        cuda_versions: []
+        status: ACTIVE
+        last_validated: "2026-05-25"
+        packages:
+          - name: langchain
+            version_spec: "0.2.0"
+            install_order: 0
+          - name: chromadb
+            version_spec: "0.5.0"
+            install_order: 1
+          - name: faiss-cpu
+            version_spec: "1.8.0"
+            install_order: 2
+          - name: sentence-transformers
+            version_spec: "2.7.0"
+            install_order: 3

--- a/backend/seeds/profiles.yaml
+++ b/backend/seeds/profiles.yaml
@@ -195,27 +195,27 @@ profiles:
         version_spec: "1.13.0"
         install_order: 7
   - slug: langchain-rag
-        name: "LangChain RAG"
-        description: >
-          LangChain-based Retrieval-Augmented Generation stack with vector
-          database support. CPU-friendly RAG pipeline for document Q&A.
-        tags: [langchain, rag, llm, vector-db, cpu]
-        os_support: [LINUX, WSL, WIN]
-        cuda_required: false
-        python_versions: ["3.10", "3.11", "3.12", "3.13"]
-        cuda_versions: []
-        status: ACTIVE
-        last_validated: "2026-05-25"
-        packages:
-          - name: langchain
-            version_spec: "0.2.0"
-            install_order: 0
-          - name: chromadb
-            version_spec: "0.5.0"
-            install_order: 1
-          - name: faiss-cpu
-            version_spec: "1.8.0"
-            install_order: 2
-          - name: sentence-transformers
-            version_spec: "2.7.0"
-            install_order: 3
+    name: "LangChain RAG"
+    description: >
+      LangChain-based Retrieval-Augmented Generation stack with vector
+      database support. CPU-friendly RAG pipeline for document Q&A.
+    tags: [langchain, rag, llm, vector-db, cpu]
+    os_support: [LINUX, WSL, WIN]
+    cuda_required: false
+    python_versions: ["3.10", "3.11", "3.12", "3.13"]
+    cuda_versions: []
+    status: ACTIVE
+    last_validated: "2026-05-25"
+    packages:
+      - name: langchain
+        version_spec: "0.2.0"
+        install_order: 0
+      - name: chromadb
+        version_spec: "0.5.0"
+        install_order: 1
+      - name: faiss-cpu
+        version_spec: "1.8.0"
+        install_order: 2
+      - name: sentence-transformers
+        version_spec: "2.7.0"
+        install_order: 3


### PR DESCRIPTION
Adds a new LangChain RAG environment profile to profiles.yaml.
     
     This profile includes:
     - langchain 0.2.0
     - chromadb 0.5.0
     - faiss-cpu 1.8.0
     - sentence-transformers 2.7.0
     
     CPU-friendly, supports Linux, WSL and Windows.
     Closes #186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new LangChain RAG profile with pre-configured packages (LangChain, ChromaDB, FAISS CPU build, Sentence Transformers), multi-OS support, CPU-only CUDA requirement, and compatibility across multiple Python versions; profile metadata includes tags and a recent validation timestamp.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->