### PR TITLE
fix(#482): remove accidental tuple wrapping of safe_commands in _perist_session

### DIFF
--- a/backend/app/ai/service.py
+++ b/backend/app/ai/service.py
@@ -354,9 +354,7 @@ class AITroubleshootService:
                         title=fix.title,
                         description=fix.description,
                         severity=fix.severity,
-                        safe_commands=(
-                            fix.safe_commands if fix.safe_commands else None,
-                        ),
+                        safe_commands=fix.safe_commands if fix.safe_commands else None,
                         template_id=fix.repair_template_id,
                         created_at=datetime.now(UTC),
                     )


### PR DESCRIPTION
## Description
In `backend/app/ai/service.py`, inside the `_persist_session` method, AI-generated suggested fixes are stored in the database. Due to a trailing comma inside the parentheses on line 357.
Python interpreted this expression as a single-element tuple (value,) containing the list of commands or None. As a result, corrupted database entries (like a list wrapped inside a tuple) were written to the AISuggestion.safe_commands column, which expects a clean ARRAY(String) or None.

This PR removes the accidental parentheses and trailing comma so that the plain list or None is passed directly.

## Related Issues
Closes #482

## Changes Made
-Modified backend/app/ai/service.py to remove parenthetical tuple wrapping for safe_commands.
-Added unit tests in backend/tests/ai/test_issue_482_safe_commands.py specifically targeting _persist_session to ensure safe_commands is persisted to the database as a plain list or None, and not wrapped in a tuple.

## Verification
 - Added unit tests (backend/tests/ai/test_issue_482_safe_commands.py)
 - an pytest tests/ successfully (all 11 integration tests and specific issue tests passed)
 - Manually tested via the API / CLI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Code refactoring to improve maintainability with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->