### PR TITLE
feat: add --json and --sarif output formats to envforge audit (#181)

### DIFF
--- a/cli/envforge_agent/audit/command.py
+++ b/cli/envforge_agent/audit/command.py
@@ -7,7 +7,7 @@ import click
 from rich.console import Console
 
 from .differ import diff
-from .formatters import format_text
+from .formatters import format_json, format_sarif, format_text
 from .sources import LocalEnvironment, LockfileSource, Source
 
 
@@ -36,9 +36,21 @@ def _resolve_source(spec: str) -> Source:
 
 
 @click.command("audit")
-@click.argument("source_a", required=True)
-@click.argument("source_b", required=True)
-def audit_command(source_a: str, source_b: str) -> None:
+@click.argument("source_a")
+@click.argument("source_b")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit results as JSON to stdout instead of a Rich table.",
+)
+@click.option(
+    "--sarif",
+    "as_sarif",
+    is_flag=True,
+    help="Emit results as SARIF v2.1.0 to stdout (for CI/security tooling).",
+)
+def audit_command(source_a: str, source_b: str, as_json: bool, as_sarif: bool) -> None:
     """Compare two environments and report drift.
 
     SOURCE_A and SOURCE_B can each be either:
@@ -65,5 +77,13 @@ def audit_command(source_a: str, source_b: str) -> None:
     except RuntimeError as exc:
         err_console.print(f"[ERROR] {exc}")
         sys.exit(1)
+    if as_json and as_sarif:
+        err_console.print("[ERROR] --json and --sarif are mutually exclusive.")
+        sys.exit(2)
 
-    format_text(result, console)
+    if as_json:
+        click.echo(format_json(result))
+    elif as_sarif:
+        click.echo(format_sarif(result))
+    else:
+        format_text(result, console)

--- a/cli/envforge_agent/audit/formatters.py
+++ b/cli/envforge_agent/audit/formatters.py
@@ -4,7 +4,11 @@ Output formatters for envforge audit.
 MVP includes only the text formatter (Rich-styled console output).
 JSON and SARIF formatters will be added in follow-up PRs.
 """
+
 from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
 from rich.console import Console
 from rich.table import Table
 from rich import box
@@ -73,3 +77,124 @@ def format_text(result: AuditResult, console: Console) -> None:
         f"\n[bold]Summary:[/] {len(result.differences)} differences "
         f"({summary}); {result.common_count} matching packages."
     )
+    
+# Mapping from envforge severity to SARIF level
+# SARIF levels: error, warning, note, none
+SEVERITY_TO_SARIF_LEVEL = {
+    "major": "error",
+    "minor": "warning",
+    "patch": "note",
+    "added": "warning",
+    "removed": "warning",
+    "other": "note",
+}
+
+
+def format_json(result: AuditResult) -> str:
+    """Render an AuditResult as a stable JSON document.
+
+    The schema is intentionally flat and machine-friendly for downstream tools
+    (CI checks, dashboards, custom diff viewers).
+    """
+    counts: dict[str, int] = {}
+    for entry in result.differences:
+        counts[entry.severity] = counts.get(entry.severity, 0) + 1
+
+    payload = {
+        "source_a": result.source_a,
+        "source_b": result.source_b,
+        "differences": [
+            {
+                "package": entry.package,
+                "version_a": entry.a_version,
+                "version_b": entry.b_version,
+                "severity": entry.severity,
+            }
+            for entry in result.differences
+        ],
+        "summary": {
+            "total": len(result.differences),
+            "by_severity": counts,
+            "common_count": result.common_count,
+        },
+    }
+    return json.dumps(payload, indent=2, sort_keys=False)
+
+
+def format_sarif(result: AuditResult) -> str:
+    """Render an AuditResult as SARIF v2.1.0.
+
+    SARIF (Static Analysis Results Interchange Format) is consumable by
+    GitHub Advanced Security, Azure DevOps, and other static-analysis
+    aggregators. Each drift entry is a SARIF result; severity maps to
+    SARIF level.
+    """
+    # Unique rules — one per severity that actually appears
+    severities_present = sorted({entry.severity for entry in result.differences})
+    rules = [
+        {
+            "id": f"drift-{sev}",
+            "name": f"Drift{sev.capitalize()}",
+            "shortDescription": {"text": f"{sev.capitalize()} version drift"},
+            "defaultConfiguration": {
+                "level": SEVERITY_TO_SARIF_LEVEL.get(sev, "note")
+            },
+        }
+        for sev in severities_present
+    ]
+
+    results = [
+        {
+            "ruleId": f"drift-{entry.severity}",
+            "level": SEVERITY_TO_SARIF_LEVEL.get(entry.severity, "note"),
+            "message": {
+                "text": (
+                    f"{entry.package}: "
+                    f"{entry.a_version or '(absent)'} -> "
+                    f"{entry.b_version or '(absent)'} "
+                    f"({entry.severity})"
+                )
+            },
+            "locations": [
+                {
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": result.source_b}
+                    }
+                }
+            ],
+            "properties": {
+                "package": entry.package,
+                "versionA": entry.a_version,
+                "versionB": entry.b_version,
+                "sourceA": result.source_a,
+                "sourceB": result.source_b,
+            },
+        }
+        for entry in result.differences
+    ]
+
+    sarif = {
+        "version": "2.1.0",
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "envforge-audit",
+                        "informationUri": "https://github.com/rishabh0510rishabh/EnvForage",
+                        "rules": rules,
+                    }
+                },
+                "invocations": [
+                    {
+                        "executionSuccessful": True,
+                        "endTimeUtc": datetime.now(timezone.utc).strftime(
+                            "%Y-%m-%dT%H:%M:%SZ"
+                        ),
+                    }
+                ],
+                "results": results,
+            }
+        ],
+    }
+    return json.dumps(sarif, indent=2, sort_keys=False)

