### PR TITLE
feat: implement local file caching for dependency metadata

### DIFF
--- a/backend/scripts/fetch_pypi_metadata.py
+++ b/backend/scripts/fetch_pypi_metadata.py
@@ -9,11 +9,13 @@ def fetch_pypi_python_requires(package: str, version: str | None = None) -> None
     """
     Fetches the Requires-Python metadata from PyPI for a given package and version.
     This script is used to automate the verification of Python compatibility matrices.
-    Uses local JSON file-based caching inside `.pypi_cache` to optimize performance.
+    Uses local JSON file-based caching inside `~/.envforge/cache` to optimize performance with a 12-hour TTL.
     """
     import os
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    cache_dir = os.path.join(script_dir, ".pypi_cache")
+    import time
+    
+    # Store cache under ~/.envforge/cache per issue #386 spec
+    cache_dir = os.path.expanduser("~/.envforge/cache")
     os.makedirs(cache_dir, exist_ok=True)
     
     safe_pkg = "".join(c for c in package if c.isalnum() or c in ".-_")
@@ -21,7 +23,18 @@ def fetch_pypi_python_requires(package: str, version: str | None = None) -> None
     cache_file = os.path.join(cache_dir, f"{safe_pkg}_{safe_ver}.json")
 
     data = None
+    cache_valid = False
+    
+    # Check if cache file exists and is less than 12 hours (43200 seconds) old
     if os.path.exists(cache_file):
+        try:
+            mtime = os.path.getmtime(cache_file)
+            if time.time() - mtime < 43200:
+                cache_valid = True
+        except Exception as e:
+            print(f"[WARN] Failed to read cache file metadata: {e}")
+
+    if cache_valid:
         try:
             with open(cache_file, "r", encoding="utf-8") as f:
                 data = json.load(f)
@@ -37,7 +50,8 @@ def fetch_pypi_python_requires(package: str, version: str | None = None) -> None
         try:
             print(f"[Cache Miss] Fetching metadata for {package} {version or 'latest'} from PyPI...")
             req = urllib.request.Request(url, headers={'User-Agent': 'EnvForage/1.0'})
-            with urllib.request.urlopen(req) as response:
+            # Added 10s timeout to prevent hanging connections
+            with urllib.request.urlopen(req, timeout=10) as response:
                 raw_response = response.read().decode('utf-8')
                 data = json.loads(raw_response)
                 

--- a/backend/scripts/fetch_pypi_metadata.py
+++ b/backend/scripts/fetch_pypi_metadata.py
@@ -1,36 +1,66 @@
 import json
 import sys
 import urllib.request
+import urllib.error
+from typing import Optional
 
 
 def fetch_pypi_python_requires(package: str, version: str | None = None) -> None:
     """
     Fetches the Requires-Python metadata from PyPI for a given package and version.
     This script is used to automate the verification of Python compatibility matrices.
+    Uses local JSON file-based caching inside `.pypi_cache` to optimize performance.
     """
-    url = f"https://pypi.org/pypi/{package}/json"
-    if version:
-        url = f"https://pypi.org/pypi/{package}/{version}/json"
+    import os
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    cache_dir = os.path.join(script_dir, ".pypi_cache")
+    os.makedirs(cache_dir, exist_ok=True)
+    
+    safe_pkg = "".join(c for c in package if c.isalnum() or c in ".-_")
+    safe_ver = "".join(c for c in version if c.isalnum() or c in ".-_") if version else "latest"
+    cache_file = os.path.join(cache_dir, f"{safe_pkg}_{safe_ver}.json")
 
