### PR TITLE
Implement dynamic semantic version range resolution in CompatibilityResolver

### DIFF
--- a/backend/app/compatibility/resolver.py
+++ b/backend/app/compatibility/resolver.py
@@ -231,6 +231,8 @@ class CompatibilityResolver:
             rocm_version=rocm_version,
             cuda_variant=constraint.cuda_variant,
         )
+    
+    
     def _resolve_version_range(
         self,
         package_name: str,

--- a/backend/app/compatibility/resolver.py
+++ b/backend/app/compatibility/resolver.py
@@ -18,6 +18,9 @@ Usage:
         cuda_required=True,
     )
 """
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import Version
+
 from app.compatibility.errors import (
     IncompatibilityError,
     UnknownVersionError,
@@ -42,8 +45,7 @@ from app.compatibility.models import (
     ResolvedEnvironment,
     ResolvedPackage,
 )
-from packaging.specifiers import InvalidSpecifier, SpecifierSet
-from packaging.version import Version
+
 
 class CompatibilityResolver:
     """
@@ -231,8 +233,8 @@ class CompatibilityResolver:
             rocm_version=rocm_version,
             cuda_variant=constraint.cuda_variant,
         )
-    
-    
+
+
     def _resolve_version_range(
         self,
         package_name: str,

--- a/backend/app/compatibility/resolver.py
+++ b/backend/app/compatibility/resolver.py
@@ -255,7 +255,7 @@ class CompatibilityResolver:
         if not entries:
             return ResolvedPackage(
                 name=package_name,
-                version=version_spec.lstrip(">=<!=~"),
+                version=version_spec,
                 cuda_variant=cuda_variant,
             )
 

--- a/backend/app/compatibility/resolver.py
+++ b/backend/app/compatibility/resolver.py
@@ -30,7 +30,7 @@ from app.compatibility.matrix.cuda import (
 from app.compatibility.matrix.os_rules import get_os_notes
 from app.compatibility.matrix.python import (
     get_framework_entry,
-    get_latest_compatible_version,
+    get_framework_versions,
 )
 from app.compatibility.matrix.rocm import (
     ROCM_MATRIX,
@@ -42,7 +42,8 @@ from app.compatibility.models import (
     ResolvedEnvironment,
     ResolvedPackage,
 )
-
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import Version
 
 class CompatibilityResolver:
     """
@@ -212,7 +213,7 @@ class CompatibilityResolver:
         spec_version = constraint.version_spec
 
         # Check if the version spec is an exact version (no operators)
-        if not any(op in spec_version for op in [">=", "<=", "!=", ">", "<", "~="]):
+        if not any(op in spec_version for op in [">=", "<=", "!=", ">", "<", "~=", "=="]):
             # Exact version — validate it and use it directly
             return self._resolve_exact_version(
                 package_name=package_name,
@@ -222,30 +223,89 @@ class CompatibilityResolver:
                 rocm_version=rocm_version,
             )
 
-        # Range spec — find the latest compatible version within range
-        # For now, defer to the matrix for well-known packages
-        latest = get_latest_compatible_version(
-            framework=package_name,
+        return self._resolve_version_range(
+            package_name=package_name,
+            version_spec=spec_version,
             python_version=python_version,
             cuda_version=cuda_version,
             rocm_version=rocm_version,
+            cuda_variant=constraint.cuda_variant,
         )
-        if latest is not None:
-            gpu_variant = self._resolve_gpu_variant(
-                package_name, latest, cuda_version, rocm_version
-            )
+    def _resolve_version_range(
+        self,
+        package_name: str,
+        version_spec: str,
+        python_version: str,
+        cuda_version: str | None,
+        rocm_version: str | None,
+        cuda_variant: str | None,
+    ) -> ResolvedPackage:
+        """
+        Resolve a semantic version range and select the highest
+        compatible version from the compatibility matrix.
+        """
+
+        entries = get_framework_versions(package_name)
+
+        # Package not in matrix — preserve existing behavior
+        if not entries:
             return ResolvedPackage(
                 name=package_name,
-                version=latest,
-                cuda_variant=gpu_variant,
+                version=version_spec.lstrip(">=<!=~"),
+                cuda_variant=cuda_variant,
             )
 
-        # Package not in matrix — use spec as-is with a warning
-        # (e.g., pip, setuptools, or other non-framework packages)
-        return ResolvedPackage(
-            name=package_name,
-            version=spec_version.lstrip(">=<!=~"),
-            cuda_variant=constraint.cuda_variant,
+        try:
+            spec = SpecifierSet(version_spec)
+        except InvalidSpecifier as exc:
+            raise IncompatibilityError(
+                component=package_name,
+                constraint=version_spec,
+                detected="Invalid version specifier",
+                suggestion="Provide a valid semantic version constraint.",
+            ) from exc
+
+        matching_entries = []
+
+        for entry in entries:
+            if python_version not in entry.supported_python:
+                continue
+
+            if cuda_version is not None and entry.supported_cuda:
+                if cuda_version not in entry.supported_cuda:
+                    continue
+
+            if rocm_version is not None and entry.supported_rocm:
+                if rocm_version not in entry.supported_rocm:
+                    continue
+
+            if Version(entry.version) in spec:
+                matching_entries.append(entry)
+
+        if not matching_entries:
+            raise IncompatibilityError(
+                component=package_name,
+                constraint=version_spec,
+                detected="No compatible versions found",
+                suggestion=(
+                    "No versions in the compatibility matrix satisfy "
+                    "the requested constraint and environment."
+                ),
+            )
+
+        matching_entries.sort(
+            key=lambda entry: Version(entry.version),
+            reverse=True,
+        )
+
+        selected = matching_entries[0]
+
+        return self._resolve_exact_version(
+            package_name=package_name,
+            version=selected.version,
+            python_version=python_version,
+            cuda_version=cuda_version,
+            rocm_version=rocm_version,
         )
 
     def _resolve_exact_version(

--- a/backend/tests/unit/compatibility/test_resolver.py
+++ b/backend/tests/unit/compatibility/test_resolver.py
@@ -266,3 +266,70 @@ def test_rocm_version_override_failure():
         )
     assert exc.value.component == "rocm"
 
+
+def test_semver_range_resolution():
+    result = R.resolve(
+        packages=[PackageConstraint("torch", ">=2.0.0,<2.3.0")],
+        python_version="3.11",
+        cuda_version="11.8",
+        target_os="LINUX",
+        profile_slug="pytorch-cuda",
+        os_support=["LINUX", "WSL"],
+        cuda_required=True,
+    )
+
+    assert result.packages[0].version == "2.2.2"
+
+
+def test_wildcard_version_resolution():
+    result = R.resolve(
+        packages=[PackageConstraint("torch", "==2.1.*")],
+        python_version="3.11",
+        cuda_version="11.8",
+        target_os="LINUX",
+        profile_slug="pytorch-cuda",
+        os_support=["LINUX", "WSL"],
+        cuda_required=True,
+    )
+
+    assert result.packages[0].version == "2.1.2"
+
+
+def test_compatible_release_resolution():
+    result = R.resolve(
+        packages=[PackageConstraint("torch", "~=2.1")],
+        python_version="3.11",
+        cuda_version="11.8",
+        target_os="LINUX",
+        profile_slug="pytorch-cuda",
+        os_support=["LINUX", "WSL"],
+        cuda_required=True,
+    )
+
+    assert result.packages[0].version == "2.5.0"
+
+
+def test_invalid_semver_specifier():
+    with pytest.raises(IncompatibilityError):
+        R.resolve(
+            packages=[PackageConstraint("torch", ">>>invalid<<<")],
+            python_version="3.11",
+            cuda_version="11.8",
+            target_os="LINUX",
+            profile_slug="pytorch-cuda",
+            os_support=["LINUX", "WSL"],
+            cuda_required=True,
+        )
+
+
+def test_no_matching_semver_range():
+    with pytest.raises(IncompatibilityError):
+        R.resolve(
+            packages=[PackageConstraint("torch", ">=99.0.0")],
+            python_version="3.11",
+            cuda_version="11.8",
+            target_os="LINUX",
+            profile_slug="pytorch-cuda",
+            os_support=["LINUX", "WSL"],
+            cuda_required=True,
+        )


### PR DESCRIPTION
## Summary

Adds dynamic semantic version range resolution to `CompatibilityResolver` using `packaging.specifiers.SpecifierSet`.

## Linked Issue

Resolves #277

## Changes

* Added semantic version range resolution using `SpecifierSet`
* Added support for:

  * Range constraints (e.g. `>=2.0.0,<2.3.0`)
  * Wildcard constraints (e.g. `==2.1.*`)
  * Compatible release constraints (e.g. `~=2.1`)
* Filtered framework versions from the compatibility matrix and selected the highest compatible version
* Added `IncompatibilityError` handling for invalid version specifiers
* Added explicit compatibility resolution failures when no versions satisfy a valid constraint
* Added unit tests covering range resolution, wildcard constraints, compatible releases, invalid specifiers, and no-match scenarios

## Testing

```bash
python -m pytest backend/tests/unit/compatibility/test_resolver.py
```

27 tests passed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the compatibility resolution system to support flexible version specification constraints, enabling more precise package version selection from the compatibility matrix. The system now handles various version constraints more robustly.

* **Tests**
  * Added comprehensive test coverage for version range resolution scenarios, including various specification formats and error handling for invalid constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->