### PR TITLE
fix(datetime): replace deprecated datetime.utcnow() with timezone-aware datetime.now(UTC)

### DIFF
--- a/backend/app/ai/service.py
+++ b/backend/app/ai/service.py
@@ -15,7 +15,7 @@ import logging
 import time
 import uuid
 from collections.abc import AsyncIterator
-from datetime import datetime
+from datetime import UTC, datetime
 
 from fastapi import HTTPException, status
 from sqlalchemy import select
@@ -340,7 +340,7 @@ class AITroubleshootService:
                     id=uuid.UUID(session_id),
                     provider=provider_name,
                     model=model_name,
-                    created_at=datetime.utcnow(),
+                    created_at=datetime.now(UTC),
                 )
 
                 db.add(db_session)
@@ -358,7 +358,7 @@ class AITroubleshootService:
                             fix.safe_commands if fix.safe_commands else None,
                         ),
                         template_id=fix.repair_template_id,
-                        created_at=datetime.utcnow(),
+                        created_at=datetime.now(UTC),
                     )
                     db.add(db_suggestion)
                 return
@@ -413,7 +413,7 @@ class AITroubleshootService:
                 provider=provider,
                 tokens_used=tokens_used,
                 latency_ms=latency_ms,
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(UTC),
             )
             db.add(log)
         except Exception as exc:

--- a/backend/app/api/v1/diagnose.py
+++ b/backend/app/api/v1/diagnose.py
@@ -6,7 +6,7 @@ import json
 import logging
 import time
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends
 
@@ -94,7 +94,7 @@ async def diagnose(
         if report.active_python
         else None,
         driver_version=report.gpus[0].driver_version if report.gpus else None,
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
     )
     db.add(db_report)
     await db.flush()
@@ -307,7 +307,7 @@ def _log_explain_audit(
             provider=provider,
             tokens_used=tokens_used,
             latency_ms=latency_ms,
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(UTC),
         )
         db.add(log)
     except Exception as exc:

--- a/backend/app/api/v1/verify.py
+++ b/backend/app/api/v1/verify.py
@@ -2,7 +2,7 @@
 
 import re
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -113,7 +113,7 @@ async def verify_environment(
         report_id=payload.report_id,
         profile_id=payload.profile_id,
         overall_status=overall_status,
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
     )
     db.add(db_result)
 

--- a/backend/app/services/script_service.py
+++ b/backend/app/services/script_service.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 import logging
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -203,7 +203,7 @@ async def generate_scripts(
         overrides=request.overrides or {},
         status="completed",
         resolved_env=resolved.to_dict(),
-        completed_at=datetime.utcnow(),
+        completed_at=datetime.now(UTC),
     )
     db.add(job)
 

--- a/backend/app/templates/models.py
+++ b/backend/app/templates/models.py
@@ -1,7 +1,7 @@
 """Data models for the Template Engine."""
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from app.compatibility.models import ResolvedEnvironment
@@ -18,7 +18,7 @@ class TemplateContext:
     profile_name: str
     resolved: ResolvedEnvironment
     envforge_version: str = "1.0.0"
-    generated_at: datetime = field(default_factory=datetime.utcnow)
+    generated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     warnings: list[str] = field(default_factory=list)
     extra: dict[str, Any] = field(default_factory=dict)
     use_uv: bool = False


### PR DESCRIPTION
## Description

`datetime.utcnow()` was deprecated in Python 3.12 and emits `DeprecationWarning` on every request that creates an AI session, diagnostic record, or script job. The function is scheduled for removal in a future Python release, which would cause `AttributeError` at runtime.

This PR replaces all eight call sites with `datetime.now(UTC)`, which returns a timezone-aware datetime in UTC and is the recommended approach per the Python documentation.

## Related Issues

Closes #437

## Changes Made

- `backend/app/ai/service.py`: 3 call sites replaced, import updated to include `UTC`
- `backend/app/api/v1/diagnose.py`: 2 call sites replaced, import updated
- `backend/app/api/v1/verify.py`: 1 call site replaced, import updated
- `backend/app/services/script_service.py`: 1 call site replaced, import updated
- `backend/app/templates/models.py`: `default_factory=datetime.utcnow` replaced with `default_factory=lambda: datetime.now(UTC)`, import updated

## Verification

- [ ] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI

No behavioral change is expected. The returned values are equivalent in UTC value but are now timezone-aware, which eliminates the deprecation warnings and ensures compatibility with future Python versions.

## Documentation

- [ ] Code is fully documented and type-hinted

Please add the appropriate NSoC '26 label to this PR. Thank you!