### PR TITLE
fix: prevent partial profile inserts in seed service

### DIFF
--- a/backend/app/services/seed_service.py
+++ b/backend/app/services/seed_service.py
@@ -95,34 +95,44 @@ async def seed_profiles(db: AsyncSession) -> None:
             skipped += 1
             continue
 
-        profile = EnvironmentProfile(
-            slug=profile_data.slug,
-            name=profile_data.name,
-            description=profile_data.description,
-            tags=profile_data.tags,
-            os_support=profile_data.os_support,
-            cuda_required=profile_data.cuda_required,
-            python_versions=profile_data.python_versions,
-            cuda_versions=profile_data.cuda_versions,
-            status=profile_data.status,
-            last_validated=profile_data.last_validated,
-        )
-        db.add(profile)
-        await db.flush()
-
-        for pkg in profile_data.packages:
-            db.add(
-                ProfilePackage(
-                    profile_id=profile.id,
-                    package_name=pkg.name,
-                    version_spec=pkg.version_spec,
-                    cuda_variant=pkg.cuda_variant,
-                    is_optional=pkg.is_optional,
-                    install_order=pkg.install_order,
+        # FIX: Wrap profile + package inserts in a nested transaction (savepoint).
+        # If any package insert fails, the entire profile is rolled back atomically,
+        # preventing partial/corrupted rows from being committed to the database.
+        try:
+            async with db.begin_nested():
+                profile = EnvironmentProfile(
+                    slug=profile_data.slug,
+                    name=profile_data.name,
+                    description=profile_data.description,
+                    tags=profile_data.tags,
+                    os_support=profile_data.os_support,
+                    cuda_required=profile_data.cuda_required,
+                    python_versions=profile_data.python_versions,
+                    cuda_versions=profile_data.cuda_versions,
+                    status=profile_data.status,
+                    last_validated=profile_data.last_validated,
                 )
-            )
+                db.add(profile)
+                await db.flush()
 
-        seeded += 1
+                for pkg in profile_data.packages:
+                    db.add(
+                        ProfilePackage(
+                            profile_id=profile.id,
+                            package_name=pkg.name,
+                            version_spec=pkg.version_spec,
+                            cuda_variant=pkg.cuda_variant,
+                            is_optional=pkg.is_optional,
+                            install_order=pkg.install_order,
+                        )
+                    )
+
+            seeded += 1
+        except Exception as exc:
+            print(
+                f"[seed] Failed to seed profile '{profile_data.slug}': {exc}"
+            )
+            invalid += 1
 
     await db.commit()
     print(


### PR DESCRIPTION
## Description

- Wraps each profile and its packages in a nested transaction (savepoint) during seeding, so any failure rolls back the entire profile atomically instead of leaving partial data in the database.

## Related Issues
Fixes #308 

## Changes Made
<!-- List the main changes made in this PR -->
- Wrapped profile + package inserts in `async with db.begin_nested()` in `seed_service.py`
- Added exception handling per profile to log failures and continue seeding remaining profiles

## Verification
<!-- Describe how you verified that your changes work. -->
- [ ] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [x] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

Note: Kindly add the appropriate GSSoC labels if the PR is clean and can merge properly, so the GSSoC points are counted toward my PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data seeding process with enhanced error handling and atomic transaction support to ensure data consistency and reliable failure recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
