### PR TITLE
Fix/profiles null metadata

### DIFF
--- a/backend/app/schemas/script.py
+++ b/backend/app/schemas/script.py
@@ -17,7 +17,6 @@ OutputFormat = Literal[
     "docker-compose.yml",
     "devcontainer.json",
     ".gitignore",
-    "pyproject.toml",
     "pyproject.poetry.toml",
 ]
 

--- a/backend/seeds/profiles.yaml
+++ b/backend/seeds/profiles.yaml
@@ -195,7 +195,6 @@ profiles:
         version_spec: "1.13.0"
         install_order: 7
 
-
   - slug: jax-cuda
     name: "JAX CUDA"
     description: >
@@ -270,7 +269,6 @@ profiles:
       - name: Pillow
         version_spec: "10.3.0"
         install_order: 6
-
   - slug: langchain-rag
     name: "LangChain RAG"
     description: >

--- a/frontend/src/app/profiles/page.tsx
+++ b/frontend/src/app/profiles/page.tsx
@@ -43,12 +43,14 @@ export default function ProfilesPage() {
 
 	// Filter profiles based on search and selected options
 	const filteredProfiles = profiles.filter((p) => {
+		const description = p.description ?? "";
+		const tags = p.tags ?? [];
+		const normalizedQuery = searchQuery.toLowerCase();
+
 		const matchesSearch =
-			p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-			p.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
-			p.tags.some((tag) =>
-				tag.toLowerCase().includes(searchQuery.toLowerCase()),
-			);
+			p.name.toLowerCase().includes(normalizedQuery) ||
+			description.toLowerCase().includes(normalizedQuery) ||
+			tags.some((tag) => tag.toLowerCase().includes(normalizedQuery));
 
 		const matchesOS =
 			selectedOS === "ALL" ||
@@ -378,7 +380,7 @@ export default function ProfilesPage() {
 											minHeight: "4.5rem",
 										}}
 									>
-										{p.description}
+										{p.description ?? "No description available."}
 									</p>
 
 									{/* OS & Python specs */}

--- a/frontend/src/app/profiles/page.tsx
+++ b/frontend/src/app/profiles/page.tsx
@@ -222,7 +222,7 @@ export default function ProfilesPage() {
 						}}
 					>
 						<option value="ALL">All Operating Systems</option>
-						<option value="WINDOWS">Windows</option>
+						<option value="WIN">Windows</option>
 						<option value="LINUX">Linux</option>
 						<option value="WSL">WSL</option>
 					</select>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -8,8 +8,8 @@ export interface PackageDef {
 export interface Profile {
 	slug: string;
 	name: string;
-	description: string;
-	tags: string[];
+	description: string | null;
+	tags: string[] | null;
 	os_support: string[];
 	cuda_required: boolean;
 	python_versions: string[];


### PR DESCRIPTION
## Description

Make the Profiles page resilient to nullable backend profile metadata by treating null descriptions as empty text and null tags as an empty list during search. Update the frontend Profile type to match the backend schema and add a fallback description in profile cards.

## Related Issues
fixes #384 

## Changes Made

1.Updated frontend/src/types/index.ts
description is now string | null
tags is now string[] | null
2.Updated frontend/src/app/profiles/page.tsx
Search no longer crashes on description: null
Search no longer crashes on tags: null
Profile cards show No description available. when description is missing

## Verification

- [ ] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted
