### PR TITLE
Fix/redis resolver cache 188

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -40,6 +40,7 @@ class Settings(BaseSettings):
     # Required in production for multi-worker correctness.
     # Format: redis://:password@host:port/db  or  redis://host:port/db
     redis_url: str | None = None
+    resolver_cache_ttl_seconds: int = 86400
 
     # ── CORS ─────────────────────────────────────────────────
     allowed_origins: str = "http://localhost:3000"

--- a/backend/app/services/script_service.py
+++ b/backend/app/services/script_service.py
@@ -1,26 +1,145 @@
 """
 Script generation service — orchestrates Compatibility Engine + Template Engine.
 """
+import hashlib
+import json
+import logging
 import uuid
 from datetime import datetime
+from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.compatibility.models import PackageConstraint
+from app.cache import get_redis_client
+from app.compatibility.models import (
+    PackageConstraint,
+    ResolvedEnvironment,
+)
+from app.compatibility.models import (
+    ResolvedPackage as CompatibilityResolvedPackage,
+)
 from app.compatibility.resolver import CompatibilityResolver
+from app.config import get_settings
 from app.models.profile import EnvironmentProfile
 from app.models.script_job import GeneratedScript, ScriptGenerationJob
 from app.schemas.script import (
     GenerationRequest,
     GenerationResponse,
-    ResolvedPackage,
     ScriptPreview,
+)
+from app.schemas.script import (
+    ResolvedPackage as ResponseResolvedPackage,
 )
 from app.templates.engine import TemplateRenderer
 from app.templates.models import TemplateContext
 
 _resolver = CompatibilityResolver()
 _renderer = TemplateRenderer()
