### PR TITLE
[NSOC'26][GSSOC'26][SSOC'26]Expand ROCm Compatibility Matrix to support ROCm 6.1 and 6.2

### DIFF
--- a/backend/app/compatibility/matrix/python.py
+++ b/backend/app/compatibility/matrix/python.py
@@ -77,14 +77,14 @@ PYTHON_MATRIX: dict[str, list[FrameworkVersionEntry]] = {
             min_python="3.8", max_python="3.12",
             supported_python=["3.8", "3.9", "3.10", "3.11", "3.12"],
             supported_cuda=["11.8", "12.1", "12.4"],
-            supported_rocm=["6.0.0"],
+            supported_rocm=["6.0.0", "6.1.0"],
         ),
         FrameworkVersionEntry(
             framework="torch", version="2.5.0",
             min_python="3.9", max_python="3.13",
             supported_python=["3.9", "3.10", "3.11", "3.12", "3.13"],
             supported_cuda=["11.8", "12.1", "12.4"],
-            supported_rocm=["6.0.0"],
+            supported_rocm=["6.2.0"],
         ),
     ],
     "tensorflow": [

--- a/backend/app/compatibility/matrix/rocm.py
+++ b/backend/app/compatibility/matrix/rocm.py
@@ -36,6 +36,18 @@ ROCM_MATRIX: dict[str, ROCMMatrixEntry] = {
         supported_gpus=["gfx906", "gfx908", "gfx90a", "gfx940", "gfx1030", "gfx1100"],
         notes="Latest stable. Significant performance boost for LLMs.",
     ),
+    "6.1.0": ROCMMatrixEntry(
+        rocm_version="6.1.0",
+        min_driver_linux="6.7",
+        supported_gpus=["gfx90a", "gfx942", "gfx1030", "gfx1100", "gfx1102"],
+        notes="Added support for MI300X and Radeon RX 7900 GRE.",
+    ),
+    "6.2.0": ROCMMatrixEntry(
+        rocm_version="6.2.0",
+        min_driver_linux="6.8",
+        supported_gpus=["gfx90a", "gfx942", "gfx1030", "gfx1100", "gfx1102", "gfx1150"],
+        notes="Latest stable release. Support for PyTorch 2.4+.",
+    ),
 }
 
 SUPPORTED_ROCM_VERSIONS: list[str] = sorted(ROCM_MATRIX.keys())
@@ -48,7 +60,8 @@ FRAMEWORK_ROCM_SUPPORT: dict[str, dict[str, list[str]]] = {
         "2.1.0": ["5.4.2", "5.6.0"],
         "2.2.0": ["5.6.0", "5.7.0"],
         "2.3.0": ["5.7.0", "6.0.0"],
-        "2.4.0": ["6.0.0"],
+        "2.4.0": ["6.0.0", "6.1.0"],
+        "2.5.0": ["6.2.0"],
     },
     "tensorflow": {
         "2.13.0": ["5.4.2"],

--- a/backend/seeds/rocm_matrix.yaml
+++ b/backend/seeds/rocm_matrix.yaml
@@ -15,6 +15,14 @@ rocm_matrix:
     min_driver_linux: "6.5"
     supported_gpus: [gfx906, gfx908, gfx90a, gfx940, gfx1030, gfx1100]
     notes: "Latest stable. Significant performance boost for LLMs."
+  - rocm_version: "6.1.0"
+    min_driver_linux: "6.7"
+    supported_gpus: [gfx90a, gfx942, gfx1030, gfx1100, gfx1102]
+    notes: "Added support for MI300X and Radeon RX 7900 GRE."
+  - rocm_version: "6.2.0"
+    min_driver_linux: "6.8"
+    supported_gpus: [gfx90a, gfx942, gfx1030, gfx1100, gfx1102, gfx1150]
+    notes: "Latest stable release. Support for PyTorch 2.4+."
 
 framework_rocm_support:
   torch:
@@ -22,7 +30,8 @@ framework_rocm_support:
     "2.1.0": ["5.4.2", "5.6.0"]
     "2.2.0": ["5.6.0", "5.7.0"]
     "2.3.0": ["5.7.0", "6.0.0"]
-    "2.4.0": ["6.0.0"]
+    "2.4.0": ["6.0.0", "6.1.0"]
+    "2.5.0": ["6.2.0"]
   tensorflow:
     "2.13.0": ["5.4.2"]
     "2.14.0": ["5.6.0"]

--- a/backend/tests/test_rocm_matrix.py
+++ b/backend/tests/test_rocm_matrix.py
@@ -26,6 +26,8 @@ def test_get_rocm_entry_invalid():
     [
         ("torch", "2.0.0", ["5.4.2"]),
         ("torch", "2.3.0", ["5.7.0", "6.0.0"]),
+        ("torch", "2.4.0", ["6.0.0", "6.1.0"]),
+        ("torch", "2.5.0", ["6.2.0"]),
         ("tensorflow", "2.14.0", ["5.6.0"]),
     ],
 )
@@ -58,6 +60,8 @@ def test_supported_rocm_versions_sorted():
         ("5.6.0", "gfx1100"),
         ("5.7.0", "gfx1101"),
         ("6.0.0", "gfx940"),
+        ("6.1.0", "gfx942"),
+        ("6.2.0", "gfx1150"),
     ],
 )
 def test_gpu_architecture_mapping(rocm_version, gpu_arch):


### PR DESCRIPTION
## Description
This PR expands the ROCm compatibility matrix to include AMD's ROCm versions `6.1.0` and `6.2.0`. These versions are required to support newer GPU architectures (like MI300X, Radeon RX 7900 GRE, and gfx1150) and are mapped to PyTorch `2.4.0` / `2.5.0`.

## Related Issues
Resolves #288

## Changes Made
- Added ROCm `6.1.0` and `6.2.0` entries to the core `ROCM_MATRIX` registry in [rocm.py](file:///e:/OPEN%20SOURCE/EnvForage/backend/app/compatibility/matrix/rocm.py) with their driver limits and supported AMD GPU architectures.
- Mapped framework compatibility in both [rocm.py](file:///e:/OPEN%20SOURCE/EnvForage/backend/app/compatibility/matrix/rocm.py) and [python.py](file:///e:/OPEN%20SOURCE/EnvForage/backend/app/compatibility/matrix/python.py): PyTorch `2.4.0` now supports both ROCm `6.0.0` and `6.1.0`, and PyTorch `2.5.0` supports ROCm `6.2.0`.
- Kept the seed specifications in sync by updating [rocm_matrix.yaml](file:///e:/OPEN%20SOURCE/EnvForage/backend/seeds/rocm_matrix.yaml).
- Added test coverage in [test_rocm_matrix.py](file:///e:/OPEN%20SOURCE/EnvForage/backend/tests/test_rocm_matrix.py) to verify the new GPU architectures (`gfx942`, `gfx1150`) and framework mappings.

## Verification
- [x] Added unit tests
- [x] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ROCm versions 6.1.0 and 6.2.0 with GPU architecture specifications and driver requirements.
  * Extended PyTorch 2.4.0 compatibility to support ROCm 6.1.0.
  * Added PyTorch 2.5.0 support for ROCm 6.2.0.

* **Tests**
  * Expanded test coverage for PyTorch and ROCm compatibility mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->