### PR TITLE
feat: add huggingface-audio profile (Whisper, Librosa)

### DIFF
--- a/backend/seeds/profiles.yaml
+++ b/backend/seeds/profiles.yaml
@@ -193,4 +193,38 @@ profiles:
         install_order: 6
       - name: scipy
         version_spec: "1.13.0"
-        install_order: 7
+        install_order: 7  - slug: huggingface-audio
+    name: "HuggingFace Audio"
+    description: >
+      Audio ML processing environment tuned for speech and audio models.
+      Includes Whisper (openai-whisper), Librosa, SoundFile, and Transformers.
+      Requires ffmpeg as a system-level dependency for audio I/O.
+    tags: [audio, speech, whisper, huggingface, transformers]
+    os_support: [LINUX, WSL, WIN, MAC]
+    cuda_required: false
+    python_versions: ["3.10", "3.11", "3.12", "3.13"]
+    cuda_versions: []
+    status: ACTIVE
+    last_validated: "2026-05-26"
+    system_requirements:
+      - name: ffmpeg
+        notes: "Required for audio decoding. Install via apt, brew, or winget."
+    packages:
+      - name: openai-whisper
+        version_spec: "20231117"
+        install_order: 0
+      - name: transformers
+        version_spec: "4.40.0"
+        install_order: 1
+      - name: librosa
+        version_spec: "0.10.1"
+        install_order: 2
+      - name: soundfile
+        version_spec: "0.12.1"
+        install_order: 3
+      - name: torch
+        version_spec: "2.5.0"
+        install_order: 4
+      - name: numpy
+        version_spec: "1.26.4"
+        install_order: 5


### PR DESCRIPTION
Closes #199

## Changes

Added `huggingface-audio` profile to `backend/seeds/profiles.yaml`.

### Profile details:
- **slug:** `huggingface-audio`
- **packages:** `openai-whisper`, `transformers`, `librosa`, `soundfile`, `torch`, `numpy`
- **os_support:** LINUX, WSL, WIN, MAC (CPU-friendly, no CUDA required)
- **system_requirements:** `ffmpeg` noted as required for audio decoding

### Why:
Audio ML processing is a distinct environment setup. This profile provides a ready-made stack for speech and audio models using Whisper and Librosa, as requested in the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `huggingface-audio` profile enabling audio and speech machine learning capabilities with necessary dependencies and system requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->