### PR TITLE
fix(cli): mask user home paths in DiagnosticReport

### DIFF
--- a/cli/envforge_agent/detectors/python_detector.py
+++ b/cli/envforge_agent/detectors/python_detector.py
@@ -15,6 +15,7 @@ Strategy:
 from __future__ import annotations
 
 import json
+import os
 import platform
 import subprocess
 import sys
@@ -28,6 +29,25 @@ _PROBE_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12","3.13"]
 # Inspector script run inside each discovered Python to get its full info
 _INSPECTOR = """
 import sys, json, os
+from pathlib import Path
+
+def sanitize_path(path):
+    if not path:
+        return path
+
+    home_dir = str(Path.home())
+
+    try:
+        normalized_path = os.path.normcase(os.path.normpath(path))
+        normalized_home = os.path.normcase(os.path.normpath(home_dir))
+
+        if normalized_path.startswith(normalized_home):
+            return path.replace(home_dir, "<USER_HOME>")
+    except Exception:
+        pass
+
+    return path
+
 prefix = getattr(sys, 'prefix', sys.executable)
 base = getattr(sys, 'base_prefix', prefix)
 is_venv = prefix != base
@@ -39,9 +59,9 @@ except ImportError:
     pip_ver = None
 print(json.dumps({
     "version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
-    "path": sys.executable,
+    "path": sanitize_path(sys.executable),
     "is_venv": is_venv,
-    "venv_path": venv_path,
+    "venv_path": sanitize_path(venv_path),
     "pip_version": pip_ver,
 }))
 """

--- a/cli/envforge_agent/detectors/python_detector.py
+++ b/cli/envforge_agent/detectors/python_detector.py
@@ -41,8 +41,13 @@ def sanitize_path(path):
         normalized_path = os.path.normcase(os.path.normpath(path))
         normalized_home = os.path.normcase(os.path.normpath(home_dir))
 
-        if normalized_path.startswith(normalized_home):
-            return path.replace(home_dir, "<USER_HOME>")
+        if (
+            normalized_path == normalized_home
+            or normalized_path.startswith(normalized_home + os.sep)
+        ):
+            relative_part = path[len(home_dir):]
+            return "<USER_HOME>" + relative_part
+
     except Exception:
         pass
 


### PR DESCRIPTION
## Description

This PR fixes a privacy issue in the CLI DiagnosticReport where user-specific home directory paths could be exposed during API transmission.

Previously, Python installation paths such as:
C:\Users\username\AppData\Local\Programs\Python\Python311\python.exe

were being serialized directly into report, which could unintentionally leak local usernames/PII.

This PR adds a sanitization step inside inspector runtime to replace user's home directory with a generic placeholder (<USER_HOME>) before serialization.

Example:

Before:
C:\Users\shail\AppData\Local\Programs\Python\Python311\python.exe

After:
<USER_HOME>\AppData\Local\Programs\Python\Python311\python.exe

## Related Issues
Fixes #184

## Changes Made
-added sanitize_path() helper inside _INSPECTOR
-masked user home directory paths before JSON serialization
-Sanitized:
      -sys.executable
      -venv_path
-used normalized path comparison for cross-platform consistency


## Verification
- [x] Manually tested sanitization logic locally  
- [x] Verified `<USER_HOME>` replacement works correctly  
- [x] Verified non-user system paths remain unchanged  
- [x] Confirmed JSON serialization still works properly  
- [x] Tested masking behavior for both `sys.executable` and `venv_path`  
- [ ] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [x] Code changes are documented and readable  
- [x] Existing functionality remains unaffected  
- [ ] No additional documentation update required for this fix  
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted

## Screenshots (if applicable)
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Python environment detection output security by sanitizing sensitive filesystem paths. Paths under the user home directory are now normalized and replaced with a placeholder to prevent exposure of sensitive directory structure information in environment reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->