### PR TITLE
fix(agent): parse cudnn header line by line

### DIFF
--- a/cli/envforge_agent/detectors/cuda_detector.py
+++ b/cli/envforge_agent/detectors/cuda_detector.py
@@ -222,14 +222,31 @@ def _detect_cudnn(toolkit_path: str | None) -> str | None:
 def _parse_cudnn_header(header_path: Path) -> str | None:
     """Extract major.minor.patch from a cuDNN header file."""
     try:
-        content = header_path.read_text(encoding="utf-8", errors="ignore")
-        major = re.search(r"#define\s+CUDNN_MAJOR\s+(\d+)", content)
-        minor = re.search(r"#define\s+CUDNN_MINOR\s+(\d+)", content)
-        patch = re.search(r"#define\s+CUDNN_PATCHLEVEL\s+(\d+)", content)
-        if major and minor and patch:
-            return f"{major.group(1)}.{minor.group(1)}.{patch.group(1)}"
-    except (FileNotFoundError, PermissionError):
-        pass
+        major, minor, patch = None, None, None
+
+        with header_path.open("r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                if major is None:
+                    match = re.search(r"#define\s+CUDNN_MAJOR\s+(\d+)", line)
+                    if match:
+                        major = match.group(1)
+
+                if minor is None:
+                    match = re.search(r"#define\s+CUDNN_MINOR\s+(\d+)", line)
+                    if match:
+                        minor = match.group(1)
+
+                if patch is None:
+                    match = re.search(r"#define\s+CUDNN_PATCHLEVEL\s+(\d+)", line)
+                    if match:
+                        patch = match.group(1)
+
+                if major and minor and patch:
+                    return f"{major}.{minor}.{patch}"
+
+    except (FileNotFoundError, PermissionError, OSError):
+        return None
+
     return None
 
 


### PR DESCRIPTION
## Description

Fixed a memory issue in `_parse_cudnn_header`.

Earlier, the function was reading the entire cuDNN header file at once using `read_text()`. This could cause high memory usage if the file was very large or corrupted.

Now the file is read line-by-line, and the function stops as soon as the required cuDNN version values are found.

## Related Issues

Fixes #304

## Changes Made

* Replaced `read_text()` with line-by-line parsing
* Added early stopping after finding cuDNN version macros
* Improved handling for large files

## Verification

* [ ] Added unit tests
* [ ] Ran `pytest tests/` successfully
* [x] Manually tested via CLI
* [ ] (If applicable) Generated scripts pass `SafetyFilter`

>Note: `pytest tests/` currently shows 1 unrelated failing test in `TestPythonDetector.test_inspector_parses_version`, which is unrelated to this CUDA parsing change.

## Documentation

* [ ] Updated `docs/FEATURES.md` (not needed)
* [ ] Updated `CHANGELOG.md`
* [x] Code is documented and type-hinted



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cuDNN version detection reliability and error handling for edge cases, ensuring the detector gracefully handles additional error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->