### PR TITLE
fix(frontend): remove unused Variants import from framer-motion

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Variants, motion, useScroll, useTransform } from "framer-motion";
+import { motion, useScroll, useTransform } from "framer-motion";
 import {
 	CheckCircle2,
 	Package,


### PR DESCRIPTION
This PR removes an unused import 'Variants' from 'framer-motion' in 'frontend/src/app/page.tsx' to resolve a ESLint warning and ensure a perfectly clean frontend build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused import reference to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->