### PR TITLE
Add Docker Compose support for backend and Ollama services Integration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,7 +24,7 @@ OPENROUTER_API_KEY=sk-or-...
 OPENROUTER_MODEL=openai/gpt-4o
 
 # Ollama (if ENVFORGE_LLM_PROVIDER=ollama)
-OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_BASE_URL=http://llm:11434
 OLLAMA_MODEL=llama3
 
 # ── Rate Limiting ─────────────────────────────────────────────

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -47,7 +47,7 @@ class Settings(BaseSettings):
     openai_model: str = "gpt-4o"
     openrouter_api_key: str = ""
     openrouter_model: str = "openai/gpt-4o"
-    ollama_base_url: str = "http://localhost:11434"
+    ollama_base_url: str = "http://llm:11434"
     ollama_model: str = "llama3"
     ai_max_tokens: int = 2048
     ai_temperature: float = 0.3

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,8 +32,6 @@ services:
     image: ollama/ollama
     container_name: envforge_ollama_prod
     restart: always
-    ports:
-      - "11434:11434"
     volumes:
       - ollama_data:/root/.ollama
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,7 +14,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
-    # DB port is NOT exposed in production — only reachable inside the compose network
 
   redis:
     image: redis:7-alpine
@@ -28,7 +27,15 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
-    # Redis port is NOT exposed in production — only reachable inside the compose network
+
+  llm:
+    image: ollama/ollama
+    container_name: envforge_ollama_prod
+    restart: always
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
 
   api:
     build:
@@ -36,13 +43,18 @@ services:
       dockerfile: Dockerfile
     container_name: envforge_api_prod
     restart: always
+
     depends_on:
       db:
         condition: service_healthy
       redis:
         condition: service_healthy
+      llm:
+        condition: service_started
+
     ports:
       - "8000:8000"
+
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
@@ -56,6 +68,8 @@ services:
       RATE_LIMIT_AI_RPM: ${RATE_LIMIT_AI_RPM:-10}
       RATE_LIMIT_REPAIR_RPM: ${RATE_LIMIT_REPAIR_RPM:-20}
       RATE_LIMIT_GENERAL_RPM: ${RATE_LIMIT_GENERAL_RPM:-60}
+      OLLAMA_HOST: http://llm:11434
+
     command: >
       sh -c "
         alembic upgrade head &&
@@ -66,3 +80,4 @@ services:
 volumes:
   postgres_data:
   redis_data:
+  ollama_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       DEBUG: "true"
       SECRET_KEY: dev_secret_key_change_in_production
       ENVFORGE_LLM_PROVIDER: mock
-      OLLAMA_HOST: http://llm:11434
+      OLLAMA_BASE_URL: http://llm:11434
 
     volumes:
       - ./backend:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,24 +18,39 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
-  
+
   redis:
     image: redis:7-alpine
     container_name: envforge_redis
     restart: unless-stopped
     ports:
       - "6379:6379"
+
+  llm:
+    image: ollama/ollama
+    container_name: envforge_ollama
+    restart: unless-stopped
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+
   api:
     build:
       context: ./backend
       dockerfile: Dockerfile
     container_name: envforge_api
     restart: unless-stopped
+
     depends_on:
       db:
         condition: service_healthy
+      llm:
+        condition: service_started
+
     ports:
       - "8000:8000"
+
     environment:
       REDIS_URL: redis://redis:6379
       DATABASE_URL: postgresql+asyncpg://envforge:envforge_dev_secret@db:5432/envforge
@@ -43,8 +58,11 @@ services:
       DEBUG: "true"
       SECRET_KEY: dev_secret_key_change_in_production
       ENVFORGE_LLM_PROVIDER: mock
+      OLLAMA_HOST: http://llm:11434
+
     volumes:
       - ./backend:/app
+
     command: >
       sh -c "
         alembic upgrade head &&
@@ -54,3 +72,4 @@ services:
 
 volumes:
   postgres_data:
+  ollama_data:


### PR DESCRIPTION
## Summary

* Added Ollama container service to Docker Compose setup
* Configured API service to communicate with Ollama using internal Docker DNS
* Added persistent Ollama volume
* Updated Ollama base URL from localhost to Docker service hostname
* Added Ollama environment variable support for development and production environments

## Testing

* Successfully built containers using Docker Compose
* Verified API startup inside Docker environment
* Verified Ollama container startup and networking
* Verified all services using `docker ps`

Closes #57 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default LLM service endpoint configuration from localhost to containerized network address
  * Added dedicated containerized LLM service to development and production environments
  * Configured service startup dependencies to ensure LLM service availability before application launch
  * Implemented persistent data storage for LLM service to maintain state across container restarts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->