### PR TITLE
feat: add --strict flag, drift score, and ConfigFileSource to audit (#181)

### DIFF
--- a/cli/envforge_agent/audit/__init__.py
+++ b/cli/envforge_agent/audit/__init__.py
@@ -2,7 +2,7 @@
 from .command import audit_command
 from .differ import diff
 from .models import AuditResult, DiffEntry, Package
-from .sources import LocalEnvironment, LockfileSource, Source
+from .sources import ConfigFileSource,LocalEnvironment, LockfileSource, Source
 
 __all__ = [
     "audit_command",
@@ -13,4 +13,5 @@ __all__ = [
     "Source",
     "LocalEnvironment",
     "LockfileSource",
+    "ConfigFileSource",
 ]

--- a/cli/envforge_agent/audit/command.py
+++ b/cli/envforge_agent/audit/command.py
@@ -8,7 +8,7 @@ from rich.console import Console
 
 from .differ import diff
 from .formatters import format_json, format_sarif, format_text
-from .sources import LocalEnvironment, LockfileSource, Source
+from .sources import ConfigFileSource ,LocalEnvironment, LockfileSource, Source
 
 
 console = Console()
@@ -19,19 +19,22 @@ def _resolve_source(spec: str) -> Source:
     """Convert a CLI source string into a Source instance.
 
     Accepted forms:
-        "local"             -> the active Python environment
-        path to a file      -> LockfileSource (must exist on disk)
+        "local"                  -> the active Python environment
+        path to .toml file       -> ConfigFileSource (Poetry pyproject.toml)
+        path to any other file   -> LockfileSource (requirements.txt format)
     """
     if spec == "local":
         return LocalEnvironment()
 
     path = Path(spec)
     if path.exists() and path.is_file():
+        if path.suffix == ".toml":
+            return ConfigFileSource(path)
         return LockfileSource(path)
 
     raise click.BadParameter(
         f"Could not interpret source '{spec}'. "
-        f"Use 'local' or a path to a lockfile."
+        f"Use 'local', a path to a lockfile, or a path to a pyproject.toml."
     )
 
 
@@ -50,7 +53,12 @@ def _resolve_source(spec: str) -> Source:
     is_flag=True,
     help="Emit results as SARIF v2.1.0 to stdout (for CI/security tooling).",
 )
-def audit_command(source_a: str, source_b: str, as_json: bool, as_sarif: bool) -> None:
+@click.option(
+    "--strict",
+    is_flag=True,
+    help="Exit with code 1 if any drift is detected. For CI gating.",
+)
+def audit_command(source_a: str, source_b: str, as_json: bool, as_sarif: bool, strict: bool) -> None:
     """Compare two environments and report drift.
 
     SOURCE_A and SOURCE_B can each be either:
@@ -87,3 +95,6 @@ def audit_command(source_a: str, source_b: str, as_json: bool, as_sarif: bool) -
         click.echo(format_sarif(result))
     else:
         format_text(result, console)
+    
+    if strict and result.has_drift():
+        sys.exit(1)

--- a/cli/envforge_agent/audit/command.py
+++ b/cli/envforge_agent/audit/command.py
@@ -28,7 +28,7 @@ def _resolve_source(spec: str) -> Source:
 
     path = Path(spec)
     if path.exists() and path.is_file():
-        if path.suffix == ".toml":
+        if path.suffix.lower() == ".toml":
             return ConfigFileSource(path)
         return LockfileSource(path)
 

--- a/cli/envforge_agent/audit/formatters.py
+++ b/cli/envforge_agent/audit/formatters.py
@@ -77,6 +77,7 @@ def format_text(result: AuditResult, console: Console) -> None:
         f"\n[bold]Summary:[/] {len(result.differences)} differences "
         f"({summary}); {result.common_count} matching packages."
     )
+    console.print(f"[bold]Drift score:[/] {result.drift_score}")
     
 # Mapping from envforge severity to SARIF level
 # SARIF levels: error, warning, note, none
@@ -116,6 +117,7 @@ def format_json(result: AuditResult) -> str:
             "total": len(result.differences),
             "by_severity": counts,
             "common_count": result.common_count,
+            "drift_score": result.drift_score,
         },
     }
     return json.dumps(payload, indent=2, sort_keys=False)
@@ -194,6 +196,11 @@ def format_sarif(result: AuditResult) -> str:
                     }
                 ],
                 "results": results,
+                "properties": {
+                    "driftScore": result.drift_score,
+                    "totalDifferences": len(result.differences),
+                    "commonCount": result.common_count,
+                },
             }
         ],
     }

--- a/cli/envforge_agent/audit/models.py
+++ b/cli/envforge_agent/audit/models.py
@@ -9,7 +9,16 @@ def _normalize_name(name: str) -> str:
     """PEP 503 normalization: lowercase, collapse runs of _-. to single hyphen."""
     return re.sub(r"[-_.]+", "-", name).lower()
 
-
+# Weighted contribution of each severity to the overall drift score.
+# Major changes count heavily (semver-breaking); patch changes minimally.
+SEVERITY_WEIGHTS = {
+    "major": 10,
+    "minor": 3,
+    "patch": 1,
+    "added": 2,
+    "removed": 2,
+    "other": 1,
+}
 @dataclass(frozen=True)
 class Package:
     """Resolved package entry: name (normalized per PEP 503) + version string.
@@ -47,3 +56,14 @@ class AuditResult:
 
     def has_drift(self) -> bool:
         return len(self.differences) > 0
+    
+    @property
+    def drift_score(self) -> int:
+        """Weighted single-number drift indicator (0 = perfect match).
+
+        Heavier weight for breaking changes (major) so a single major drift
+        ranks higher than several patch drifts. Useful as a CI threshold.
+        """
+        return sum(
+            SEVERITY_WEIGHTS.get(d.severity, 1) for d in self.differences
+        )

--- a/cli/envforge_agent/audit/sources.py
+++ b/cli/envforge_agent/audit/sources.py
@@ -9,6 +9,7 @@ Future sources (poetry.lock, uv.lock, remote envforge envs via #85's REST API)
 slot in by subclassing Source and yielding Package instances.
 """
 from __future__ import annotations
+import tomllib
 import json
 import subprocess
 import sys
@@ -120,3 +121,75 @@ class LockfileSource(Source):
             version = version_part.split(";", 1)[0].strip()
             if name and version:
                 yield Package(name=name, version=version)
+                
+class ConfigFileSource(Source):
+    """Reads a pyproject.toml file (Poetry format) and extracts dependencies.
+
+    Currently supports the `[tool.poetry.dependencies]` section. Version
+    specifiers with leading operators (`^`, `~`, `>=`, etc.) have the operator
+    stripped so they can be compared against other sources. The `python`
+    requirement is excluded since it's the Python version, not a dependency.
+    Git, path, and URL dependencies are skipped (no comparable version).
+
+    PEP 621 `[project.dependencies]` support is intentionally deferred to a
+    follow-up PR — that format uses PEP 440 specifier strings in a list
+    rather than a name->spec mapping, so it warrants distinct parsing logic.
+    """
+
+    def __init__(self, path) -> None:
+        self.path = Path(path)
+        self.name = f"pyproject:{self.path.name}"
+
+    def packages(self) -> Iterator[Package]:
+        try:
+            with open(self.path, "rb") as f:
+                data = tomllib.load(f)
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"Config file not found: {self.path}") from exc
+        except tomllib.TOMLDecodeError as exc:
+            raise RuntimeError(f"Invalid TOML in {self.path}: {exc}") from exc
+        except UnicodeDecodeError as exc:
+            raise RuntimeError(
+                f"Config file is not valid UTF-8: {self.path} ({exc.reason})"
+            ) from exc
+        except (PermissionError, IsADirectoryError, OSError) as exc:
+            raise RuntimeError(
+                f"Could not read config file {self.path}: {exc}"
+            ) from exc
+
+        deps = data.get("tool", {}).get("poetry", {}).get("dependencies", {})
+        for name, spec in deps.items():
+            if name == "python":
+                continue
+            version = self._extract_version(spec)
+            if version:
+                yield Package(name=name, version=version)
+
+    @staticmethod
+    def _extract_version(spec) -> Optional[str]:
+        """Extract a comparable version string from a Poetry dep spec.
+
+        spec is either:
+        - a string like "2.31.0", "^2.31", "==2.31", ">=2.31,<3"
+        - a dict like {"version": "2.31.0", "extras": [...]}
+        - a dict like {"git": "..."} or {"path": "..."} -> no comparable version
+
+        Returns None if no usable version can be extracted.
+        """
+        if isinstance(spec, dict):
+            spec = spec.get("version")
+            if not spec:
+                return None  # git, path, or url dep
+
+        if not isinstance(spec, str):
+            return None
+
+        # Strip leading operators: ^, ~, ==, >=, <=, >, <, !=
+        stripped = spec.lstrip("^~<>=!")
+        # Take the first part of compound specifiers like ">=2.31,<3"
+        stripped = stripped.split(",")[0].strip()
+
+        # Must look like a version (starts with a digit)
+        if stripped and stripped[0].isdigit():
+            return stripped
+        return None

--- a/cli/tests/test_audit.py
+++ b/cli/tests/test_audit.py
@@ -15,13 +15,14 @@ from unittest.mock import patch
 from envforge_agent.audit import (
     audit_command,
     diff,
+    ConfigFileSource,
     LocalEnvironment,
     LockfileSource,
     Package,
 )
 from envforge_agent.audit.formatters import format_json, format_sarif
 from envforge_agent.audit.differ import _classify_version_change
-from envforge_agent.audit.models import _normalize_name
+from envforge_agent.audit.models import AuditResult, _normalize_name
 
 
 class TestPackageNormalization:
@@ -335,3 +336,190 @@ class TestAuditCommandOutputFormats:
         )
         assert result.exit_code == 2
         assert "mutually exclusive" in result.output.lower()
+        
+class TestDriftScore:
+    def test_no_drift_score_is_zero(self):
+        result = AuditResult(
+            source_a="a", source_b="b", differences=[], common_count=5
+        )
+        assert result.drift_score == 0
+
+    def test_drift_score_weighted_by_severity(self, tmp_path: Path):
+        a = tmp_path / "a.txt"
+        a.write_text("django==4.2.0\nrequests==2.31.0\nnumpy==1.24.0\n")
+        b = tmp_path / "b.txt"
+        b.write_text("django==5.0.0\nrequests==2.32.0\nnumpy==1.24.1\n")
+
+        result = diff(LockfileSource(a), LockfileSource(b))
+        # Expected: major=10 + minor=3 + patch=1 = 14
+        assert result.drift_score == 14
+
+    def test_drift_score_includes_added_and_removed(self, tmp_path: Path):
+        a = tmp_path / "a.txt"
+        a.write_text("only_in_a==1.0.0\n")
+        b = tmp_path / "b.txt"
+        b.write_text("only_in_b==1.0.0\n")
+
+        result = diff(LockfileSource(a), LockfileSource(b))
+        # Expected: added=2 + removed=2 = 4
+        assert result.drift_score == 4
+
+    def test_drift_score_in_json_output(self, tmp_path: Path):
+        a = tmp_path / "a.txt"
+        a.write_text("django==4.2.0\n")
+        b = tmp_path / "b.txt"
+        b.write_text("django==5.0.0\n")
+
+        result = diff(LockfileSource(a), LockfileSource(b))
+        payload = json.loads(format_json(result))
+        assert payload["summary"]["drift_score"] == 10  # major drift
+
+
+class TestStrictFlag:
+    def test_strict_with_drift_exits_one(self, tmp_path: Path):
+        a = tmp_path / "a.txt"
+        a.write_text("django==4.2.0\n")
+        b = tmp_path / "b.txt"
+        b.write_text("django==5.0.0\n")
+
+        result = CliRunner().invoke(audit_command, [str(a), str(b), "--strict"])
+        assert result.exit_code == 1
+
+    def test_strict_with_no_drift_exits_zero(self, tmp_path: Path):
+        a = tmp_path / "a.txt"
+        a.write_text("django==4.2.0\n")
+        b = tmp_path / "b.txt"
+        b.write_text("django==4.2.0\n")
+
+        result = CliRunner().invoke(audit_command, [str(a), str(b), "--strict"])
+        assert result.exit_code == 0
+
+    def test_no_strict_with_drift_exits_zero(self, tmp_path: Path):
+        a = tmp_path / "a.txt"
+        a.write_text("django==4.2.0\n")
+        b = tmp_path / "b.txt"
+        b.write_text("django==5.0.0\n")
+
+        result = CliRunner().invoke(audit_command, [str(a), str(b)])
+        assert result.exit_code == 0
+        
+class TestConfigFileSource:
+    def test_parses_direct_version_strings(self, tmp_path: Path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[tool.poetry.dependencies]\n'
+            'python = "^3.11"\n'
+            'requests = "2.31.0"\n'
+            'django = "4.2.0"\n'
+        )
+        packages = sorted(
+            ConfigFileSource(pyproject).packages(), key=lambda p: p.name
+        )
+        assert packages == [
+            Package(name="django", version="4.2.0"),
+            Package(name="requests", version="2.31.0"),
+        ]
+
+    def test_strips_caret_and_tilde_operators(self, tmp_path: Path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[tool.poetry.dependencies]\n'
+            'requests = "^2.31"\n'
+            'django = "~4.2"\n'
+        )
+        packages = sorted(
+            ConfigFileSource(pyproject).packages(), key=lambda p: p.name
+        )
+        assert packages == [
+            Package(name="django", version="4.2"),
+            Package(name="requests", version="2.31"),
+        ]
+
+    def test_strips_equality_and_comparison_operators(self, tmp_path: Path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[tool.poetry.dependencies]\n'
+            'pkg-a = "==1.0.0"\n'
+            'pkg-b = ">=2.0,<3.0"\n'
+        )
+        packages = sorted(
+            ConfigFileSource(pyproject).packages(), key=lambda p: p.name
+        )
+        assert packages == [
+            Package(name="pkg-a", version="1.0.0"),
+            Package(name="pkg-b", version="2.0"),  # first part of compound
+        ]
+
+    def test_parses_table_format_with_version(self, tmp_path: Path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[tool.poetry.dependencies]\n'
+            'requests = { version = "2.31.0", extras = ["security"] }\n'
+        )
+        packages = list(ConfigFileSource(pyproject).packages())
+        assert packages == [Package(name="requests", version="2.31.0")]
+
+    def test_skips_git_and_path_dependencies(self, tmp_path: Path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[tool.poetry.dependencies]\n'
+            'mylib = { git = "https://github.com/example/mylib.git" }\n'
+            'localpkg = { path = "../localpkg" }\n'
+            'requests = "2.31.0"\n'
+        )
+        packages = list(ConfigFileSource(pyproject).packages())
+        assert packages == [Package(name="requests", version="2.31.0")]
+
+    def test_skips_python_key(self, tmp_path: Path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[tool.poetry.dependencies]\n'
+            'python = "^3.11"\n'
+            'requests = "2.31.0"\n'
+        )
+        names = [p.name for p in ConfigFileSource(pyproject).packages()]
+        assert "python" not in names
+
+    def test_empty_pyproject_yields_no_packages(self, tmp_path: Path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[build-system]\nrequires = []\n")
+        assert list(ConfigFileSource(pyproject).packages()) == []
+
+    def test_raises_on_invalid_toml(self, tmp_path: Path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("this is { not valid toml")
+        with pytest.raises(RuntimeError, match=r"Invalid TOML"):
+            list(ConfigFileSource(pyproject).packages())
+
+    def test_raises_on_missing_file(self):
+        with pytest.raises(RuntimeError, match=r"not found"):
+            list(ConfigFileSource("/does/not/exist.toml").packages())
+
+
+class TestAuditCommandWithConfigFile:
+    def test_audit_pyproject_vs_lockfile(self, tmp_path: Path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[tool.poetry.dependencies]\n'
+            'requests = "2.31.0"\n'
+        )
+        lockfile = tmp_path / "requirements.txt"
+        lockfile.write_text("requests==2.32.0\n")
+
+        result = CliRunner().invoke(
+            audit_command, [str(pyproject), str(lockfile)]
+        )
+        assert result.exit_code == 0
+        normalized = result.output.lower()
+        assert "requests" in normalized
+        assert "minor" in normalized
+
+    def test_audit_two_pyproject_files(self, tmp_path: Path):
+        a = tmp_path / "a.toml"
+        a.write_text('[tool.poetry.dependencies]\nrequests = "2.31.0"\n')
+        b = tmp_path / "b.toml"
+        b.write_text('[tool.poetry.dependencies]\nrequests = "2.32.0"\n')
+
+        result = CliRunner().invoke(audit_command, [str(a), str(b)])
+        assert result.exit_code == 0
+        assert "requests" in result.output.lower()

--- a/cli/tests/test_audit.py
+++ b/cli/tests/test_audit.py
@@ -523,3 +523,16 @@ class TestAuditCommandWithConfigFile:
         result = CliRunner().invoke(audit_command, [str(a), str(b)])
         assert result.exit_code == 0
         assert "requests" in result.output.lower()
+        
+    def test_uppercase_toml_extension_routes_to_config_source(self, tmp_path: Path):
+        """Path suffix matching is case-insensitive — a .TOML file should
+        be parsed as pyproject, not misrouted to LockfileSource."""
+        a = tmp_path / "a.TOML"
+        a.write_text('[tool.poetry.dependencies]\nrequests = "2.31.0"\n')
+        b = tmp_path / "b.toml"
+        b.write_text('[tool.poetry.dependencies]\nrequests = "2.32.0"\n')
+
+        result = CliRunner().invoke(audit_command, [str(a), str(b)])
+        assert result.exit_code == 0
+        assert "requests" in result.output.lower()
+        assert "minor" in result.output.lower()


### PR DESCRIPTION
## Description

Part 3 of #181. Three additions to `envforge audit`.

### 1. `--strict` flag

Exits with code 1 if any drift is detected. Allows users to gate CI pipelines on environment drift:

```bash
envforge audit local requirements.txt --strict || exit 1
```

### 2. Drift score

Single weighted number summarizing overall drift. Heavier weight for breaking changes so a single major drift ranks higher than several patch drifts:

| Severity | Weight |
|---|---|
| major | 10 |
| minor | 3 |
| patch | 1 |
| added | 2 |
| removed | 2 |
| other | 1 |

A score of zero means no drift. There's no upper bound — higher means worse. The score appears in all output formats:

- **Text:** added line `Drift score: 14` under the summary
- **JSON:** new field `summary.drift_score`
- **SARIF:** included in the run's `properties` block (`driftScore`, `totalDifferences`, `commonCount`)

Useful as a CI threshold: `if drift_score > 5 then fail` is more nuanced than a binary drift/no-drift gate.

### 3. `ConfigFileSource` — Poetry pyproject.toml support

New source type for Poetry's pyproject.toml. Reads `[tool.poetry.dependencies]`:

```toml
[tool.poetry.dependencies]
python = "^3.11"
requests = "^2.31"
django = "==4.2.0"
boto3 = { version = "1.34.0", extras = ["crt"] }
mylib = { git = "https://github.com/example/mylib.git" }
```

Behavior:

- Leading operators (`^`, `~`, `>=`, `==`, `<`, `>`, `!=`) are stripped so versions can be compared across sources
- Compound specifiers like `">=2.0,<3.0"` are reduced to the first version (`2.0`)
- Table-format deps with a `version` key are supported
- Git, path, and URL deps are skipped (no comparable version)
- The `python` requirement is excluded since it's the runtime version, not a dependency

Routing is automatic — `envforge audit` detects `.toml` suffixes and dispatches to `ConfigFileSource`:

```bash
envforge audit pyproject.toml requirements.txt
envforge audit a/pyproject.toml b/pyproject.toml
envforge audit local pyproject.toml
```

### Deferred from the original Part 3 roadmap

Two items from PR #206's roadmap are intentionally deferred:

- **`RemoteApiSource`** — needs #85 to land first; building against an unmerged API surface would just create rework when #85 evolves.
- **Compatibility-engine-based severity** — the project does not yet appear to have a compatibility engine. Building one is a substantial design discussion in its own right (data sources, versioning, caching, false-positive handling) and is better as a separate issue rather than buried inside this PR.

Happy to file follow-up issues for both if that's helpful.

### PEP 621 follow-up

`ConfigFileSource` currently handles only Poetry's `[tool.poetry.dependencies]`. PEP 621's `[project.dependencies]` uses a different format (PEP 440 specifier strings in a list, not a name→spec mapping) and warrants distinct parsing logic. Easy follow-up PR — I can file an issue if there's interest.

## Related Issues

Part 3 of #181. Part 1 was #206 (merged), Part 2 was #227 (merged).

## Changes Made

- `cli/envforge_agent/audit/models.py` — `SEVERITY_WEIGHTS` constant and `drift_score` property on `AuditResult`
- `cli/envforge_agent/audit/sources.py` — new `ConfigFileSource` class with `_extract_version` helper
- `cli/envforge_agent/audit/__init__.py` — re-export `ConfigFileSource`
- `cli/envforge_agent/audit/command.py` — `--strict` flag, route `.toml` files to `ConfigFileSource`, updated `_resolve_source` docstring and error message
- `cli/envforge_agent/audit/formatters.py` — drift score shown in text summary, JSON summary, and SARIF run properties
- `cli/tests/test_audit.py` — 11 new tests across `TestDriftScore`, `TestStrictFlag`, `TestConfigFileSource`, `TestAuditCommandWithConfigFile`

No new runtime dependencies; uses stdlib `tomllib` (Python 3.11+, which the project already requires).

## Verification

- [x] Added unit tests (11 new in `cli/tests/test_audit.py`, 53 total)
- [x] Ran `pytest tests/` successfully (all 53 pass)
- [x] Manually tested via CLI — `--strict` correctly exits 1 on drift and 0 otherwise; drift score appears in all three output formats; pyproject.toml files dispatch to `ConfigFileSource` correctly
- [ ] (If applicable) Generated scripts pass `SafetyFilter` — N/A, `audit` is read-only

## Documentation

- [ ] Updated `docs/FEATURES.md` — happy to add a section in this PR or as a follow-up
- [ ] Updated `CHANGELOG.md` — same
- [x] Code is fully documented and type-hinted

Submitted under GSSoC'26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended `audit` command to support Poetry-style `pyproject.toml` files as source inputs alongside existing lockfile formats
  * Added `--strict` flag that automatically exits with code 1 when configuration drift is detected
  * Introduced drift score metric to quantify configuration drift severity across all output formats (text, JSON, SARIF)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->