### PR TITLE
fix(templates): gracefully handle missing custom_template_dir

### DIFF
--- a/backend/app/templates/engine.py
+++ b/backend/app/templates/engine.py
@@ -4,6 +4,8 @@ Template Engine — renders Jinja2 templates into setup scripts.
 All rendered output passes through SafetyFilter before being returned.
 This module never executes generated code; it only renders text.
 """
+
+import logging
 from collections.abc import Sequence
 from functools import lru_cache
 from pathlib import Path
@@ -20,36 +22,45 @@ TEMPLATES_DIR = Path(__file__).parent / "jinja"
 
 # ── Template name → output filename mapping ────────────────────────────────────
 TEMPLATE_MAP: dict[str, str] = {
-    "setup.sh":           "setup/setup_linux.sh.j2",
-    "setup.ps1":          "setup/setup_windows.ps1.j2",
-    "requirements.txt":   "config/requirements.j2",
-    "Dockerfile":         "config/dockerfile.j2",
+    "setup.sh": "setup/setup_linux.sh.j2",
+    "setup.ps1": "setup/setup_windows.ps1.j2",
+    "requirements.txt": "config/requirements.j2",
+    "Dockerfile": "config/dockerfile.j2",
     "docker-compose.yml": "config/docker-compose.yml.j2",
-    "devcontainer.json":  "config/devcontainer.j2",
-    "verify.sh":          "verify/verify_generic.sh.j2",
-    "verify_torch.sh":    "verify/verify_torch.sh.j2",
-    "verify_tf.sh":       "verify/verify_tf.sh.j2",
-    "verify_opencv.sh":   "verify/verify_opencv.sh.j2",
-    "environment.yml":    "config/environment.yml.j2",
-    "pyproject.toml":     "config/pyproject.toml.j2",
+    "devcontainer.json": "config/devcontainer.j2",
+    "verify.sh": "verify/verify_generic.sh.j2",
+    "verify_torch.sh": "verify/verify_torch.sh.j2",
+    "verify_tf.sh": "verify/verify_tf.sh.j2",
+    "verify_opencv.sh": "verify/verify_opencv.sh.j2",
+    "environment.yml": "config/environment.yml.j2",
+    "pyproject.toml": "config/pyproject.toml.j2",
     "pyproject.poetry.toml": "config/poetry.toml.j2",
     ".gitignore": "config/gitignore.j2",
 }
 
 # ── Profile-specific verify template mapping ───────────────────────────────────
 PROFILE_VERIFY_TEMPLATES: dict[str, str] = {
-    "pytorch-cuda":        "verify_torch.sh",
-    "tf-gpu":              "verify_tf.sh",
-    "yolov8":              "verify_torch.sh",
-    "stable-diffusion":    "verify_torch.sh",
-    "opencv-beginner":     "verify_opencv.sh",
+    "pytorch-cuda": "verify_torch.sh",
+    "tf-gpu": "verify_tf.sh",
+    "yolov8": "verify_torch.sh",
+    "stable-diffusion": "verify_torch.sh",
+    "opencv-beginner": "verify_opencv.sh",
 }
+
 
 @lru_cache(maxsize=16)
 def _get_jinja_env(custom_template_dir: Path | None) -> SandboxedEnvironment:
     loaders = []
     if custom_template_dir:
-        loaders.append(FileSystemLoader(str(custom_template_dir)))
+        resolved_path = Path(custom_template_dir)
+        if resolved_path.exists() and resolved_path.is_dir():
+            loaders.append(FileSystemLoader(str(resolved_path)))
+        else:
+            logging.getLogger(__name__).warning(
+                "Configured custom_template_dir '%s' does not exist or is not a directory. "
+                "Falling back to defaults.",
+                custom_template_dir,
+            )
     loaders.append(FileSystemLoader(str(TEMPLATES_DIR)))
 
     return SandboxedEnvironment(
@@ -59,7 +70,6 @@ def _get_jinja_env(custom_template_dir: Path | None) -> SandboxedEnvironment:
         trim_blocks=True,
         lstrip_blocks=True,
     )
-
 
 _JINJA_ENV = _get_jinja_env(None)
 


### PR DESCRIPTION
## Description
When `custom_template_dir` was configured in settings but the directory
did not exist, `FileSystemLoader` raised a `FileNotFoundError` crashing
the FastAPI app on startup. This PR adds a path existence check before
adding the custom loader, logging a warning and falling back to defaults.

## Related Issues
Closes #283

## Changes Made
- Added `import logging` to `app/templates/engine.py`
- Added `resolved_path.exists() and resolved_path.is_dir()` check
  before adding custom loader in `_get_jinja_env`
- Logs warning when custom dir is missing, falls back to defaults

## Verification
- [x] Ran `pytest tests/` — 209 passed, 0 failed
- [x] Ruff lint — zero errors

## Documentation
- [x] Code is fully documented and type-hinted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of custom template directory configurations to ensure proper setup and graceful fallback to defaults when issues are detected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->