-    try:
-        req = urllib.request.Request(url, headers={"User-Agent": "EnvForage/1.0"})
-        with urllib.request.urlopen(req) as response:
-            data = json.loads(response.read().decode("utf-8"))
+    data = None
+    if os.path.exists(cache_file):
+        try:
+            with open(cache_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            print(f"[Cache Hit] Loaded metadata for {package} {version or 'latest'} from local cache.")
+        except Exception as e:
+            print(f"[WARN] Failed to read cache: {e}")
 
-            info = data.get("info", {})
-            pkg_version = info.get("version", "unknown")
-            requires_python = info.get("requires_python", "Not specified")
+    if not data:
+        url = f"https://pypi.org/pypi/{package}/json"
+        if version:
+            url = f"https://pypi.org/pypi/{package}/{version}/json"
 
-            print(f"Package: {package}")
-            print(f"Version: {pkg_version}")
-            print(f"Requires-Python: {requires_python}")
+        try:
+            print(f"[Cache Miss] Fetching metadata for {package} {version or 'latest'} from PyPI...")
+            req = urllib.request.Request(url, headers={'User-Agent': 'EnvForage/1.0'})
+            with urllib.request.urlopen(req) as response:
+                raw_response = response.read().decode('utf-8')
+                data = json.loads(raw_response)
+                
+            try:
+                with open(cache_file, "w", encoding="utf-8") as f:
+                    f.write(raw_response)
+            except Exception as e:
+                print(f"[WARN] Failed to write cache: {e}")
+                
+        except urllib.error.HTTPError as e:
+            print(f"Failed to fetch metadata for {package} {version or ''}: HTTP {e.code}")
+            sys.exit(1)
+        except Exception as e:
+            print(f"Error fetching metadata: {e}")
+            sys.exit(1)
 
-    except urllib.error.HTTPError as e:
-        print(f"Failed to fetch metadata for {package} {version or ''}: HTTP {e.code}")
-        sys.exit(1)
-    except Exception as e:
-        print(f"Error fetching metadata: {e}")
-        sys.exit(1)
+    info = data.get("info", {})
+    pkg_version = info.get("version", "unknown")
+    requires_python = info.get("requires_python", "Not specified")
+    
+    print(f"Package: {package}")
+    print(f"Version: {pkg_version}")
+    print(f"Requires-Python: {requires_python}")
 
 
 if __name__ == "__main__":

--- a/backend/scripts/update_python_matrix.py
+++ b/backend/scripts/update_python_matrix.py
@@ -21,9 +21,12 @@ SUPPORTED_PYTHONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
 
 def fetch_pypi_python_bounds(package: str, version: str):
-    """Fetch required python bounds from PyPI, using a local file cache."""
-    # Ensure cache directory exists
-    cache_dir = Path(__file__).resolve().parent / ".pypi_cache"
+    """Fetch required python bounds from PyPI, using a local file cache with a 12-hour TTL."""
+    import os
+    import time
+    
+    # Store cache under ~/.envforge/cache per issue #386 spec
+    cache_dir = Path(os.path.expanduser("~/.envforge/cache"))
     cache_dir.mkdir(parents=True, exist_ok=True)
     
     safe_pkg = "".join(c for c in package if c.isalnum() or c in ".-_")
@@ -31,7 +34,18 @@ def fetch_pypi_python_bounds(package: str, version: str):
     cache_file = cache_dir / f"{safe_pkg}_{safe_ver}.json"
 
     data = None
+    cache_valid = False
+    
+    # Check if cache file exists and is less than 12 hours (43200 seconds) old
     if cache_file.exists():
+        try:
+            mtime = cache_file.stat().st_mtime
+            if time.time() - mtime < 43200:
+                cache_valid = True
+        except Exception as e:
+            print(f"  [WARN] Failed to read cache file metadata: {e}")
+
+    if cache_valid:
         try:
             with open(cache_file, "r", encoding="utf-8") as f:
                 data = json.load(f)
@@ -42,7 +56,8 @@ def fetch_pypi_python_bounds(package: str, version: str):
     if not data:
         url = f"https://pypi.org/pypi/{package}/{version}/json"
         print(f"  [Cache Miss] Fetching {url} from PyPI...")
-        r = httpx.get(url)
+        # Added 10s timeout to prevent hanging connections
+        r = httpx.get(url, timeout=10)
         
         if r.status_code != 200:
             print(f"  [WARN] Failed to fetch {package} {version} (Status {r.status_code})")

--- a/backend/scripts/update_python_matrix.py
+++ b/backend/scripts/update_python_matrix.py
@@ -21,16 +21,42 @@ SUPPORTED_PYTHONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
 
 def fetch_pypi_python_bounds(package: str, version: str):
-    """Fetch required python bounds from PyPI."""
-    url = f"https://pypi.org/pypi/{package}/{version}/json"
-    print(f"Fetching {url}...")
-    r = httpx.get(url)
+    """Fetch required python bounds from PyPI, using a local file cache."""
+    # Ensure cache directory exists
+    cache_dir = Path(__file__).resolve().parent / ".pypi_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    
+    safe_pkg = "".join(c for c in package if c.isalnum() or c in ".-_")
+    safe_ver = "".join(c for c in version if c.isalnum() or c in ".-_")
+    cache_file = cache_dir / f"{safe_pkg}_{safe_ver}.json"
 
-    if r.status_code != 200:
-        print(f"  [WARN] Failed to fetch {package} {version} (Status {r.status_code})")
-        return None
+    data = None
+    if cache_file.exists():
+        try:
+            with open(cache_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            print(f"  [Cache Hit] Loaded {package} {version} from local cache.")
+        except Exception as e:
+            print(f"  [WARN] Failed to read cache: {e}")
 
-    data = r.json()
+    if not data:
+        url = f"https://pypi.org/pypi/{package}/{version}/json"
+        print(f"  [Cache Miss] Fetching {url} from PyPI...")
+        r = httpx.get(url)
+        
+        if r.status_code != 200:
+            print(f"  [WARN] Failed to fetch {package} {version} (Status {r.status_code})")
+            return None
+
+        data = r.json()
+        
+        # Save JSON to cache file
+        try:
+            with open(cache_file, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=4)
+        except Exception as e:
+            print(f"  [WARN] Failed to write cache: {e}")
+
     requires_python = data.get("info", {}).get("requires_python")
 
     if not requires_python:

--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -127,8 +127,6 @@ def cli(ctx: click.Context, no_color: bool) -> None:
 def diagnose(output: str | None, send: bool, api_url: str, quiet: bool, sarif: bool, timeout: int, output_format: str = "json") -> None:
     asyncio.run(_diagnose(output, send, api_url, quiet, sarif, timeout, output_format))
 
-def diagnose(output: str | None, send: bool, api_url: str, quiet: bool, sarif: bool, timeout: int, output_format: str) -> None:
-    asyncio.run(_diagnose(output, send, api_url, quiet, sarif, timeout, output_format))
 
 async def _diagnose(output: str | None, send: bool, api_url: str, quiet: bool, sarif: bool, timeout: int, output_format: str) -> None:
     """

--- a/cli/tests/test_fix.py
+++ b/cli/tests/test_fix.py
@@ -47,61 +47,59 @@ def mock_api_success() -> MagicMock:
     return mock_resp
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_httpx(mock_api_success):
-    """Globally mock httpx.AsyncClient for all tests in this file."""
+    from unittest.mock import AsyncMock
     mock_client = MagicMock()
-    mock_client.post = AsyncMock(return_value=mock_api_success)
+    mock_post = AsyncMock(return_value=mock_api_success)
+    mock_client.post = mock_post
     
-    mock_async_client_class = MagicMock()
-    mock_async_client_class.return_value.__aenter__.return_value = mock_client
+    mock_class = MagicMock()
+    mock_class.return_value.__aenter__.return_value = mock_client
     
-    with patch("httpx.AsyncClient", mock_async_client_class):
-        yield mock_client
+    with patch("httpx.AsyncClient", mock_class):
+        yield mock_post
 
 
 class TestFixHappyPath:
     """Happy path tests for envforge fix."""
 
-    def test_fix_displays_script_content(self, valid_report):
+    def test_fix_displays_script_content(self, valid_report, mock_httpx):
         """Standard run should print script content in a rich panel."""
         runner = CliRunner()
-        with patch("httpx.AsyncClient.post", return_value=mock_api_success):
-            result = runner.invoke(cli, [
-                "fix",
-                "--report", str(valid_report),
-                "--profile", "pytorch-cuda",
-            ])
+        result = runner.invoke(cli, [
+            "fix",
+            "--report", str(valid_report),
+            "--profile", "pytorch-cuda",
+        ])
 
         assert result.exit_code == 0
         assert "setup.sh" in result.output
         assert "test-job-123" in result.output
 
-    def test_fix_dry_run_lists_filenames_only(self, valid_report):
+    def test_fix_dry_run_lists_filenames_only(self, valid_report, mock_httpx):
         """--dry-run should list script filenames without printing content."""
         runner = CliRunner()
-        with patch("httpx.AsyncClient.post", return_value=mock_api_success):
-            result = runner.invoke(cli, [
-                "fix",
-                "--report", str(valid_report),
-                "--profile", "pytorch-cuda",
-                "--dry-run",
-            ])
+        result = runner.invoke(cli, [
+            "fix",
+            "--report", str(valid_report),
+            "--profile", "pytorch-cuda",
+            "--dry-run",
+        ])
 
         assert result.exit_code == 0
         assert "setup.sh" in result.output
         # Full script content should NOT appear in dry-run
         assert "pip install torch" not in result.output
 
-    def test_fix_shows_resolved_packages(self, valid_report):
+    def test_fix_shows_resolved_packages(self, valid_report, mock_httpx):
         """Output should include resolved packages from API response."""
         runner = CliRunner()
-        with patch("httpx.AsyncClient.post", return_value=mock_api_success):
-            result = runner.invoke(cli, [
-                "fix",
-                "--report", str(valid_report),
-                "--profile", "pytorch-cuda",
-            ])
+        result = runner.invoke(cli, [
+            "fix",
+            "--report", str(valid_report),
+            "--profile", "pytorch-cuda",
+        ])
 
         assert result.exit_code == 0
         assert "torch==2.3.0" in result.output
@@ -115,9 +113,9 @@ class TestFixHappyPath:
             "--profile", "pytorch-cuda",
         ])
 
-        assert mock_httpx.post.called
-        call_kwargs = mock_httpx.post.call_args[1]
-        payload = call_kwargs["json"]
+        assert mock_httpx.called
+        call_kwargs = mock_httpx.call_args
+        payload = call_kwargs[1]["json"] if "json" in call_kwargs[1] else call_kwargs[0][1]
         assert payload["profile_id"] == "pytorch-cuda"
         assert "target_os" in payload
         assert "python_version" in payload
@@ -125,15 +123,14 @@ class TestFixHappyPath:
     def test_fix_uses_custom_api_url(self, valid_report, mock_httpx):
         """--api-url flag should override the default localhost URL."""
         runner = CliRunner()
-        with patch("httpx.AsyncClient.post", return_value=mock_api_success) as mock_post:
-            runner.invoke(cli, [
-                "fix",
-                "--report", str(valid_report),
-                "--profile", "pytorch-cuda",
-                "--api-url", "http://myserver:9000",
-            ])
+        runner.invoke(cli, [
+            "fix",
+            "--report", str(valid_report),
+            "--profile", "pytorch-cuda",
+            "--api-url", "http://myserver:9000",
+        ])
 
-        called_url = mock_httpx.post.call_args[0][0]
+        called_url = mock_httpx.call_args[0][0]
         assert "myserver:9000" in called_url
 
 
@@ -143,14 +140,13 @@ class TestFixAPIErrors:
     def test_fix_exits_on_connect_error(self, valid_report):
         """ConnectError should print a helpful message and exit 1."""
         import httpx
+        from unittest.mock import AsyncMock
         runner = CliRunner()
-        
-        mock_client = MagicMock()
-        mock_client.post.side_effect = httpx.ConnectError("refused")
-        mock_async_client_class = MagicMock()
-        mock_async_client_class.return_value.__aenter__.return_value = mock_client
+        mock_post = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        mock_class = MagicMock()
+        mock_class.return_value.__aenter__.return_value.post = mock_post
 
-        with patch("httpx.AsyncClient", mock_async_client_class):
+        with patch("httpx.AsyncClient", mock_class):
             result = runner.invoke(cli, [
                 "fix",
                 "--report", str(valid_report),
@@ -163,6 +159,7 @@ class TestFixAPIErrors:
     def test_fix_exits_on_http_error(self, valid_report):
         """4xx/5xx API responses should exit with code 1."""
         import httpx
+        from unittest.mock import AsyncMock
         runner = CliRunner()
 
         mock_resp = MagicMock()
@@ -172,12 +169,11 @@ class TestFixAPIErrors:
             "400", request=MagicMock(), response=mock_resp
         )
 
-        mock_client = MagicMock()
-        mock_client.post.return_value = mock_resp
-        mock_async_client_class = MagicMock()
-        mock_async_client_class.return_value.__aenter__.return_value = mock_client
+        mock_post = AsyncMock(return_value=mock_resp)
+        mock_class = MagicMock()
+        mock_class.return_value.__aenter__.return_value.post = mock_post
 
-        with patch("httpx.AsyncClient", mock_async_client_class):
+        with patch("httpx.AsyncClient", mock_class):
             result = runner.invoke(cli, [
                 "fix",
                 "--report", str(valid_report),
@@ -189,6 +185,7 @@ class TestFixAPIErrors:
     def test_fix_exits_on_500_error(self, valid_report):
         """500 server error should exit with code 1."""
         import httpx
+        from unittest.mock import AsyncMock
         runner = CliRunner()
 
         mock_resp = MagicMock()
@@ -198,12 +195,11 @@ class TestFixAPIErrors:
             "500", request=MagicMock(), response=mock_resp
         )
 
-        mock_client = MagicMock()
-        mock_client.post.return_value = mock_resp
-        mock_async_client_class = MagicMock()
-        mock_async_client_class.return_value.__aenter__.return_value = mock_client
+        mock_post = AsyncMock(return_value=mock_resp)
+        mock_class = MagicMock()
+        mock_class.return_value.__aenter__.return_value.post = mock_post
 
-        with patch("httpx.AsyncClient", mock_async_client_class):
+        with patch("httpx.AsyncClient", mock_class):
             result = runner.invoke(cli, [
                 "fix",
                 "--report", str(valid_report),


### PR DESCRIPTION
Resolves #386. Implements local file caching for PyPI dependency metadata fetches inside fetch_pypi_metadata.py and update_python_matrix.py to avoid redundant HTTP requests, and fixes async CLI tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Added local caching for PyPI package metadata to reduce redundant network requests and speed up package resolution.

* **Behavior Change**
  * The diagnose command now defaults to JSON output when no format is specified.

* **Tests**
  * Refactored CLI integration tests to use async HTTP client mocking with a reusable fixture, improving test reliability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->