### PR TITLE
fix(ui): fix dark mode dropdown option visibility on profiles page

### DIFF
--- a/frontend/src/app/profiles/page.tsx
+++ b/frontend/src/app/profiles/page.tsx
@@ -116,23 +116,23 @@ export default function ProfilesPage() {
           <select
             value={selectedOS}
             onChange={(e) => setSelectedOS(e.target.value)}
-            style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid var(--border-subtle)', borderRadius: '8px', color: 'var(--text-primary)', padding: '0.5rem 1rem', outline: 'none', cursor: 'pointer', fontSize: '0.9rem' }}
+            style={{ background: '#1e1e2e', border: '1px solid var(--border-subtle)', borderRadius: '8px', color: 'var(--text-primary)', padding: '0.5rem 1rem', outline: 'none', cursor: 'pointer', fontSize: '0.9rem' }}
           >
-            <option value="ALL">All Operating Systems</option>
-            <option value="WINDOWS">Windows</option>
-            <option value="LINUX">Linux</option>
-            <option value="WSL">WSL</option>
+            <option value="ALL" style={{ background: '#1e1e2e', color: '#e2e8f0' }}>All Operating Systems</option>
+            <option value="WINDOWS" style={{ background: '#1e1e2e', color: '#e2e8f0' }}>Windows</option>
+            <option value="LINUX" style={{ background: '#1e1e2e', color: '#e2e8f0' }}>Linux</option>
+            <option value="WSL" style={{ background: '#1e1e2e', color: '#e2e8f0' }}>WSL</option>
           </select>
 
           {/* CUDA Dropdown */}
           <select
             value={cudaFilter}
             onChange={(e) => setCudaFilter(e.target.value)}
-            style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid var(--border-subtle)', borderRadius: '8px', color: 'var(--text-primary)', padding: '0.5rem 1rem', outline: 'none', cursor: 'pointer', fontSize: '0.9rem' }}
+            style={{ background: '#1e1e2e', border: '1px solid var(--border-subtle)', borderRadius: '8px', color: 'var(--text-primary)', padding: '0.5rem 1rem', outline: 'none', cursor: 'pointer', fontSize: '0.9rem' }}
           >
-            <option value="ALL">All CUDA Configs</option>
-            <option value="REQUIRED">CUDA Required</option>
-            <option value="OPTIONAL">CPU / Non-CUDA</option>
+            <option value="ALL" style={{ background: '#1e1e2e', color: '#e2e8f0' }}>All CUDA Configs</option>
+            <option value="REQUIRED" style={{ background: '#1e1e2e', color: '#e2e8f0' }}>CUDA Required</option>
+            <option value="OPTIONAL" style={{ background: '#1e1e2e', color: '#e2e8f0' }}>CPU / Non-CUDA</option>
           </select>
         </div>
       </motion.div>


### PR DESCRIPTION
## Description
Dropdown options on the Profiles page were invisible in dark mode 
due to browser default dark-on-dark rendering of <option> elements.

## Related Issues
Closes #266

## Changes Made
- Added explicit `background: '#1e1e2e'` and `color: '#e2e8f0'` 
  to all `<option>` elements in OS and CUDA filter dropdowns in 
  `frontend/src/app/profiles/page.tsx`

## Verification
- [x] Tested in dark mode — options now clearly visible
- [x] No existing tests affected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of OS and CUDA dropdown selectors with revised background colors and improved consistency across all dropdown options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->