### PR TITLE
fix: pass rocm_version to _resolve_with_override preventing silent ROCm validation bypass and incorrect GPU variant resolution

### DIFF
--- a/backend/app/api/v1/diagnose.py
+++ b/backend/app/api/v1/diagnose.py
@@ -68,7 +68,7 @@ async def diagnose(
         gpu_name=report.gpus[0].name if report.gpus else None,
         cuda_version=report.cuda.version if report.cuda else None,
         rocm_version=report.rocm.version if report.rocm else None,
-        python_version=report.active_python.version[:4]
+        python_version=".".join(report.active_python.version.split(".")[:2])
         if report.active_python
         else None,
         driver_version=report.gpus[0].driver_version if report.gpus else None,

--- a/backend/app/compatibility/resolver.py
+++ b/backend/app/compatibility/resolver.py
@@ -205,6 +205,7 @@ class CompatibilityResolver:
                 override_version=override_version,
                 python_version=python_version,
                 cuda_version=cuda_version,
+                rocm_version=rocm_version,
             )
 
         # Use version from profile spec (treat as exact version if no range)

--- a/backend/tests/unit/compatibility/test_resolver.py
+++ b/backend/tests/unit/compatibility/test_resolver.py
@@ -233,3 +233,36 @@ def test_cuda_125_126_in_supported_versions():
     from app.compatibility.matrix.cuda import SUPPORTED_CUDA_VERSIONS
     assert "12.5" in SUPPORTED_CUDA_VERSIONS
     assert "12.6" in SUPPORTED_CUDA_VERSIONS
+
+
+def test_rocm_version_override_success():
+    result = R.resolve(
+        packages=[PackageConstraint("torch", "2.0.0")],
+        python_version="3.10",
+        cuda_version=None,
+        rocm_version="5.6.0",
+        target_os="LINUX",
+        profile_slug="pytorch-rocm",
+        os_support=["LINUX"],
+        rocm_required=True,
+        overrides={"torch": "2.1.0"},
+    )
+    assert result.packages[0].version == "2.1.0"
+    assert result.packages[0].cuda_variant == "rocm5.6.0"
+
+
+def test_rocm_version_override_failure():
+    with pytest.raises(IncompatibilityError) as exc:
+        R.resolve(
+            packages=[PackageConstraint("torch", "2.1.0")],
+            python_version="3.10",
+            cuda_version=None,
+            rocm_version="5.6.0",
+            target_os="LINUX",
+            profile_slug="pytorch-rocm",
+            os_support=["LINUX"],
+            rocm_required=True,
+            overrides={"torch": "2.4.0"},  # 2.4.0 only supports ROCm 6.0.0
+        )
+    assert exc.value.component == "rocm"
+


### PR DESCRIPTION
Closes #321

## Summary

Fixes a critical silent bug where ROCm (AMD GPU) compatibility validation and GPU variant resolution are completely bypassed when a user specifies a package version override. This causes AMD GPU environments to silently receive CPU-only wheel install commands instead of the correct ROCm-accelerated wheels.

## Root Cause

In `backend/app/compatibility/resolver.py`, the `_resolve_package()` method delegates to `_resolve_with_override()` when the user specifies a version override. However, **`rocm_version` was not passed** to `_resolve_with_override()`:

```python
# BEFORE (broken):
return self._resolve_with_override(
    package_name=package_name,
    override_version=override_version,
    python_version=python_version,
    cuda_version=cuda_version,
    # ❌ rocm_version omitted — defaults to None!
)
```

This causes three cascading failures:
1. `_resolve_with_override` defaults `rocm_version` to `None`
2. ROCm version compatibility validation is skipped entirely (e.g., PyTorch 2.4.0 requires ROCm 6.0.0, but ROCm 5.6.0 would pass unchecked)
3. `_resolve_gpu_variant` resolves the GPU suffix as `None` instead of `"rocm5.6.0"`, generating CPU-only pip install commands

## Fix

### `backend/app/compatibility/resolver.py`
Pass `rocm_version` through to `_resolve_with_override`:
```python
# AFTER (fixed):
return self._resolve_with_override(
    package_name=package_name,
    override_version=override_version,
    python_version=python_version,
    cuda_version=cuda_version,
    rocm_version=rocm_version,  # ✅ Now passed correctly
)
```

### `backend/app/api/v1/diagnose.py`
Also fixed a secondary bug: `python_version=report.active_python.version[:4]` uses a naive character slice which produces incorrect results for double-digit minor versions (e.g., `"3.13.5"[:4]` → `"3.13"` ✅, but `"3.9.7"[:4]` → `"3.9."` ❌ with trailing dot). Replaced with a robust `.split(".")[:2]` join.

### `backend/tests/unit/compatibility/test_resolver.py`
Added two dedicated unit tests:
- **`test_rocm_version_override_success`**: Asserts that a valid ROCm version override correctly resolves the package version AND the GPU variant suffix (`"rocm5.6.0"`)
- **`test_rocm_version_override_failure`**: Asserts that specifying an incompatible override (e.g., torch 2.4.0 on ROCm 5.6.0, which only supports ROCm 6.0.0) raises an `IncompatibilityError` with component `"rocm"`

## Testing

All 22 resolver unit tests pass, including the 2 new ROCm override tests:
```
backend/tests/unit/compatibility/test_resolver.py   22 passed in 12.15s
```

All modified files compile cleanly with `python -m py_compile`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Python version reporting in diagnostic information to use proper version format.
  * Improved ROCm compatibility checking when resolving packages with custom versions.

* **Tests**
  * Added test coverage for ROCm version override behavior in package compatibility resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->