### PR TITLE
feat(cli): add --no-color flag for CI pipeline compatibility

### DIFF
--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -34,6 +34,14 @@ console = Console()
 err_console = Console(stderr=True, style="bold red")
 
 
+def _reinit_consoles(no_color: bool) -> None:
+    """Reinitialise global consoles with no-color mode if requested."""
+    global console, err_console
+    if no_color:
+        console = Console(no_color=True, highlight=False)
+        err_console = Console(stderr=True, no_color=True, highlight=False)
+
+
 def check_macos_support():
     if platform.system() == "Darwin":
         err_console.print("[ERROR] EnvForge is not currently supported on macOS.")
@@ -46,8 +54,18 @@ def check_macos_support():
 
 @click.group()
 @click.version_option(__version__, prog_name="envforge-agent")
-def cli() -> None:
+@click.option(
+    "--no-color",
+    is_flag=True,
+    default=False,
+    envvar="NO_COLOR",
+    help="Disable colour and Rich markup in all output. Useful for CI pipelines.",
+)
+@click.pass_context
+def cli(ctx: click.Context, no_color: bool) -> None:
     """EnvForge CLI Diagnostic Agent — inspect your ML environment."""
+    ctx.ensure_object(dict)
+    _reinit_consoles(no_color)
     check_macos_support()
 
 


### PR DESCRIPTION
## Description
Adds `--no-color` as a global Click option on the root `cli` group.
EnvForge CLI uses Rich for styled output which produces raw ANSI escape
codes in CI pipelines (GitHub Actions, GitLab CI, Jenkins), making logs
unreadable. This flag strips all styling from every command's output.

## Related Issues
Closes #178

## Changes Made
- `cli/envforge_agent/cli.py` only — two changes:
  - Added `_reinit_consoles(no_color)` helper that reinitialises global `console` and `err_console` with `no_color=True, highlight=False`
  - Added `--no-color` Click option to root `cli` group with `envvar="NO_COLOR"` so it also respects the standard `NO_COLOR` environment variable

## Usage
```bash
envforge --no-color diagnose     # plain text output
envforge --no-color verify       # works for all subcommands
NO_COLOR=1 envforge diagnose     # via environment variable
```

## Verification
- [ ] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [x] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

Verified `--no-color` appears in `--help` and diagnose runs cleanly:
--no-color  Disable colour and Rich markup in all output. Useful for CI
pipelines.

## Documentation
- [ ] Updated `docs/FEATURES.md`
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted

## Screenshots
<img width="1102" height="267" alt="image" src="https://github.com/user-attachments/assets/e8b75ed8-ae6e-4abd-b38e-f7d83b65e2c3" />
