### PR TITLE
fix(schemas): cap gpus and python_installations list lengths in DiagnosticReportSchema

### DIFF
--- a/backend/app/schemas/diagnostic.py
+++ b/backend/app/schemas/diagnostic.py
@@ -160,7 +160,8 @@ class DiagnosticReportSchema(BaseModel):
     ram: RAMInfo
     gpus: list[GPUInfo] = Field(
         default_factory=list,
-        description="Detected GPUs on the system.",
+        max_length=32,
+        description="Detected GPUs on the system. Capped at 32 entries to prevent memory exhaustion.",
     )
     cuda: CUDAInfo = Field(
         default_factory=lambda: CUDAInfo(
@@ -181,7 +182,8 @@ class DiagnosticReportSchema(BaseModel):
     )
     python_installations: list[PythonInfo] = Field(
         default_factory=list,
-        description="All detected Python installations.",
+        max_length=64,
+        description="All detected Python installations. Capped at 64 entries to prevent memory exhaustion.",
     )
     active_python: PythonInfo | None = Field(
         None,


### PR DESCRIPTION
## Description

`DiagnosticReportSchema` accepted `list[GPUInfo]` and `list[PythonInfo]` with no upper bound. A single POST to `/api/v1/diagnose` could submit thousands of entries, forcing the server to allocate and validate a proportionally large object graph before Pydantic finishes -- a straightforward memory exhaustion vector for any authenticated caller.

This PR adds `max_length=32` to `gpus` and `max_length=64` to `python_installations`. Pydantic enforces these limits at deserialization time and returns HTTP 422 before any further processing.

The caps are generous -- no real server reports more than a handful of GPUs, and 64 Python interpreters covers any realistic environment.

## Related Issues

Closes #438

## Changes Made

- `backend/app/schemas/diagnostic.py`:
  - `gpus`: added `max_length=32`
  - `python_installations`: added `max_length=64`

## Verification

- [ ] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI

**Manual test:** Sending a payload with 100 GPU entries returns HTTP 422. Sending a payload with 10 GPU entries succeeds.

## Documentation

- [ ] Code is fully documented and type-hinted

Please add the appropriate NSoC '26 label to this PR. Thank you!