### PR TITLE
fix: detect_disk Windows drive path and missing disk field in DiagnosticReport

### DIFF
--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -183,12 +183,11 @@ def _print_report_summary(report: DiagnosticReport) -> None:
     elif report.ram.total_gb < 16:
         ram_str += "  [yellow][!] WARNING: Under 16 GB — some ML profiles may be slow[/]"
     table.add_row("RAM", ram_str)
-    
-    disk = detect_disk()
-    disk_str = f"{disk['free_gb']} GB free of {disk['total_gb']} GB"
-    if disk["free_gb"] < 5:
+
+    disk_str = f"{report.disk.available_gb:.1f} GB free of {report.disk.total_gb:.1f} GB"
+    if report.disk.available_gb < 5:
         disk_str += "  [bold red]⚠ CRITICAL: Under 5 GB — setup will likely fail[/]"
-    elif disk["free_gb"] < 20:
+    elif report.disk.available_gb < 20:
         disk_str += "  [yellow]⚠ WARNING: Low disk space — GPU profiles need 20+ GB[/]"
     table.add_row("Disk Free", disk_str)
 

--- a/cli/envforge_agent/detectors/__init__.py
+++ b/cli/envforge_agent/detectors/__init__.py
@@ -4,7 +4,7 @@ from envforge_agent.detectors.gpu_detector import detect_gpus
 from envforge_agent.detectors.os_detector import detect_os
 from envforge_agent.detectors.python_detector import detect_python
 from envforge_agent.detectors.rocm_detector import detect_rocm
-from envforge_agent.detectors.system_detector import detect_cpu, detect_ram
+from envforge_agent.detectors.system_detector import detect_cpu, detect_ram, detect_disk
 
 __all__ = [
     "detect_os",
@@ -13,5 +13,6 @@ __all__ = [
     "detect_gpus",
     "detect_cuda",
     "detect_rocm",
+    "detect_disk",
     "detect_python",
 ]

--- a/cli/envforge_agent/detectors/system_detector.py
+++ b/cli/envforge_agent/detectors/system_detector.py
@@ -10,7 +10,7 @@ import platform
 import shutil
 import psutil
 
-from envforge_agent.schemas import CPUInfo, RAMInfo
+from envforge_agent.schemas import CPUInfo, RAMInfo, DISKInfo
 
 
 def detect_cpu() -> CPUInfo:
@@ -71,18 +71,24 @@ def _get_cpu_brand() -> str:
     brand = platform.processor()
     return brand if brand else "Unknown CPU"
 
-def detect_disk() -> dict[str, float]:
+def detect_disk() -> DISKInfo:
     """
     Detect available disk space using shutil.
 
     Returns:
-        dict with total_gb and free_gb (rounded to 2 decimal places).
+        DISKInfo with total_gb and available_gb (rounded to 2 decimal places).
         Falls back to zeroes on any failure.
     """
     try:
-        usage = shutil.disk_usage("/")
+        import os
+        if platform.system() == "Windows":
+            root_path = os.environ.get("SystemDrive", "C:") + "\\"
+        else:
+            root_path = "/"
+
+        usage = shutil.disk_usage(root_path)
         total_gb = round(usage.total / (1024 ** 3), 2)
         free_gb = round(usage.free / (1024 ** 3), 2)
-        return {"total_gb": total_gb, "free_gb": free_gb}
+        return DISKInfo(total_gb=total_gb, available_gb=free_gb)
     except Exception:
-        return {"total_gb": 0.0, "free_gb": 0.0}
+        return DISKInfo(total_gb=0.0, available_gb=0.0)

--- a/cli/envforge_agent/report.py
+++ b/cli/envforge_agent/report.py
@@ -16,6 +16,7 @@ from envforge_agent.detectors import (
     detect_python,
     detect_ram,
     detect_rocm,
+    detect_disk,
 )
 from envforge_agent.schemas import DiagnosticReport
 
@@ -49,6 +50,7 @@ class ReportBuilder:
         gpus = detect_gpus(timeout=self._timeout)
         cuda_info = detect_cuda(timeout=self._timeout)
         rocm_info = detect_rocm()
+        disk_info = detect_disk()
         installations, active_python = detect_python()
 
         return DiagnosticReport(
@@ -58,6 +60,7 @@ class ReportBuilder:
             gpus=gpus,
             cuda=cuda_info,
             rocm=rocm_info,
+            disk=disk_info,
             python_installations=installations,
             active_python=active_python,
         )

--- a/cli/envforge_agent/schemas.py
+++ b/cli/envforge_agent/schemas.py
@@ -53,6 +53,11 @@ class ROCMInfo(BaseModel):
     gcn_arch: str | None = None      # e.g. "gfx1030"
 
 
+class DISKInfo(BaseModel):
+    total_gb: float = 0.0
+    available_gb: float = 0.0
+
+
 class PythonInfo(BaseModel):
     version: str
     path: str
@@ -75,6 +80,7 @@ class DiagnosticReport(BaseModel):
     gpus: list[GPUInfo] = Field(default_factory=list)
     cuda: CUDAInfo = Field(default_factory=CUDAInfo)
     rocm: ROCMInfo = Field(default_factory=ROCMInfo)
+    disk: DISKInfo = Field(default_factory=DISKInfo)
     python_installations: list[PythonInfo] = Field(default_factory=list)
     active_python: PythonInfo | None = None
 
@@ -136,6 +142,7 @@ class DiagnosticReport(BaseModel):
                         "ram_gb": self.ram.total_gb,
                         "python": self.active_python.version if self.active_python else None,
                         "cuda": self.cuda.version,
+                        "disk": self.disk.total_gb
                     },
                 }
             ],


### PR DESCRIPTION
## Description
On Windows, `detect_disk()` was using `"/"` as the path for `shutil.disk_usage()`, which resolves to the current working directory's drive instead of the system drive. Running `envforge diagnose` from `D:\` would report `D:\` disk space instead of `C:\`. Additionally, `DISKInfo` was never wired into `DiagnosticReport`, so disk info was missing from both the terminal summary table and the JSON output entirely.

## Related Issues
Fixes #296

## Changes Made
- Fix `detect_disk()` in `system_detector.py` to use `os.environ.get("SystemDrive", "C:")` on Windows instead of hardcoded `"/"`
- Add `DISKInfo` model to `schemas.py` with safe defaults (`0.0`) and `disk` field to `DiagnosticReport`
- Wire `detect_disk()` into `ReportBuilder.build()` in `report.py` and pass result to `DiagnosticReport`
- Update `_print_report_summary()` in `cli.py` to use `report.disk` instead of calling `detect_disk()` directly
- Remove unused `detect_disk` import from `cli.py`

## Verification
<!-- Describe how you verified that your changes work. -->
- [ ] Added unit tests
- [x] Ran `pytest tests/` successfully
- [x] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced diagnostic reports now include disk capacity and available space metrics with improved formatting
  * Strengthened cross-platform disk detection support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->