--- a/cli/tests/test_audit.py
+++ b/cli/tests/test_audit.py
@@ -1,5 +1,8 @@
 """Unit tests for envforge audit (#181 MVP)."""
+
 from __future__ import annotations
+
+import json
 from pathlib import Path
 from typing import List
 
@@ -16,6 +19,7 @@ from envforge_agent.audit import (
     LockfileSource,
     Package,
 )
+from envforge_agent.audit.formatters import format_json, format_sarif
 from envforge_agent.audit.differ import _classify_version_change
 from envforge_agent.audit.models import _normalize_name
 
@@ -225,3 +229,109 @@ class TestLocalEnvironmentErrors:
         mock_run.side_effect = FileNotFoundError("python not found")
         with pytest.raises(RuntimeError, match=r"Could not execute Python interpreter"):
             list(LocalEnvironment(python_executable="/bad/python").packages())
+            
+class TestJsonFormatter:
+    def test_format_json_no_drift(self):
+        # Use a synthetic empty result via direct construction
+        from envforge_agent.audit.models import AuditResult
+        result = AuditResult(
+            source_a="lockfile:a.txt",
+            source_b="lockfile:b.txt",
+            differences=[],
+            common_count=5,
+        )
+        payload = json.loads(format_json(result))
+        assert payload["source_a"] == "lockfile:a.txt"
+        assert payload["source_b"] == "lockfile:b.txt"
+        assert payload["differences"] == []
+        assert payload["summary"]["total"] == 0
+        assert payload["summary"]["common_count"] == 5
+
+    def test_format_json_with_drift(self, tmp_path: Path):
+        a = tmp_path / "a.txt"
+        a.write_text("django==4.2.0\nrequests==2.31.0\n")
+        b = tmp_path / "b.txt"
+        b.write_text("django==5.0.0\nrequests==2.32.0\n")
+
+        result = diff(LockfileSource(a), LockfileSource(b))
+        payload = json.loads(format_json(result))
+
+        assert payload["summary"]["total"] == 2
+        assert payload["summary"]["by_severity"]["major"] == 1
+        assert payload["summary"]["by_severity"]["minor"] == 1
+
+        packages = {entry["package"] for entry in payload["differences"]}
+        assert packages == {"django", "requests"}
+
+
+class TestSarifFormatter:
+    def test_format_sarif_structure(self, tmp_path: Path):
+        a = tmp_path / "a.txt"
+        a.write_text("django==4.2.0\n")
+        b = tmp_path / "b.txt"
+        b.write_text("django==5.0.0\n")
+
+        result = diff(LockfileSource(a), LockfileSource(b))
+        sarif = json.loads(format_sarif(result))
+
+        assert sarif["version"] == "2.1.0"
+        assert "runs" in sarif
+        assert len(sarif["runs"]) == 1
+        run = sarif["runs"][0]
+        assert run["tool"]["driver"]["name"] == "envforge-audit"
+        assert len(run["results"]) == 1
+        assert run["results"][0]["ruleId"] == "drift-major"
+        assert run["results"][0]["level"] == "error"
+
+    def test_format_sarif_severity_mapping(self, tmp_path: Path):
+        a = tmp_path / "a.txt"
+        a.write_text("a==1.0.0\nb==1.0.0\nc==1.0.0\n")
+        b = tmp_path / "b.txt"
+        b.write_text("a==2.0.0\nb==1.1.0\nc==1.0.1\n")
+
+        result = diff(LockfileSource(a), LockfileSource(b))
+        sarif = json.loads(format_sarif(result))
+        results = sarif["runs"][0]["results"]
+
+        levels_by_severity = {
+            r["ruleId"].replace("drift-", ""): r["level"] for r in results
+        }
+        assert levels_by_severity["major"] == "error"
+        assert levels_by_severity["minor"] == "warning"
+        assert levels_by_severity["patch"] == "note"
+
+
+class TestAuditCommandOutputFormats:
+    def test_json_flag_outputs_valid_json(self, tmp_path: Path):
+        a = tmp_path / "a.txt"
+        a.write_text("django==4.2.0\n")
+        b = tmp_path / "b.txt"
+        b.write_text("django==5.0.0\n")
+
+        result = CliRunner().invoke(audit_command, [str(a), str(b), "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["summary"]["total"] == 1
+
+    def test_sarif_flag_outputs_valid_sarif(self, tmp_path: Path):
+        a = tmp_path / "a.txt"
+        a.write_text("django==4.2.0\n")
+        b = tmp_path / "b.txt"
+        b.write_text("django==5.0.0\n")
+
+        result = CliRunner().invoke(audit_command, [str(a), str(b), "--sarif"])
+        assert result.exit_code == 0
+        sarif = json.loads(result.output)
+        assert sarif["version"] == "2.1.0"
+
+    def test_json_and_sarif_mutually_exclusive(self, tmp_path: Path):
+        a = tmp_path / "a.txt"
+        a.write_text("django==4.2.0\n")
+        b = tmp_path / "b.txt"
+        b.write_text("django==5.0.0\n")
+
+        result = CliRunner().invoke(
+            audit_command, [str(a), str(b), "--json", "--sarif"]
+        )
+        assert result.exit_code == 2
+        assert "mutually exclusive" in result.output.lower()


### PR DESCRIPTION
## Description

Part 2 of #181. Adds two new output flags to `envforge audit`:

- `--json` — emits a flat JSON document with source identifiers, per-package differences, and a severity summary. Useful for CI scripts and downstream tooling.
- `--sarif` — emits SARIF v2.1.0, consumable by GitHub Advanced Security, Azure DevOps Code Insights, and similar static-analysis aggregators.

Flags are mutually exclusive (exit code 2 with a clear error if both are passed).

### JSON example

```bash
envforge audit local requirements.txt --json
```

```json
{
  "source_a": "local",
  "source_b": "lockfile:requirements.txt",
  "differences": [
    {
      "package": "django",
      "version_a": "4.2.0",
      "version_b": "5.0.0",
      "severity": "major"
    }
  ],
  "summary": {
    "total": 1,
    "by_severity": { "major": 1 },
    "common_count": 12
  }
}
```

### SARIF example

```bash
envforge audit local requirements.txt --sarif > drift.sarif
```

Severity maps to SARIF levels: `major` → `error`, `minor` / `added` / `removed` → `warning`, `patch` / `other` → `note`. Each drift entry becomes a SARIF result tagged with a `drift-<severity>` rule. The output can be uploaded directly to GitHub code scanning.

### What's next (Part 3)

`ConfigFileSource`, `RemoteApiSource` (depends on #85), drift score, compatibility-engine-based severity, and the `--strict` flag for CI use cases.

## Related Issues

Part 2 of #181. #206 (Part 1) merged the MVP foundation.

## Changes Made

- `cli/envforge_agent/audit/formatters.py` — new `format_json()` and `format_sarif()` functions plus `SEVERITY_TO_SARIF_LEVEL` mapping
- `cli/envforge_agent/audit/command.py` — two new Click options (`--json`, `--sarif`) with mutual-exclusion check
- `cli/tests/test_audit.py` — 7 new tests covering JSON structure, SARIF structure, severity-to-level mapping, end-to-end command invocation with each flag, and the mutual-exclusion error path

No new runtime dependencies; uses stdlib `json` + `datetime` on top of what's already in `cli/pyproject.toml`.

## Verification

- [x] Added unit tests (7 new in `cli/tests/test_audit.py`, 35 total now)
- [x] Ran `pytest tests/` successfully (all 35 pass)
- [x] Manually tested via CLI — both `--json` and `--sarif` flags produce valid output; `--json --sarif` together fails cleanly with exit 2
- [ ] (If applicable) Generated scripts pass `SafetyFilter` — N/A, `audit` is read-only

## Documentation

- [ ] Updated `docs/FEATURES.md` — happy to add a section here or as a follow-up
- [ ] Updated `CHANGELOG.md` — same
- [x] Code is fully documented and type-hinted

Submitted under GSSoC'26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added JSON output format for audit results via `--json` flag
* Added SARIF v2.1.0 output format for audit results via `--sarif` flag
* Audit command now validates and rejects simultaneous use of both output format flags

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->