### PR TITLE
fix: resolve asyncio.run() RuntimeError in async context

### DIFF
--- a/backend/app/templates/safety.py
+++ b/backend/app/templates/safety.py
@@ -6,6 +6,7 @@ returning scripts to the client. This is a hard safety gate —
 no script passes without this validation.
 """
 import asyncio
+import concurrent.futures
 import logging
 import re
 
@@ -16,7 +17,6 @@ from app.ai.providers.base import LLMProvider
 logger = logging.getLogger(__name__)
 
 FORBIDDEN_PATTERNS: list[tuple[str, str]] = [
-    # Pattern, Description
     (r"rm\s+-[rRf]{1,3}\s+/", "Recursive delete of filesystem path"),
     (r"rm\s+-[rRf]{1,3}\s+\$HOME", "Recursive delete of home directory"),
     (r"rm\s+-[rRf]{1,3}\s+~", "Recursive delete of home directory (tilde)"),
@@ -98,13 +98,30 @@ def validate_rendered_output(
                     "LLM client does not implement a recognized completion method."
                 )
 
-            verdict = asyncio.run(
-                method_to_call(
-                    system_prompt=system_prompt,
-                    user_message=user_message,
-                    response_model=AISafetyVerdict,
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+
+            if loop and loop.is_running():
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    future = pool.submit(
+                        asyncio.run,
+                        method_to_call(
+                            system_prompt=system_prompt,
+                            user_message=user_message,
+                            response_model=AISafetyVerdict,
+                        )
+                    )
+                    verdict = future.result()
+            else:
+                verdict = asyncio.run(
+                    method_to_call(
+                        system_prompt=system_prompt,
+                        user_message=user_message,
+                        response_model=AISafetyVerdict,
+                    )
                 )
-            )
 
             if not verdict.is_safe:
                 raise SafetyViolationError(


### PR DESCRIPTION
## Problem
`asyncio.run()` inside `validate_rendered_output` 
raises `RuntimeError` when called from an active 
async event loop (e.g., FastAPI).

## Fix
Added a check using `asyncio.get_running_loop()`.
If a loop is already running, the coroutine is 
executed in a ThreadPoolExecutor instead.

## Changes
- Added `concurrent.futures` import
- Replaced direct `asyncio.run()` with loop-aware 
  execution using ThreadPoolExecutor

Fixes #276