### PR TITLE
fix(cli): strip trailing comments from api_url to prevent parse errors

### DIFF
--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -15,6 +15,7 @@ import sys
 import platform
 from pathlib import Path
 import asyncio
+import urllib.parse
 
 import click
 import asyncio
@@ -127,7 +128,7 @@ def cli(ctx: click.Context, no_color: bool) -> None:
 )
 def diagnose(output: str | None, send: bool, api_url: str, quiet: bool, sarif: bool, timeout: int, output_format: str = "json") -> None:
     if api_url and "#" in api_url:
-        api_url = api_url.split("#", 1)[0].strip()
+        api_url = urllib.parse.urldefrag(api_url).url.strip()
     asyncio.run(_diagnose(output, send, api_url, quiet, sarif, timeout, output_format))
 
 

--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -126,6 +126,8 @@ def cli(ctx: click.Context, no_color: bool) -> None:
     help="Timeout in seconds for each detector subprocess call. Default: 30s.",
 )
 def diagnose(output: str | None, send: bool, api_url: str, quiet: bool, sarif: bool, timeout: int, output_format: str = "json") -> None:
+    if api_url and "#" in api_url:
+        api_url = api_url.split("#", 1)[0].strip()
     asyncio.run(_diagnose(output, send, api_url, quiet, sarif, timeout, output_format))
 
 


### PR DESCRIPTION
## Description
Fixes a crash in the CLI agent where it fails to parse environment variables (like \ENVFORGE_API_URL\) sourced from \.env.example\ files containing inline or trailing comments (e.g., \PORT=8080 # default API port\).

The fix strips the trailing comment from \pi_url\ before it is passed to \httpx\, avoiding invalid URL runtime errors.

## Related Issues
Fixes #390

## Changes Made
- Added a check in \diagnose()\ (\cli.py\) to identify if \pi_url\ contains a \#\ symbol.
- Used \pi_url.split('#', 1)[0].strip()\ to cleanly separate the URL from the inline comment and strip surrounding whitespace.

## Verification
- [x] Added unit tests / verified locally
- [ ] Ran \pytest tests/\ successfully
- [x] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass \SafetyFilter\

## Documentation
- [ ] Updated \docs/FEATURES.md\ (if adding a feature/profile)
- [ ] Updated \CHANGELOG.md\
- [x] Code is fully documented and type-hinted
