### PR TITLE
test(profiles): add require_admin unit tests, wrong-key integration tests, and audit logging

### DIFF
--- a/backend/app/api/v1/profiles.py
+++ b/backend/app/api/v1/profiles.py
@@ -150,8 +150,10 @@ async def create_profile(
     """
     Create a new environment profile.
     """
+    logger.info("Admin write: creating profile slug=%s", profile_in.slug)
     try:
         profile = await profile_service.create_profile(db, profile_in)
+        logger.info("Profile created: slug=%s", profile.slug)
         return ProfileDetailSchema.model_validate(profile)
     except IntegrityError as exc:
         await db.rollback()
@@ -188,9 +190,11 @@ async def delete_profile(
     """
     Soft delete a profile by slug.
     """
+    logger.info("Admin write: deleting profile slug=%s", slug)
     deleted = await profile_service.delete_profile(db, slug)
     if not deleted:
         raise EntityNotFoundError(
             resource=f"Profile '{slug}'",
             error_code="PROFILE_NOT_FOUND",
         )
+    logger.info("Profile deleted: slug=%s", slug)

--- a/backend/tests/integration/test_profiles.py
+++ b/backend/tests/integration/test_profiles.py
@@ -181,3 +181,25 @@ async def test_delete_profile_without_admin_key_returns_401(client):
     """Test that DELETE /api/v1/profiles/{slug} without an admin key returns 401."""
     response = await client.delete("/api/v1/profiles/any-slug")
     assert response.status_code == 401
+
+
+async def test_create_profile_with_wrong_admin_key_returns_401(client):
+    """Test that POST /api/v1/profiles with an incorrect admin key returns 401."""
+    wrong_headers = {"X-Admin-API-Key": "this-is-not-the-right-key"}
+    profile_data = {
+        "slug": "wrong-key-test",
+        "name": "Wrong Key Test",
+        "os_support": ["LINUX"],
+        "python_versions": ["3.11"],
+    }
+    response = await client.post("/api/v1/profiles", json=profile_data, headers=wrong_headers)
+    assert response.status_code == 401
+    assert response.json()["detail"]["error"]["code"] == "INVALID_ADMIN_KEY"
+
+
+async def test_delete_profile_with_wrong_admin_key_returns_401(client):
+    """Test that DELETE /api/v1/profiles/{slug} with an incorrect admin key returns 401."""
+    wrong_headers = {"X-Admin-API-Key": "this-is-not-the-right-key"}
+    response = await client.delete("/api/v1/profiles/any-slug", headers=wrong_headers)
+    assert response.status_code == 401
+    assert response.json()["detail"]["error"]["code"] == "INVALID_ADMIN_KEY"

--- a/backend/tests/unit/test_require_admin.py
+++ b/backend/tests/unit/test_require_admin.py
@@ -1,0 +1,71 @@
+"""Unit tests for the require_admin dependency in app.api.deps."""
+import os
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.deps import require_admin
+
+# The test suite conftest.py sets ADMIN_API_KEY to this value.
+_VALID_KEY = os.environ.get("ADMIN_API_KEY", "test-admin-key-for-ci")
+
+
+class TestRequireAdmin:
+    """Covers all branches of require_admin: valid key, missing key, wrong key, unconfigured."""
+
+    @pytest.mark.asyncio
+    async def test_valid_key_passes(self):
+        """A matching key should return None without raising."""
+        result = await require_admin(x_admin_api_key=_VALID_KEY)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_missing_key_raises_401(self):
+        """Absent header (None) must raise 401."""
+        with pytest.raises(HTTPException) as exc_info:
+            await require_admin(x_admin_api_key=None)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_wrong_key_raises_401(self):
+        """An incorrect key must raise 401."""
+        with pytest.raises(HTTPException) as exc_info:
+            await require_admin(x_admin_api_key="completely-wrong-key")
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_empty_key_raises_401(self):
+        """An empty string key must be rejected with 401."""
+        with pytest.raises(HTTPException) as exc_info:
+            await require_admin(x_admin_api_key="")
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_www_authenticate_header_on_failure(self):
+        """The 401 response must include the WWW-Authenticate header."""
+        with pytest.raises(HTTPException) as exc_info:
+            await require_admin(x_admin_api_key=None)
+        assert "WWW-Authenticate" in exc_info.value.headers
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_key_raises_503(self, monkeypatch):
+        """When ADMIN_API_KEY is not configured the server must return 503."""
+        monkeypatch.setenv("ADMIN_API_KEY", "")
+        # Bust the lru_cache so get_settings() re-reads the env.
+        from app.config import get_settings
+        get_settings.cache_clear()
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                await require_admin(x_admin_api_key="any-key")
+            assert exc_info.value.status_code == 503
+        finally:
+            # Restore so subsequent tests are not affected.
+            get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_partial_key_prefix_raises_401(self):
+        """A key that is a prefix of the correct key must not pass."""
+        partial = _VALID_KEY[:4] if len(_VALID_KEY) > 4 else _VALID_KEY + "x"
+        with pytest.raises(HTTPException) as exc_info:
+            await require_admin(x_admin_api_key=partial)
+        assert exc_info.value.status_code == 401


### PR DESCRIPTION
## Summary

The `require_admin` dependency introduced in PR #355 had no dedicated test coverage, and the `create_profile` / `delete_profile` handlers produced no log output when admin write operations were performed, making it impossible to attribute changes from application logs.

This PR adds:

- **7 unit tests** for `require_admin` covering every branch: valid key, missing key, wrong key, empty key, partial-prefix key, `WWW-Authenticate` header presence on failure, and the 503 path when `ADMIN_API_KEY` is not configured in the environment.
- **2 new integration test cases** that were absent from the existing `test_profiles.py`: POST and DELETE with a non-empty but incorrect admin key both return 401 with error code `INVALID_ADMIN_KEY`.
- **Audit logging** in `create_profile` and `delete_profile` so every admin write is visible in application logs with the affected slug.

Closes #324

## Files Changed

- `backend/tests/unit/test_require_admin.py` (new): 7 unit tests for all branches of `require_admin`
- `backend/tests/integration/test_profiles.py`: 2 new wrong-key rejection tests
- `backend/app/api/v1/profiles.py`: structured `logger.info` calls on admin write paths

## Testing

```bash
# Unit tests
pytest tests/unit/test_require_admin.py -v

# Integration tests
pytest tests/integration/test_profiles.py -v
```

All 7 unit tests pass locally. All existing integration tests continue to pass.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] I have added tests covering the new behaviour
- [x] There are no merge conflicts with the base branch
- [x] All functional CI checks are passing
- [x] This PR is linked to the correct issue

Could you please add the appropriate NSoC'26 label to this PR? It helps with tracking and scoring. Thank you!