### PR TITLE
fix: buffer stream chunks to handle UTF-8 multi-byte chars at boundaries

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -82,22 +82,34 @@ export const api = {
     }
 
     const reader = response.body.getReader();
-    const decoder = new TextDecoder();
+    const decoder = new TextDecoder('utf-8');
     let fullContent = '';
+    let buffer = '';
 
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
 
-      const chunk = decoder.decode(value, { stream: true });
-      const lines = chunk.split('\n');
-      
+      const chunk = decoder.decode(value, { stream: !done });
+      buffer += chunk;
+
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
       for (const line of lines) {
         if (line.startsWith('data: ')) {
           const token = line.slice(6);
           fullContent += token;
           onToken(token);
         }
+      }
+
+      if (done) {
+        if (buffer.startsWith('data: ')) {
+          const token = buffer.slice(6);
+          fullContent += token;
+          onToken(token);
+        }
+        break;
       }
     }
 


### PR DESCRIPTION
## Description
Fixed a bug in `frontend/src/services/api.ts` where multi-byte UTF-8 characters (emojis, smart quotes, etc.) split across network chunk boundaries were being decoded incorrectly, producing replacement characters (`?`) in the streaming UI.
The fix introduces a `buffer` variable that accumulates decoded chunks before splitting on newlines, ensuring partial lines are held over to the next iteration rather than processed immediately. `TextDecoder` is now instantiated with an explicit `'utf-8'` encoding and `{ stream: !done }` so the decoder correctly handles byte sequences that span chunk boundaries.

## Related Issues
Fixes #294 

## Changes Made
- Added a `buffer` string to accumulate decoded stream data before line-splitting
- Changed `new TextDecoder()` to `new TextDecoder('utf-8')` for explicit encoding
- Moved `if (done) break` to after processing so the final chunk is never skipped

## Verification
- Manually reviewed the logic against the streaming reader pattern
- `npm run lint` — passed with no errors
- `npm run build` — compiled successfully (Next.js 16.2.6, TypeScript clean)

## Documentation
- No feature or profile changes, docs update not required
- No new public API surface, changelog entry not required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved streaming data handling to ensure complete and reliable token delivery by properly processing partial data chunks, preventing potential data loss during streaming operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->