### PR TITLE
Warn on ABI-sensitive hybrid conda/pip GPU environments

### DIFF
--- a/backend/app/compatibility/resolver.py
+++ b/backend/app/compatibility/resolver.py
@@ -138,11 +138,14 @@ class CompatibilityResolver:
             )
             resolved_packages.append(resolved)
 
-        # Step 4: Collect OS-specific notes
+        # Step 4: Collect compatibility warnings
         framework_names = [p.name for p in packages]
         gpu_required = cuda_required or rocm_required
         os_notes = get_os_notes(target_os, gpu_required, framework_names)
         warnings.extend(os_notes)
+        warnings.extend(
+            self._warn_on_abi_sensitive_hybrid_environment(resolved_packages)
+        )
 
         return ResolvedEnvironment(
             python_version=python_version,
@@ -403,6 +406,25 @@ class CompatibilityResolver:
             cuda_version=cuda_version,
             rocm_version=rocm_version,
         )
+
+    def _warn_on_abi_sensitive_hybrid_environment(
+        self,
+        resolved_packages: list[ResolvedPackage],
+    ) -> list[str]:
+        """Detect ABI-sensitive conda + pip hybrid package mixes."""
+        has_gpu_wheel = any(pkg.cuda_variant for pkg in resolved_packages)
+        has_non_gpu_package = any(not pkg.cuda_variant for pkg in resolved_packages)
+
+        if has_gpu_wheel and has_non_gpu_package:
+            return [
+                (
+                    "This profile mixes conda-managed packages with pip-installed "
+                    "GPU wheel packages. Hybrid conda/pip environments are ABI-sensitive; "
+                    "pip may resolve secondary dependencies and override Conda-managed binaries. "
+                    "Review pins or use a conda-first profile."
+                )
+            ]
+        return []
 
     @staticmethod
     def _resolve_gpu_variant(

--- a/backend/app/templates/jinja/config/environment.yml.j2
+++ b/backend/app/templates/jinja/config/environment.yml.j2
@@ -8,8 +8,11 @@
 #
 # Install with:
 #   conda env create -f environment.yml
-# ==============================================================================
-
+# =============================================================================={% if warnings %}#
+# ── EnvForge Warnings ─────────────────────────────────────────────────────────
+{% for warning in warnings %}# WARNING: {{ warning }}
+{% endfor %}#
+{% endif %}
 name: {{ profile.name }}
 channels:
 {% if conda_channels is defined and conda_channels %}

--- a/backend/tests/unit/compatibility/test_resolver.py
+++ b/backend/tests/unit/compatibility/test_resolver.py
@@ -221,6 +221,25 @@ def test_non_matrix_package_uses_spec():
     assert result.packages[0].version == "3.8.4"
 
 
+def test_warns_on_hybrid_conda_pip_gpu_environment():
+    result = R.resolve(
+        packages=[
+            PackageConstraint("numpy", "1.26.4"),
+            PackageConstraint("torch", "2.1.2", cuda_variant="cu118"),
+        ],
+        python_version="3.11",
+        cuda_version="11.8",
+        target_os="LINUX",
+        profile_slug="pytorch-cuda",
+        os_support=["LINUX", "WSL"],
+        cuda_required=True,
+    )
+    assert any(
+        "conda-managed packages" in warning and "ABI-sensitive" in warning
+        for warning in result.warnings
+    )
+
+
 def test_to_dict_serializes():
     result = R.resolve(
         packages=[PackageConstraint("torch", "2.1.0")],

--- a/backend/tests/unit/compatibility/test_resolver.py
+++ b/backend/tests/unit/compatibility/test_resolver.py
@@ -3,6 +3,8 @@ Unit tests for the Compatibility Resolver.
 No mocks for matrix data — the matrix IS the ground truth.
 """
 
+import inspect
+
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -46,6 +48,12 @@ PACKAGE_CONSTRAINTS = st.one_of(
         version_spec=VERSION_STRINGS,
     ),
 )
+
+
+async def _await_if_needed(value):
+    if inspect.isawaitable(value):
+        return await value
+    return value
 
 
 @settings(max_examples=1000, deadline=None)
@@ -223,18 +231,21 @@ async def test_non_matrix_package_uses_spec():
     assert result.packages[0].version == "3.8.4"
 
 
-def test_warns_on_hybrid_conda_pip_gpu_environment():
-    result = R.resolve(
-        packages=[
-            PackageConstraint("numpy", "1.26.4"),
-            PackageConstraint("torch", "2.1.2", cuda_variant="cu118"),
-        ],
-        python_version="3.11",
-        cuda_version="11.8",
-        target_os="LINUX",
-        profile_slug="pytorch-cuda",
-        os_support=["LINUX", "WSL"],
-        cuda_required=True,
+@pytest.mark.asyncio
+async def test_warns_on_hybrid_conda_pip_gpu_environment():
+    result = await _await_if_needed(
+        R.resolve(
+            packages=[
+                PackageConstraint("numpy", "1.26.4"),
+                PackageConstraint("torch", "2.1.2", cuda_variant="cu118"),
+            ],
+            python_version="3.11",
+            cuda_version="11.8",
+            target_os="LINUX",
+            profile_slug="pytorch-cuda",
+            os_support=["LINUX", "WSL"],
+            cuda_required=True,
+        )
     )
     assert any(
         "conda-managed packages" in warning and "ABI-sensitive" in warning
@@ -242,15 +253,18 @@ def test_warns_on_hybrid_conda_pip_gpu_environment():
     )
 
 
-def test_to_dict_serializes():
-    result = R.resolve(
-        packages=[PackageConstraint("torch", "2.1.0")],
-        python_version="3.11",
-        cuda_version="11.8",
-        target_os="LINUX",
-        profile_slug="pytorch-cuda",
-        os_support=["LINUX", "WSL"],
-        cuda_required=True,
+@pytest.mark.asyncio
+async def test_to_dict_serializes():
+    result = await _await_if_needed(
+        R.resolve(
+            packages=[PackageConstraint("torch", "2.1.0")],
+            python_version="3.11",
+            cuda_version="11.8",
+            target_os="LINUX",
+            profile_slug="pytorch-cuda",
+            os_support=["LINUX", "WSL"],
+            cuda_required=True,
+        )
     )
     d = result.to_dict()
     assert d["python_version"] == "3.11"

--- a/backend/tests/unit/templates/test_conda_template.py
+++ b/backend/tests/unit/templates/test_conda_template.py
@@ -109,6 +109,23 @@ def test_conda_template_empty_packages():
     assert "dependencies:" in result.content
 
 
+def test_conda_template_includes_warnings_comments():
+    context = make_context(
+        profile_name="warn-env",
+        python_version="3.11",
+        packages=[
+            ResolvedPackage(name="numpy", version="1.26.4", cuda_variant=None),
+            ResolvedPackage(name="torch", version="2.1.2", cuda_variant="cu118"),
+        ],
+    )
+    context.warnings = [
+        "This profile mixes conda-managed packages with pip-installed GPU wheels."
+    ]
+    renderer = TemplateRenderer()
+    result = renderer.render("environment.yml", context)
+    assert "# WARNING: This profile mixes conda-managed packages" in result.content
+
+
 def test_conda_template_cuda_variant_goes_to_pip_section():
     """Packages with CUDA variant ('+' in spec) must appear under pip: section."""
     context = make_context(


### PR DESCRIPTION
## Description
Adds a warning for ABI-sensitive hybrid Conda + pip GPU environments. When a profile mixes Conda-managed packages with pip-installed CUDA wheel packages, EnvForge now emits a compatibility warning in both resolver output and generated `environment.yml`.

## Related Issues
#465 

## Changes Made
- Added hybrid ABI sensitivity detection to resolver.py
- Added warning rendering to environment.yml.j2
- Added unit tests for resolver warning generation
- Added unit tests for template warning rendering

## Verification
- [x] Added unit tests
- [x] Ran targeted `pytest` successfully for modified tests
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated FEATURES.md (if adding a feature/profile)
- [ ] Updated CHANGELOG.md
- [x] Code is fully documented and type-hinted



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and warn when environments mix GPU-enabled and non‑GPU packages, flagging ABI-sensitive conda/pip hybrids.
  * Generated environment configuration files now include formatted warning comments at the top when such warnings exist.

Level: Intermediiate 
Type: Feature
* **Tests**
  * Added and updated unit tests to verify warning generation and inclusion in rendered environment files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->