### PR TITLE
Feat/markdown diagnostic format v2

### DIFF
--- a/cli/envforge_agent/audit/sources.py
+++ b/cli/envforge_agent/audit/sources.py
@@ -10,7 +10,10 @@ slot in by subclassing Source and yielding Package instances.
 """
 
 from __future__ import annotations
-import tomllib
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef]
 import json
 import re
 import subprocess

--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -18,7 +18,6 @@ import asyncio
 import urllib.parse
 
 import click
-import asyncio
 import httpx
 from rich.console import Console
 from rich.panel import Panel

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -25,18 +25,35 @@ envforge diagnose [OPTIONS]
 ### Options
 | Option | Description |
 |--------|-------------|
-| `-o, --output PATH` | Save the JSON report to the specified file path. |
-| `--send` | Send the report directly to the EnvForge API for compatibility analysis. |
+| `-o, --output PATH` | Save the report to the specified file path. |
+| `-f, --format [json\|yaml\|markdown]` | Output format for the diagnostic report. Defaults to `json`. |
+| `--send` | Send the report directly to the EnvForge API for compatibility analysis. Requires `--format json`. |
 | `--api-url TEXT` | The base URL of the EnvForge API. Defaults to `http://localhost:8000`. Can also be set via `ENVFORGE_API_URL`. |
-| `-q, --quiet` | Suppress all human-readable terminal output and only print the raw JSON to stdout (useful for piping). |
+| `-q, --quiet` | Suppress all human-readable terminal output and only print the raw report to stdout. |
+| `--sarif` | Output diagnostics in SARIF 2.1.0 format for CI/CD pipeline integrations. |
+| `-t, --timeout INT` | Timeout in seconds for each detector subprocess call. Defaults to `30`. |
+
+> **WSL2 Note**: On WSL2 systems, `envforge diagnose` automatically checks GPU passthrough health (`/dev/dxg`, `nvidia-smi`, NVIDIA container toolkit) and warns if GPU acceleration is unavailable inside WSL2.
 
 ### Example
 ```bash
-# Save to file
-envforge diagnose --output my_report.json
+# Save JSON to file
+envforge diagnose --output report.json
+
+# Output as markdown
+envforge diagnose --format markdown
+
+# Save markdown report to file
+envforge diagnose --format markdown --output report.md
+
+# Output as YAML
+envforge diagnose --format yaml
 
 # Send to API for immediate analysis
 envforge diagnose --send
+
+# CI/CD SARIF output
+envforge diagnose --sarif
 ```
 
 ---


### PR DESCRIPTION
## Description

Adds --format markdown output option to envforge diagnose command, allowing diagnostic reports to be rendered as structured Markdown documents — useful for pasting into GitHub issues, wikis, or CI job summaries.

Also updates docs/CLI_REFERENCE.md with all missing options (--format, --sarif, --timeout) and the WSL2 GPU passthrough note that were undocumented since the original CLI was written.

## Related Issues

Fixes #391
Relates to #472 (duplicate diagnose function — already fixed by another contributor, this PR completes the missing documentation left behind from that refactor)

## Changes Made

- Added to_markdown() method on DiagnosticReport in schemas.py
- Added markdown to --format choices in cli.py diagnose command
- Fixed duplicate import asyncio leftover in cli.py
- Added 11 pytest unit tests for to_markdown() in test_diagnose_output.py
- Updated docs/FEATURES.md with Feature 8 (Markdown Diagnostic Format)
- Updated docs/CLI_REFERENCE.md with all undocumented options and WSL2 GPU passthrough note
- Updated CHANGELOG.md with markdown format entry
 - Fixed tomllib import in audit/sources.py for Python 3.10 compatibility


## Verification
Ran `envforge diagnose --format markdown` locally via CLI — output rendered correctly as structured Markdown (see screenshot). Unit tests added for `to_markdown()` covering all sections, fallback cases, and CLI integration paths.

- [x] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [x] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [x] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [x] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted

## Screenshots (if applicable)

<img width="774" height="595" alt="Screenshot 2026-06-03 131344" src="https://github.com/user-attachments/assets/cd85cdbf-1c5c-4e7e-a570-add970388799" />



💡 Innovation opportunity — the WSL2 GPU passthrough detection (detect_wsl_gpu_passthrough) is already implemented in gpu_detector.py but currently only warns to terminal. It could be surfaced in the markdown/SARIF report output as a structured ## Warnings section, making it actionable in CI pipelines. Want me to add that?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced CLI reference documentation for `envforge diagnose` with additional options including `--format` (json|yaml|markdown), `--sarif`, and `--timeout`.
  * Added new usage examples demonstrating multiple output formats, API integration, and SARIF output generation.
  * Included WSL2-specific GPU passthrough notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->