### PR TITLE
fix [Feature]: Add markdown formatting option for CLI diagnostic reports

### DIFF
--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -115,7 +115,7 @@ def cli(ctx: click.Context, no_color: bool) -> None:
     type=click.Choice(["json", "yaml", "markdown"], case_sensitive=False),
     default="json",
     show_default=True,
-    help="Output format for the diagnostic report (json, yaml).",
+    help="Output format for the diagnostic report (json, yaml, markdown).",
 )
 @click.option(
     "--timeout", "-t",

--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -112,7 +112,7 @@ def cli(ctx: click.Context, no_color: bool) -> None:
     "--format",
     "-f",
     "output_format",
-    type=click.Choice(["json", "yaml"], case_sensitive=False),
+    type=click.Choice(["json", "yaml", "markdown"], case_sensitive=False),
     default="json",
     show_default=True,
     help="Output format for the diagnostic report (json, yaml).",
@@ -163,6 +163,8 @@ async def _diagnose(output: str | None, send: bool, api_url: str, quiet: bool, s
     if output_format == "yaml":
         import yaml
         report_output = yaml.dump(report.model_dump(mode='json'), default_flow_style=False, sort_keys=False)
+    elif output_format == "markdown":
+        report_output = report.to_markdown()
     else:
         report_output = report.to_json(indent=2)
 

--- a/cli/envforge_agent/schemas.py
+++ b/cli/envforge_agent/schemas.py
@@ -141,7 +141,7 @@ class DiagnosticReport(BaseModel):
             py = self.active_python
             venv = " (venv)" if py.is_venv else ""
             lines.append(f"- **Active**: {py.version} at `{py.path}`{venv}")
-        if len(self.python_installations) > 1:
+        if len(self.python_installations) >= 1:
             others = [
                 p for p in self.python_installations
                 if p.path != (self.active_python.path if self.active_python else "")

--- a/cli/envforge_agent/schemas.py
+++ b/cli/envforge_agent/schemas.py
@@ -88,6 +88,70 @@ class DiagnosticReport(BaseModel):
         """Serialize to JSON string (API-compatible)."""
         return self.model_dump_json(indent=indent)
 
+    def to_markdown(self) -> str:
+        """Serialize diagnostic report to a Markdown-formatted string."""
+        lines = ["# EnvForge Diagnostic Report", ""]
+
+        lines += [
+            "## System",
+            f"- **OS**: {self.os.name} {self.os.version} ({self.os.architecture})",
+        ]
+        if self.os.wsl_version:
+            lines.append(f"- **WSL**: {self.os.wsl_version}")
+        lines += [
+            f"- **CPU**: {self.cpu.brand} — {self.cpu.cores}C / {self.cpu.threads}T",
+            f"- **RAM**: {self.ram.total_gb} GB total, {self.ram.available_gb} GB free",
+            f"- **Disk**: {self.disk.available_gb:.1f} GB free of {self.disk.total_gb:.1f} GB",
+            "",
+        ]
+
+        lines.append("## GPU")
+        if self.gpus:
+            for gpu in self.gpus:
+                vram = f"{gpu.vram_gb} GB" if gpu.vram_gb else "?"
+                driver = gpu.driver_version or "?"
+                lines.append(f"- **{gpu.name}**: {vram} VRAM, driver {driver}")
+        else:
+            lines.append("- No NVIDIA GPU detected")
+        lines.append("")
+
+        lines.append("## CUDA")
+        if self.cuda.version:
+            lines.append(f"- **Version**: {self.cuda.version}")
+            if self.cuda.cudnn_version:
+                lines.append(f"- **cuDNN**: {self.cuda.cudnn_version}")
+            if self.cuda.nccl_version:
+                lines.append(f"- **NCCL**: {self.cuda.nccl_version}")
+            if self.cuda.toolkit_path:
+                lines.append(f"- **Toolkit Path**: {self.cuda.toolkit_path}")
+        else:
+            lines.append("- Not detected")
+        lines.append("")
+
+        lines.append("## ROCm")
+        if self.rocm.version:
+            gcn = f" (GCN {self.rocm.gcn_arch})" if self.rocm.gcn_arch else ""
+            lines.append(f"- **Version**: {self.rocm.version}{gcn}")
+        else:
+            lines.append("- Not detected")
+        lines.append("")
+
+        lines.append("## Python")
+        if self.active_python:
+            py = self.active_python
+            venv = " (venv)" if py.is_venv else ""
+            lines.append(f"- **Active**: {py.version} at `{py.path}`{venv}")
+        if len(self.python_installations) > 1:
+            others = [
+                p for p in self.python_installations
+                if p.path != (self.active_python.path if self.active_python else "")
+            ]
+            if others:
+                lines.append("- **Others**: " + ", ".join(f"{p.version} (`{p.path}`)" for p in others[:3]))
+        lines.append("")
+
+        return "\n".join(lines)
+
     def to_sarif(self) -> dict:
         """Serialize diagnostic report to SARIF 2.1.0 format for CI/CD pipelines."""
         results = []


### PR DESCRIPTION
## Description
Added `--format markdown` option to `envforge diagnose` command. 
Follows the existing json/yaml pattern with no new dependencies or files.


## Related Issues
Fixes #391

## Changes Made
- Added `to_markdown()` method on `DiagnosticReport` in `schemas.py`
- Added `"markdown"` to `click.Choice(["json", "yaml", "markdown"])` in `cli.py`
- Added `elif output_format == "markdown": report_output = report.to_markdown()` in `cli.py`

## Verification
<!-- Describe how you verified that your changes work. -->
- [ ] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [x] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added markdown export format to the `envforge diagnose` command. Diagnostic reports can now be output in markdown format via the `--format` option, complementing existing JSON and YAML formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->