+_logger = logging.getLogger(__name__)
+
+_RESOLVER_CACHE_PREFIX = "compatibility_resolver:v1"
+
+
+def _resolver_cache_ttl_seconds() -> int:
+    return max(get_settings().resolver_cache_ttl_seconds, 1)
+
+
+def _resolver_cache_key(
+    profile: EnvironmentProfile,
+    request: GenerationRequest,
+    constraints: list[PackageConstraint],
+) -> str:
+    """Build a stable cache key for deterministic resolver inputs."""
+    payload = {
+        "profile_slug": profile.slug,
+        "target_os": request.target_os,
+        "python_version": request.python_version,
+        "cuda_version": request.cuda_version,
+        "overrides": request.overrides or {},
+        "os_support": sorted(profile.os_support),
+        "cuda_required": profile.cuda_required,
+        "packages": [
+            {
+                "name": constraint.name,
+                "version_spec": constraint.version_spec,
+                "cuda_variant": constraint.cuda_variant,
+            }
+            for constraint in constraints
+        ],
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return f"{_RESOLVER_CACHE_PREFIX}:{digest}"
+
+
+def _resolved_environment_from_dict(data: dict[str, Any]) -> ResolvedEnvironment:
+    return ResolvedEnvironment(
+        python_version=data["python_version"],
+        cuda_version=data.get("cuda_version"),
+        rocm_version=data.get("rocm_version"),
+        target_os=data["target_os"],
+        packages=[
+            CompatibilityResolvedPackage(
+                name=package["name"],
+                version=package["version"],
+                cuda_variant=package.get("cuda_variant"),
+            )
+            for package in data.get("packages", [])
+        ],
+        warnings=list(data.get("warnings", [])),
+    )
+
+
+async def _get_cached_resolved_environment(
+    cache_key: str,
+) -> ResolvedEnvironment | None:
+    try:
+        redis = await get_redis_client()
+    except Exception as exc:  # pragma: no cover - defensive cache fallback
+        _logger.warning("Redis resolver cache client unavailable: %s", exc)
+        return None
+
+    if redis is None:
+        return None
+
+    try:
+        cached = await redis.get(cache_key)
+    except Exception as exc:  # pragma: no cover - defensive cache fallback
+        _logger.warning("Redis resolver cache read failed: %s", exc)
+        return None
+
+    if cached is None:
+        return None
+
+    try:
+        return _resolved_environment_from_dict(json.loads(cached))
+    except (KeyError, TypeError, ValueError) as exc:
+        _logger.warning("Ignoring invalid resolver cache payload: %s", exc)
+        return None
+
+
+async def _cache_resolved_environment(
+    cache_key: str,
+    resolved: ResolvedEnvironment,
+) -> None:
+    try:
+        redis = await get_redis_client()
+    except Exception as exc:  # pragma: no cover - defensive cache fallback
+        _logger.warning("Redis resolver cache client unavailable: %s", exc)
+        return
+
+    if redis is None:
+        return
+
+    try:
+        await redis.set(
+            cache_key,
+            json.dumps(resolved.to_dict(), sort_keys=True),
+            ex=_resolver_cache_ttl_seconds(),
+        )
+    except Exception as exc:  # pragma: no cover - defensive cache fallback
+        _logger.warning("Redis resolver cache write failed: %s", exc)
 
 
 async def generate_scripts(
@@ -47,16 +166,20 @@ async def generate_scripts(
     ]
 
     # Step 2: Resolve compatible versions
-    resolved = _resolver.resolve(
-        packages=constraints,
-        python_version=request.python_version,
-        cuda_version=request.cuda_version,
-        target_os=request.target_os,
-        profile_slug=profile.slug,
-        os_support=list(profile.os_support),
-        cuda_required=profile.cuda_required,
-        overrides=request.overrides,
-    )
+    cache_key = _resolver_cache_key(profile, request, constraints)
+    resolved = await _get_cached_resolved_environment(cache_key)
+    if resolved is None:
+        resolved = _resolver.resolve(
+            packages=constraints,
+            python_version=request.python_version,
+            cuda_version=request.cuda_version,
+            target_os=request.target_os,
+            profile_slug=profile.slug,
+            os_support=list(profile.os_support),
+            cuda_required=profile.cuda_required,
+            overrides=request.overrides,
+        )
+        await _cache_resolved_environment(cache_key, resolved)
 
     # Step 3: Render templates
     ctx = TemplateContext(
@@ -101,7 +224,7 @@ async def generate_scripts(
         python_version=request.python_version,
         cuda_version=request.cuda_version,
         resolved_packages=[
-            ResolvedPackage(
+            ResponseResolvedPackage(
                 name=p.name,
                 version=p.version,
                 cuda_variant=p.cuda_variant,

--- a/backend/tests/unit/services/test_script_service_cache.py
+++ b/backend/tests/unit/services/test_script_service_cache.py
@@ -1,0 +1,142 @@
+"""Tests for Redis caching in the script generation service."""
+
+import json
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.compatibility.models import ResolvedEnvironment, ResolvedPackage
+from app.schemas.script import GenerationRequest
+from app.services import script_service
+
+
+class FakeDB:
+    def __init__(self) -> None:
+        self.added = []
+
+    def add(self, item) -> None:
+        self.added.append(item)
+
+    async def flush(self) -> None:
+        return None
+
+
+class FakeRedis:
+    def __init__(self, cached: str | None = None) -> None:
+        self.cached = cached
+        self.get_calls = []
+        self.set_calls = []
+
+    async def get(self, key: str) -> str | None:
+        self.get_calls.append(key)
+        return self.cached
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        self.set_calls.append((key, value, ex))
+        self.cached = value
+
+
+class FakeRenderer:
+    def render_all(self, output_formats, ctx):
+        package = ctx.resolved.packages[0]
+        return [
+            SimpleNamespace(
+                filename="requirements.txt",
+                content=f"{package.name}=={package.version}",
+                size_bytes=len(package.name) + len(package.version) + 2,
+            )
+        ]
+
+
+def _profile():
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        slug="pytorch-cuda",
+        name="PyTorch CUDA",
+        os_support=["LINUX", "WSL"],
+        cuda_required=False,
+        packages=[
+            SimpleNamespace(
+                package_name="torch",
+                version_spec="2.1.0",
+                cuda_variant=None,
+                install_order=0,
+            )
+        ],
+    )
+
+
+def _request() -> GenerationRequest:
+    return GenerationRequest(
+        profile_id="pytorch-cuda",
+        target_os="LINUX",
+        python_version="3.11",
+        cuda_version=None,
+        overrides={},
+        output_formats=["requirements.txt"],
+    )
+
+
+def _resolved(version: str = "2.1.0") -> ResolvedEnvironment:
+    return ResolvedEnvironment(
+        python_version="3.11",
+        cuda_version=None,
+        target_os="LINUX",
+        packages=[ResolvedPackage(name="torch", version=version)],
+        warnings=[],
+    )
+
+
+async def _fake_redis_client(redis: FakeRedis) -> FakeRedis:
+    return redis
+
+
+@pytest.mark.asyncio
+async def test_generate_scripts_returns_cached_resolved_environment(monkeypatch):
+    cached = _resolved(version="2.1.0")
+    redis = FakeRedis(json.dumps(cached.to_dict()))
+
+    class ResolverShouldNotRun:
+        def resolve(self, **kwargs):
+            raise AssertionError("resolver should not run on cache hit")
+
+    monkeypatch.setattr(script_service, "get_redis_client", lambda: _fake_redis_client(redis))
+    monkeypatch.setattr(script_service, "_resolver", ResolverShouldNotRun())
+    monkeypatch.setattr(script_service, "_renderer", FakeRenderer())
+
+    response = await script_service.generate_scripts(FakeDB(), _profile(), _request())
+
+    assert response.resolved_packages[0].version == "2.1.0"
+    assert response.scripts[0].content == "torch==2.1.0"
+    assert len(redis.get_calls) == 1
+    assert redis.set_calls == []
+
+
+@pytest.mark.asyncio
+async def test_generate_scripts_caches_resolved_environment_on_miss(monkeypatch):
+    redis = FakeRedis()
+
+    class CountingResolver:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def resolve(self, **kwargs):
+            self.calls += 1
+            return _resolved(version="2.2.0")
+
+    resolver = CountingResolver()
+    monkeypatch.setattr(script_service, "get_redis_client", lambda: _fake_redis_client(redis))
+    monkeypatch.setattr(script_service, "_resolver", resolver)
+    monkeypatch.setattr(script_service, "_renderer", FakeRenderer())
+
+    response = await script_service.generate_scripts(FakeDB(), _profile(), _request())
+
+    assert response.resolved_packages[0].version == "2.2.0"
+    assert resolver.calls == 1
+    assert len(redis.get_calls) == 1
+    assert len(redis.set_calls) == 1
+    cache_key, cache_value, cache_ttl = redis.set_calls[0]
+    assert cache_key.startswith("compatibility_resolver:v1:")
+    assert cache_ttl == 86400
+    assert json.loads(cache_value)["packages"][0]["version"] == "2.2.0"


### PR DESCRIPTION
## Description
Adds a Redis caching layer for deterministic `CompatibilityResolver` outputs during script generation. Since resolution depends only on the profile/package constraints plus OS, Python, CUDA, and overrides, repeated requests can reuse a cached `ResolvedEnvironment` instead of recomputing it.

If Redis is unavailable or not configured, script generation falls back to the existing resolver flow.

## Related Issues
Fixes #188

## Changes Made
- Added stable SHA-256 cache key generation for resolver inputs in `script_service.py`
- Added Redis read/write logic around `CompatibilityResolver.resolve()`
- Added cache payload hydration back into `ResolvedEnvironment`
- Added graceful fallback for Redis read/write/client failures
- Added unit tests for cache hit and cache miss behavior

## Verification
- [x] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

Notes:
- Ran syntax verification successfully:
  `python -m compileall backend\app\services\script_service.py backend\tests\unit\services\test_script_service_cache.py`
- Could not run pytest locally because `pytest` is not installed in the current environment.

## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted

## Screenshots (if applicable)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable resolver cache time-to-live (TTL) setting, defaulting to 24 hours, enabling environment-based customization of cache expiration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->