### PR TITLE
fix: add pool_recycle to database engine

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -28,6 +28,7 @@ def _make_engine() -> AsyncEngine:
         pool_pre_ping=True,
         pool_size=10,
         max_overflow=20,
+        pool_recycle=1800,
         connect_args={
             "prepared_statement_cache_size": 0,
             "statement_cache_size": 0,


### PR DESCRIPTION
## Description

Adds `pool_recycle=1800` to the SQLAlchemy async engine configuration.

This helps prevent stale database connections from being reused after long idle periods, improving reliability when using cloud-hosted PostgreSQL providers such as Supabase, AWS RDS, and Render.

## Related Issues

Fixes #292

## Changes Made

* Added `pool_recycle=1800` to the database engine configuration
* Improved handling of idle database connections to reduce transient connection dropouts

## Verification

* [ ] Added unit tests
* [ ] Ran `pytest tests/` successfully
* [x] Manually verified the database engine configuration update
* [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation

* [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
* [ ] Updated `CHANGELOG.md`
* [x] Code is fully documented and type-hinted

## Screenshots (if applicable)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database connection stability through enhanced connection lifecycle management to ensure more reliable database interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->