### PR TITLE
fix(profiles): apply filters to count query in list_profiles

### DIFF
--- a/backend/app/services/profile_service.py
+++ b/backend/app/services/profile_service.py
@@ -1,6 +1,7 @@
 """
 Profile service — business logic for profile CRUD operations.
 """
+
 import uuid
 from datetime import UTC, datetime
 
@@ -29,28 +30,36 @@ async def list_profiles(
     )
 
     if filters.os:
-        query = query.where(
-            EnvironmentProfile.os_support.contains([filters.os])
-        )
+        query = query.where(EnvironmentProfile.os_support.contains([filters.os]))
 
     if filters.cuda_required is not None:
-        query = query.where(
-            EnvironmentProfile.cuda_required == filters.cuda_required
-        )
+        query = query.where(EnvironmentProfile.cuda_required == filters.cuda_required)
 
     if filters.tags:
         for tag in filters.tags:
-            query = query.where(
-                EnvironmentProfile.tags.contains([tag])
-            )
+            query = query.where(EnvironmentProfile.tags.contains([tag]))
 
-    # Count total (before pagination)
-    count_result = await db.execute(
-        select(EnvironmentProfile.id)
+    # Count total (before pagination) — apply same filters as main query
+    from sqlalchemy import func
+
+    count_query = (
+        select(func.count(EnvironmentProfile.id))
         .where(EnvironmentProfile.deleted_at.is_(None))
         .where(EnvironmentProfile.status == "ACTIVE")
     )
-    total = len(count_result.all())
+    if filters.os:
+        count_query = count_query.where(
+            EnvironmentProfile.os_support.contains([filters.os])
+        )
+    if filters.cuda_required is not None:
+        count_query = count_query.where(
+            EnvironmentProfile.cuda_required == filters.cuda_required
+        )
+    if filters.tags:
+        for tag in filters.tags:
+            count_query = count_query.where(EnvironmentProfile.tags.contains([tag]))
+    count_result = await db.execute(count_query)
+    total = count_result.scalar_one()
 
     # Apply pagination
     offset = (filters.page - 1) * filters.limit
@@ -136,4 +145,3 @@ async def delete_profile(
         await db.rollback()
         raise
     return True
-


### PR DESCRIPTION
## Description
The `list_profiles` service function had a bug where the count query
used for pagination ignored all active filters (os, cuda_required, tags).
This caused the API to return an incorrect `total` count when filters
were applied, breaking pagination for filtered results.

## Related Issues
Closes #281

## Changes Made
- Fixed count query in `list_profiles` to apply the same filters
  as the main query (os, cuda_required, tags)
- Replaced `len(count_result.all())` with `func.count()` for
  better database efficiency
- Added `from sqlalchemy import func` import to profile_service.py

## Verification
- [x] Ran `pytest tests/` successfully — 209 passed, 0 failed
- [x] Ruff lint — zero errors
- [x] Black formatting — clean
- [x] Manually verified count matches filtered results

## Documentation
- [x] Code is fully documented and type-hinted