### PR TITLE
fix: use WIN value for Windows profiles filter

### DIFF
--- a/frontend/src/app/profiles/page.tsx
+++ b/frontend/src/app/profiles/page.tsx
@@ -222,7 +222,7 @@ export default function ProfilesPage() {
 						}}
 					>
 						<option value="ALL">All Operating Systems</option>
-						<option value="WINDOWS">Windows</option>
+						<option value="WIN">Windows</option>
 						<option value="LINUX">Linux</option>
 						<option value="WSL">WSL</option>
 					</select>


### PR DESCRIPTION
## Description

Update the Profiles page OS filter so the Windows option submits the canonical WIN code instead of WINDOWS. This aligns the filter with backend/profile OS support values and allows Windows-supported profiles to appear when filtering.

## Related Issues
fixes #383 

## Changes Made

1. Updated frontend/src/app/profiles/page.tsx
2. Changed the Windows filter value from
3. This matches the backend/profile OS code and should make Windows-supported profiles appear when selecting Windows.


## Verification
<!-- Describe how you verified that your changes work. -->
- [ ] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Windows operating system filter option in the profiles page to correctly display and filter profiles based on operating system selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->