### PR TITLE
[Feature] Add Poetry pyproject.toml generation support with locked dependencies

### DIFF
--- a/backend/app/schemas/script.py
+++ b/backend/app/schemas/script.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 OSTarget = Literal["LINUX", "WSL", "WIN"]
-OutputFormat = Literal["setup.sh", "setup.ps1", "requirements.txt", "Dockerfile", "docker-compose.yml", "devcontainer.json", "pyproject.toml"]
+OutputFormat = Literal["setup.sh", "setup.ps1", "requirements.txt", "Dockerfile", "docker-compose.yml", "devcontainer.json", "pyproject.toml", "poetry.toml"]
 
 
 class GenerationRequest(BaseModel):

--- a/backend/app/templates/engine.py
+++ b/backend/app/templates/engine.py
@@ -32,6 +32,7 @@ TEMPLATE_MAP: dict[str, str] = {
     "verify_opencv.sh":   "verify/verify_opencv.sh.j2",
     "environment.yml":    "config/environment.yml.j2",
     "pyproject.toml":     "config/pyproject.toml.j2",
+    "poetry.toml":        "config/poetry.toml.j2",
 }
 
 # ── Profile-specific verify template mapping ───────────────────────────────────

--- a/backend/app/templates/jinja/config/poetry.toml.j2
+++ b/backend/app/templates/jinja/config/poetry.toml.j2
@@ -1,0 +1,25 @@
+# ==============================================================================
+# EnvForge Generated pyproject.toml (Poetry)
+# Profile  : {{ profile.name }}
+# Python   : {{ python_version }}
+{% if cuda_version %}# CUDA     : {{ cuda_version }}
+{% endif %}# Generated: {{ generated_at }}
+# EnvForge : v{{ envforge_version }}
+# ==============================================================================
+
+[tool.poetry]
+name = "envforge-generated"
+version = "0.1.0"
+description = "Generated dependencies for {{ profile.name }}"
+authors = ["EnvForge <envforge@example.com>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^{{ python_version }}"
+{% for pkg in packages %}
+{{ pkg.name }} = "{{ pkg.version }}{% if pkg.cuda_variant %}+{{ pkg.cuda_variant }}{% endif %}"
+{% endfor %}
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/backend/app/templates/jinja/config/poetry.toml.j2
+++ b/backend/app/templates/jinja/config/poetry.toml.j2
@@ -15,7 +15,7 @@ authors = ["EnvForge <envforge@example.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^{{ python_version }}"
+python = "{{ python_version }}.*"
 {% for pkg in packages %}
 {{ pkg.name }} = "{{ pkg.version }}{% if pkg.cuda_variant %}+{{ pkg.cuda_variant }}{% endif %}"
 {% endfor %}


### PR DESCRIPTION
## Description
Added support for generating Poetry-compatible `pyproject.toml` files with locked dependency formatting.  

This PR introduces a new Jinja template for Poetry configuration generation and updates the API schema and template engine mappings to support the new `poetry.toml` output format. This enables users to generate Poetry-based Python project configurations directly from the API.


## Related Issues
closes #202 / fixes #202 

## Changes Made
- Added new template: `backend/app/templates/jinja/config/poetry.toml.j2`
- Added support for `[tool.poetry]` and `[tool.poetry.dependencies]` formatting
- Added `python = "^{{ python_version }}"` declaration
- Added dependency mapping with optional CUDA variants
- Added Poetry build-system configuration using `poetry-core`
- Updated `OutputFormat` literal in `backend/app/schemas/script.py`
- Registered `poetry.toml` in `backend/app/templates/engine.py`

## Verification

- [ ] Manually tested via the API / CLI


## Documentation

- [ ] Code is fully documented and type-hinted
