### PR TITLE
fix(resolver): expand _resolve_gpu_variant to support onnxruntime-gpu and cupy (#302)

### DIFF
--- a/backend/app/compatibility/resolver.py
+++ b/backend/app/compatibility/resolver.py
@@ -345,19 +345,21 @@ class CompatibilityResolver:
         cuda_version: str | None,
         rocm_version: str | None,
     ) -> str | None:
-        """
-        Determine the pip install variant suffix for a package.
+        """Resolves specific GPU-accelerated variants (CUDA/ROCm) for targeted packages.
+
         e.g., torch 2.1.0 with CUDA 11.8 → variant = "cu118"
               torch 2.1.0 with ROCm 5.6 → variant = "rocm5.6"
         """
+        gpu_packages = {"torch", "torchvision", "torchaudio", "onnxruntime-gpu", "cupy"}
+
+        if package_name not in gpu_packages:
+            return None
+
         if cuda_version is not None:
-            if package_name not in ("torch", "torchvision", "torchaudio"):
-                return None
             return "cu" + cuda_version.replace(".", "")
 
         if rocm_version is not None:
-            if package_name not in ("torch", "torchvision", "torchaudio"):
-                return None
             return "rocm" + rocm_version
 
         return None
+    


### PR DESCRIPTION
### Description
Addresses a bug in the Compatibility Resolver where non-PyTorch GPU-accelerated packages were being resolved without their respective CUDA/ROCm variant suffixes, causing them to default to standard CPU packages.

### Changes
- Updated `_resolve_gpu_variant` to accept an expanded `GPU_PACKAGES` set including `onnxruntime-gpu` and `cupy`.
- Refactored the package validation check to the top of the function to clean up redundant validation code blocks.

### Verification Results
- Successfully passed all 22 isolated unit tests in `tests/unit/compatibility/test_resolver.py`.

Closes #302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded GPU-variant support to include additional packages (onnxruntime-gpu, cupy), ensuring proper CUDA/ROCm variant selection for more dependencies in GPU environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rishabh0510rishabh/EnvForage/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->