### PR TITLE
Add property-based tests for compatibility resolver

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -701,6 +701,40 @@ socks = ["socksio (==1.*)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "hypothesis"
+version = "6.153.0"
+description = "The property-based testing library for Python"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"dev\""
+files = [
+    {file = "hypothesis-6.153.0-py3-none-any.whl", hash = "sha256:2aeda9bbb44ae0ee0bfa67ef744a25be05c1f804dca4eb6479c63518dc9f2900"},
+    {file = "hypothesis-6.153.0.tar.gz", hash = "sha256:11616e5158fc485d62bae19d9cc69333237faa8050ad44a45218254a1ef272bb"},
+]
+
+[package.dependencies]
+sortedcontainers = ">=2.1.0,<3.0.0"
+
+[package.extras]
+all = ["black (>=20.8b0)", "click (>=7.0)", "crosshair-tool (>=0.0.104)", "django (>=5.2)", "dpcontracts (>=0.4)", "hypothesis-crosshair (>=0.0.28)", "lark (>=0.10.1)", "libcst (>=0.3.16)", "numpy (>=1.21.6)", "pandas (>=1.1)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "tzdata (>=2026.2) ; sys_platform == \"win32\" or sys_platform == \"emscripten\"", "watchdog (>=4.0.0)"]
+cli = ["black (>=20.8b0)", "click (>=7.0)", "rich (>=9.0.0)"]
+codemods = ["libcst (>=0.3.16)"]
+crosshair = ["crosshair-tool (>=0.0.104)", "hypothesis-crosshair (>=0.0.28)"]
+dateutil = ["python-dateutil (>=1.4)"]
+django = ["django (>=5.2)"]
+dpcontracts = ["dpcontracts (>=0.4)"]
+ghostwriter = ["black (>=20.8b0)"]
+lark = ["lark (>=0.10.1)"]
+numpy = ["numpy (>=1.21.6)"]
+pandas = ["pandas (>=1.1)"]
+pytest = ["pytest (>=4.6)"]
+pytz = ["pytz (>=2014.1)"]
+redis = ["redis (>=3.0.0)"]
+watchdog = ["watchdog (>=4.0.0)"]
+zoneinfo = ["tzdata (>=2026.2) ; sys_platform == \"win32\" or sys_platform == \"emscripten\""]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 description = "File identification library for Python"
@@ -1661,6 +1695,19 @@ files = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+optional = true
+python-versions = "*"
+groups = ["main"]
+markers = "extra == \"dev\""
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.49"
 description = "Database Abstraction Library"
@@ -2123,9 +2170,9 @@ files = [
 ]
 
 [extras]
-dev = ["aiosqlite", "black", "httpx", "mypy", "pre-commit", "pytest", "pytest-asyncio", "pytest-cov", "ruff", "types-pyyaml"]
+dev = ["aiosqlite", "black", "httpx", "hypothesis", "mypy", "pre-commit", "pytest", "pytest-asyncio", "pytest-cov", "ruff", "types-pyyaml"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "8e29799c4996ef4480d46b0ec59b7818ea7f74d559f2adc5c38d5e006bd106c0"
+content-hash = "14f37a25d3295221bd661cd25caaddc6e6665375cba876404592a8e7110a8fe4"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
     "pytest>=8.2.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=5.0.0",
+    "hypothesis>=6.100.0",
     "httpx>=0.27.0",
     "aiosqlite>=0.20.0",
     "black>=26.5.1",

--- a/backend/tests/unit/compatibility/test_resolver.py
+++ b/backend/tests/unit/compatibility/test_resolver.py
@@ -3,16 +3,81 @@ Unit tests for the Compatibility Resolver.
 No mocks for matrix data — the matrix IS the ground truth.
 """
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from app.compatibility.errors import (
     IncompatibilityError,
     UnknownVersionError,
     UnsupportedOSError,
 )
+from app.compatibility.matrix.cuda import CUDA_MATRIX
+from app.compatibility.matrix.python import PYTHON_MATRIX
 from app.compatibility.models import PackageConstraint
 from app.compatibility.resolver import CompatibilityResolver
 
 R = CompatibilityResolver()
+
+KNOWN_FRAMEWORK_VERSIONS = [
+    (framework, entry.version)
+    for framework, entries in PYTHON_MATRIX.items()
+    for entry in entries
+]
+VERSION_STRINGS = st.one_of(
+    st.sampled_from(["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]),
+    st.from_regex(r"\d{1,2}\.\d{1,2}(?:\.\d{1,2})?", fullmatch=True),
+    st.sampled_from(["", "latest", "cu118", "12.x", "3.11-dev"]),
+)
+PACKAGE_CONSTRAINTS = st.one_of(
+    st.sampled_from(KNOWN_FRAMEWORK_VERSIONS).map(
+        lambda package: PackageConstraint(package[0], package[1])
+    ),
+    st.builds(
+        PackageConstraint,
+        name=st.sampled_from(["torch", "tensorflow", "jax", "ultralytics"]),
+        version_spec=VERSION_STRINGS,
+    ),
+    st.builds(
+        PackageConstraint,
+        name=st.sampled_from(["matplotlib", "numpy", "scikit-learn"]),
+        version_spec=VERSION_STRINGS,
+    ),
+)
+
+
+@settings(max_examples=1000, deadline=None)
+@given(
+    packages=st.lists(PACKAGE_CONSTRAINTS, min_size=0, max_size=4),
+    python_version=VERSION_STRINGS,
+    cuda_version=st.one_of(st.none(), st.sampled_from(list(CUDA_MATRIX)), VERSION_STRINGS),
+    target_os=st.sampled_from(["LINUX", "WSL", "WIN"]),
+    cuda_required=st.booleans(),
+)
+def test_resolve_handles_generated_version_inputs(
+    packages,
+    python_version,
+    cuda_version,
+    target_os,
+    cuda_required,
+):
+    """Generated inputs either resolve or fail with a structured compatibility error."""
+    try:
+        result = R.resolve(
+            packages=packages,
+            python_version=python_version,
+            cuda_version=cuda_version,
+            target_os=target_os,
+            profile_slug="generated-profile",
+            os_support=["LINUX", "WSL", "WIN"],
+            cuda_required=cuda_required,
+        )
+    except (IncompatibilityError, UnknownVersionError, UnsupportedOSError):
+        return
+
+    assert result.python_version == python_version
+    assert result.cuda_version == cuda_version
+    assert result.target_os == target_os
+    assert len(result.packages) == len(packages)
 
 def test_resolve_pytorch_cuda118_py311():
     result = R.resolve(


### PR DESCRIPTION
## Description
Added property-based testing for `CompatibilityResolver` using Hypothesis. This helps validate that generated combinations of package constraints, Python versions, CUDA versions, OS targets, and CUDA-required flags either resolve successfully or fail with the resolver’s structured compatibility exceptions instead of crashing unexpectedly.

## Related Issues
Fixes #187

## Changes Made
- Added `hypothesis` to backend dev dependencies
- Added a Hypothesis-based resolver test with 1000 generated examples
- Refreshed `backend/poetry.lock`

## Verification
- [x] Added unit tests
- [x] Ran `pytest tests/unit/compatibility/test_resolver.py` successfully
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted

## Screenshots (if applicable)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced compatibility resolver testing with property-based test generation to improve robustness and edge case coverage.

* **Chores**
  * Updated development dependencies and test configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->