### PR TITLE
fix(config): extend SECRET_KEY guard to staging and all non-development environments

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -77,11 +77,23 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def validate_secret_key(self) -> "Settings":
+        """Enforce a strong SECRET_KEY in all non-development environments.
+
+        The default value (DEV_SECRET_KEY) is committed to the public repository.
+        Any deployment that omits SECRET_KEY in staging or production will silently
+        sign JWTs with this known-public string, allowing trivial token forgery.
+
+        Raises:
+            ValueError: When the insecure default is used outside development.
         """
-        Validate that the default development secret key is not used in production.
-        """
-        if self.environment == "production" and self.secret_key == DEV_SECRET_KEY:
-            raise ValueError("Production environment requires a strong SECRET_KEY.")
+        if self.secret_key == DEV_SECRET_KEY and self.environment != "development":
+            raise ValueError(
+                f"A strong SECRET_KEY is required when environment='{self.environment}'. "
+                "Set the SECRET_KEY environment variable to a cryptographically random "
+                "value before deploying. "
+                "The default key ('dev-secret-key-change-in-production') is committed "
+                "to the public repository and must never be used outside local development."
+            )
         return self
 
 


### PR DESCRIPTION
## Description

The existing `validate_secret_key` validator in `backend/app/config.py` only blocked the insecure default key when `environment='production'`. This left staging (and any other named environment) silently using `DEV_SECRET_KEY` -- a value committed to the public repository -- to sign all JWTs. An attacker who reads the source can forge valid tokens for any user in a staging deployment.

The fix widens the guard to raise `ValueError` for any `environment` value other than `'development'`.

## Related Issues

Closes #436

## Changes Made

- `backend/app/config.py`: Updated `validate_secret_key` to cover all non-development environments (`environment != "development"` instead of `environment == "production"`). Improved the error message to include the current environment name and explain why the default key is dangerous.

## Verification

- [ ] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI

**Manual test:** Setting `ENVIRONMENT=staging` without `SECRET_KEY` raises `ValueError` at startup. Setting `ENVIRONMENT=development` without `SECRET_KEY` still starts with the dev default (expected for local development).

## Documentation

- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted

Please add the appropriate NSoC '26 label to this PR. Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development credentials are now properly rejected in staging and production environments. Enhanced validation error messages clearly guide users to configure appropriate credentials before deploying to non-development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->