### PR TITLE
security: add global deny-by-default API key authentication middleware

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -48,6 +48,8 @@ class Settings(BaseSettings):
     def allowed_origins_list(self) -> list[str]:
         return [o.strip() for o in self.allowed_origins.split(",")]
 
+    api_key: str | None = None  # Set API_KEY env var to enable auth
+
     # ── AI / LLM ─────────────────────────────────────────────
     envforge_llm_provider: Literal["openai", "openrouter", "ollama", "mock"] = "mock"
     openai_api_key: str = ""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from app.middleware.auth import APIKeyMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy import text
 
@@ -56,6 +57,7 @@ def create_app() -> FastAPI:
 
     register_exception_handlers(app)
 
+    app.add_middleware(APIKeyMiddleware)
     # ── CORS ─────────────────────────────────────────────────
     app.add_middleware(
         CORSMiddleware,

--- a/backend/app/middleware/auth.py
+++ b/backend/app/middleware/auth.py
@@ -1,0 +1,89 @@
+"""
+Global API key authentication middleware.
+
+Implements a deny-by-default security perimeter for all sensitive API routes.
+Public routes (health check, docs, openapi schema) are explicitly exempted.
+
+Configuration:
+    Set the ``API_KEY`` environment variable to enable authentication.
+    If ``API_KEY`` is not set, the middleware is disabled (development mode).
+
+Usage:
+    The middleware is registered globally in ``app/main.py`` and applies
+    to all requests automatically. No per-route decoration is needed.
+
+    Clients must send the API key in one of:
+        - ``Authorization: Bearer <api_key>`` header
+        - ``X-API-Key: <api_key>`` header
+"""
+import logging
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from app.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+# Routes that do not require authentication
+PUBLIC_ROUTES: set[str] = {
+    "/health",
+    "/api/docs",
+    "/api/redoc",
+    "/api/openapi.json",
+}
+
+
+class APIKeyMiddleware(BaseHTTPMiddleware):
+    """
+    Deny-by-default middleware that requires a valid API key for
+    all routes except those listed in PUBLIC_ROUTES.
+
+    If ``settings.api_key`` is None or empty, the middleware is
+    disabled and all requests pass through (development mode).
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        settings = get_settings()
+
+        # Middleware disabled if no API key is configured
+        if not settings.api_key:
+            return await call_next(request)
+
+        # Allow public routes without authentication
+        if request.url.path in PUBLIC_ROUTES:
+            return await call_next(request)
+
+        # Extract API key from headers
+        api_key = self._extract_api_key(request)
+
+        if api_key != settings.api_key:
+            logger.warning(
+                "Unauthorized request to %s from %s",
+                request.url.path,
+                request.client.host if request.client else "unknown",
+            )
+            return JSONResponse(
+                status_code=401,
+                content={
+                    "error": "UNAUTHORIZED",
+                    "message": (
+                        "Missing or invalid API key. "
+                        "Provide a valid key via 'Authorization: Bearer <key>' "
+                        "or 'X-API-Key: <key>' header."
+                    ),
+                },
+            )
+
+        return await call_next(request)
+
+    def _extract_api_key(self, request: Request) -> str | None:
+        """Extract API key from Authorization or X-API-Key header."""
+        # Check Authorization: Bearer <token>
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            return auth_header[len("Bearer "):]
+
+        # Check X-API-Key header
+        return request.headers.get("X-API-Key")


### PR DESCRIPTION
Closes #47

## Changes

Implemented a global deny-by-default authentication middleware to protect all sensitive API endpoints from unauthorized access.

### Files changed:

- `backend/app/middleware/auth.py` — new file, global API key middleware
- `backend/app/main.py` — registered `APIKeyMiddleware` globally
- `backend/app/config.py` — added `api_key` setting (reads from `API_KEY` env var)

### How it works:

- All API routes require a valid API key by default
- Public routes are explicitly exempted: `/health`, `/api/docs`, `/api/redoc`, `/api/openapi.json`
- API key can be sent via:
  - `Authorization: Bearer <key>` header
  - `X-API-Key: <key>` header
- Returns `401 Unauthorized` for missing or invalid keys
- If `API_KEY` env var is not set, middleware is disabled (safe for development)

### Environment variable:
API_KEY=your-secret-key

### Security behaviour:
- Unauthorized requests return `401` with descriptive error message
- Invalid attempts are logged with client IP for audit trail
- No sensitive routes are left unprotected when `API_KEY` is configured