### PR TITLE
fix(api): prevent memory leak by limiting concurrent thread resolution

### DIFF
--- a/backend/app/api/v1/diagnose.py
+++ b/backend/app/api/v1/diagnose.py
@@ -45,6 +45,9 @@ router = APIRouter()
 # accumulates all pages before running the resolver.
 _PROFILE_PAGE_SIZE = 100
 
+# Limit concurrency to 5 threads globally across all requests to avoid memory spikes under heavy load
+_RESOLVER_SEMAPHORE = asyncio.Semaphore(5)
+
 
 @router.post(
     "/diagnose",
@@ -133,24 +136,21 @@ async def diagnose(
     compatible_profiles: list[str] = []
     recommendations: list[str] = []
 
-    # Limit concurrency to 5 threads per request to avoid memory spikes under heavy load
-    sem = asyncio.Semaphore(5)
-
     # CompatibilityResolver.resolve() is a CPU-bound synchronous function.
     # Calling it directly inside an async handler blocks the event loop for
     # the duration of every resolve call. Under concurrent load, all other
     # requests queue behind the resolver. Each call is offloaded to a thread
     # via asyncio.to_thread so the event loop stays free.
     async def _resolve(profile: EnvironmentProfile) -> ResolvedEnvironment:
-        async with sem:
-            packages = [
-                PackageConstraint(
-                    name=package.package_name,
-                    version_spec=package.version_spec,
-                    cuda_variant=package.cuda_variant,
-                )
-                for package in sorted(profile.packages, key=lambda item: item.install_order)
-            ]
+        packages = [
+            PackageConstraint(
+                name=package.package_name,
+                version_spec=package.version_spec,
+                cuda_variant=package.cuda_variant,
+            )
+            for package in sorted(profile.packages, key=lambda item: item.install_order)
+        ]
+        async with _RESOLVER_SEMAPHORE:
             return await asyncio.to_thread(
                 resolver.resolve,
                 packages=packages,

--- a/backend/app/api/v1/diagnose.py
+++ b/backend/app/api/v1/diagnose.py
@@ -133,35 +133,39 @@ async def diagnose(
     compatible_profiles: list[str] = []
     recommendations: list[str] = []
 
+    # Limit concurrency to 5 threads per request to avoid memory spikes under heavy load
+    sem = asyncio.Semaphore(5)
+
     # CompatibilityResolver.resolve() is a CPU-bound synchronous function.
     # Calling it directly inside an async handler blocks the event loop for
     # the duration of every resolve call. Under concurrent load, all other
     # requests queue behind the resolver. Each call is offloaded to a thread
     # via asyncio.to_thread so the event loop stays free.
     async def _resolve(profile: EnvironmentProfile) -> ResolvedEnvironment:
-        packages = [
-            PackageConstraint(
-                name=package.package_name,
-                version_spec=package.version_spec,
-                cuda_variant=package.cuda_variant,
+        async with sem:
+            packages = [
+                PackageConstraint(
+                    name=package.package_name,
+                    version_spec=package.version_spec,
+                    cuda_variant=package.cuda_variant,
+                )
+                for package in sorted(profile.packages, key=lambda item: item.install_order)
+            ]
+            return await asyncio.to_thread(
+                resolver.resolve,
+                packages=packages,
+                python_version=(
+                    report.active_python.version if report.active_python else None
+                )
+                or "3.10",
+                cuda_version=report.cuda.version if report.cuda else None,
+                rocm_version=report.rocm.version if report.rocm else None,
+                target_os=target_os,
+                profile_slug=profile.slug,
+                os_support=profile.os_support,
+                cuda_required=profile.cuda_required,
+                rocm_required=getattr(profile, "rocm_required", False),
             )
-            for package in sorted(profile.packages, key=lambda item: item.install_order)
-        ]
-        return await asyncio.to_thread(
-            resolver.resolve,
-            packages=packages,
-            python_version=(
-                report.active_python.version if report.active_python else None
-            )
-            or "3.10",
-            cuda_version=report.cuda.version if report.cuda else None,
-            rocm_version=report.rocm.version if report.rocm else None,
-            target_os=target_os,
-            profile_slug=profile.slug,
-            os_support=profile.os_support,
-            cuda_required=profile.cuda_required,
-            rocm_required=getattr(profile, "rocm_required", False),
-        )
 
     results = await asyncio.gather(
         *[_resolve(p) for p in all_profiles],


### PR DESCRIPTION
## Description
Fixes a memory leak and performance bottleneck in the /api/v1/diagnose endpoint. Previously, when handling a diagnostic payload, the engine would fetch all profiles and spawn a thread for each simultaneously using syncio.to_thread. Under concurrent load (e.g. 500 requests), this spins up tens of thousands of threads simultaneously, spiking memory usage and crashing the application.

This PR adds an \syncio.Semaphore(5)\ to limit the number of concurrent profile resolutions per request.

## Related Issues
Fixes #388

## Changes Made
- Introduced an \syncio.Semaphore\ initialized to 5 in the \diagnose\ route.
- Wrapped the \syncio.to_thread(resolver.resolve, ...)\ call in \sync with sem\ to constrain maximum parallel threads spawned per request.

## Verification
- [x] Added unit tests / verified locally
- [ ] Ran \pytest tests/\ successfully
- [x] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass \SafetyFilter\

## Documentation
- [ ] Updated \docs/FEATURES.md\ (if adding a feature/profile)
- [ ] Updated \CHANGELOG.md\
- [x] Code is fully documented and type-hinted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Improved handling of concurrent requests to the diagnosis service for better stability under high-load scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->