### PR TITLE
fix(#483): decouple safety_passed from DB persistence failures in audit log

### DIFF
--- a/backend/app/ai/service.py
+++ b/backend/app/ai/service.py
@@ -186,7 +186,7 @@ class AITroubleshootService:
             db,
             session_id=session_id,
             input_hash=input_hash,
-            safety_passed=not persist_failed,
+            safety_passed=True,
             safety_violation="DB persistence failure" if persist_failed else None,
             provider=provider_name,
             tokens_used=total_tokens,

--- a/backend/tests/ai/test_issue_483_safety_passed.py
+++ b/backend/tests/ai/test_issue_483_safety_passed.py
@@ -59,6 +59,7 @@ class TestSafetyPassedNotMisused:
                         mock_db = AsyncMock()
                         mock_request = MagicMock()
                         mock_request.session_id = None
+                        mock_request.user_description = "some problem"
                         mock_request.model_dump_json.return_value = "{}"
 
                         await service.troubleshoot(mock_request, mock_db)
@@ -110,6 +111,7 @@ class TestSafetyPassedNotMisused:
                         mock_db = AsyncMock()
                         mock_request = MagicMock()
                         mock_request.session_id = None
+                        mock_request.user_description = "some problem"
                         mock_request.model_dump_json.return_value = "{}"
 
                         await service.troubleshoot(mock_request, mock_db)
@@ -159,6 +161,7 @@ class TestSafetyPassedNotMisused:
                         mock_db = AsyncMock()
                         mock_request = MagicMock()
                         mock_request.session_id = None
+                        mock_request.user_description = "some problem"
                         mock_request.model_dump_json.return_value = "{}"
 
                         await service.troubleshoot(mock_request, mock_db)
@@ -189,13 +192,14 @@ class TestSafetyPassedNotMisused:
             })
 
         with patch.object(service, "_validate_response_safety",
-                          side_effect=SafetyViolationError("rm -rf detected")):
+                          side_effect=SafetyViolationError(pattern="rm -rf", description="rm -rf detected")):
             with patch.object(service, "_log_audit",
                               side_effect=capture_log_audit):
                 with patch("app.ai.service.record_ai_token_usage"):
                     mock_db = AsyncMock()
                     mock_request = MagicMock()
                     mock_request.session_id = None
+                    mock_request.user_description = "some problem"
                     mock_request.model_dump_json.return_value = "{}"
 
                     with pytest.raises(SafetyViolationError):

--- a/backend/tests/ai/test_issue_483_safety_passed.py
+++ b/backend/tests/ai/test_issue_483_safety_passed.py
@@ -1,0 +1,204 @@
+"""
+Tests for Issue #483 — safety_passed misused for DB persistence failure tracking.
+Branch: fix/483-safety-passed-misuse
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+
+class TestSafetyPassedNotMisused:
+    """
+    Verify safety_passed=True is always set on the success audit path,
+    regardless of DB persistence failure. DB failures must NOT cause
+    safety_passed=False in audit logs.
+    """
+
+    @pytest.mark.asyncio
+    async def test_safety_passed_true_when_persist_fails(self):
+        """
+        CRITICAL: Even if _persist_session raises an exception,
+        safety_passed must still be True in the audit log.
+        Old bug: safety_passed=not persist_failed  ← set to False on DB error.
+        Fixed:   safety_passed=True  ← always True on this code path.
+        """
+        from app.ai.service import AITroubleshootService
+
+        mock_provider = AsyncMock()
+        mock_provider.model = "gpt-4"
+        mock_provider.last_token_usage = {"total_tokens": 100,
+                                          "prompt_tokens": 60,
+                                          "completion_tokens": 40}
+        mock_provider.complete.return_value = MagicMock(
+            suggested_fixes=[],
+            session_id=None,
+            suppressed_fix_count=0,
+            confidence=0.0,
+            repair_script_available=False,
+        )
+
+        service = AITroubleshootService(provider=mock_provider)
+
+        audit_calls = []
+
+        async def capture_log_audit(db, *, session_id, input_hash,
+                                    safety_passed, safety_violation,
+                                    provider, tokens_used, latency_ms):
+            audit_calls.append({
+                "safety_passed": safety_passed,
+                "safety_violation": safety_violation,
+            })
+
+        with patch.object(service, "_validate_response_safety"):
+            with patch.object(service, "_persist_session",
+                              side_effect=Exception("DB connection refused")):
+                with patch.object(service, "_log_audit",
+                                  side_effect=capture_log_audit):
+                    with patch("app.ai.service.record_ai_token_usage"):
+                        mock_db = AsyncMock()
+                        mock_request = MagicMock()
+                        mock_request.session_id = None
+                        mock_request.model_dump_json.return_value = "{}"
+
+                        await service.troubleshoot(mock_request, mock_db)
+
+        assert len(audit_calls) == 1, f"Expected 1 audit call, got {len(audit_calls)}"
+        final_audit = audit_calls[0]
+
+        assert final_audit["safety_passed"] is True, (
+            f"safety_passed={final_audit['safety_passed']} but expected True. "
+            "DB failure must NOT set safety_passed=False. Issue #483 NOT fixed!"
+        )
+
+    @pytest.mark.asyncio
+    async def test_safety_violation_indicates_db_failure_not_safety(self):
+        """
+        When DB persistence fails, safety_violation field should indicate
+        it's a persistence issue, not an AI safety violation.
+        """
+        from app.ai.service import AITroubleshootService
+
+        mock_provider = AsyncMock()
+        mock_provider.model = "gpt-4"
+        mock_provider.last_token_usage = {}
+        mock_provider.complete.return_value = MagicMock(
+            suggested_fixes=[],
+            session_id=None,
+            suppressed_fix_count=0,
+            confidence=0.0,
+            repair_script_available=False,
+        )
+
+        service = AITroubleshootService(provider=mock_provider)
+        audit_calls = []
+
+        async def capture_log_audit(db, *, session_id, input_hash,
+                                    safety_passed, safety_violation,
+                                    provider, tokens_used, latency_ms):
+            audit_calls.append({
+                "safety_passed": safety_passed,
+                "safety_violation": safety_violation,
+            })
+
+        with patch.object(service, "_validate_response_safety"):
+            with patch.object(service, "_persist_session",
+                              side_effect=Exception("DB down")):
+                with patch.object(service, "_log_audit",
+                                  side_effect=capture_log_audit):
+                    with patch("app.ai.service.record_ai_token_usage"):
+                        mock_db = AsyncMock()
+                        mock_request = MagicMock()
+                        mock_request.session_id = None
+                        mock_request.model_dump_json.return_value = "{}"
+
+                        await service.troubleshoot(mock_request, mock_db)
+
+        final_audit = audit_calls[0]
+        # safety_violation should mention DB, not be a real safety violation
+        if final_audit["safety_violation"] is not None:
+            assert "DB" in final_audit["safety_violation"] or \
+                   "persistence" in final_audit["safety_violation"].lower(), (
+                "safety_violation must clearly indicate DB failure, not an AI safety issue"
+            )
+
+    @pytest.mark.asyncio
+    async def test_safety_passed_true_and_no_violation_on_full_success(self):
+        """On full success path, safety_passed=True and safety_violation=None."""
+        from app.ai.service import AITroubleshootService
+
+        mock_provider = AsyncMock()
+        mock_provider.model = "gpt-4"
+        mock_provider.last_token_usage = {"total_tokens": 200,
+                                          "prompt_tokens": 100,
+                                          "completion_tokens": 100}
+        mock_provider.complete.return_value = MagicMock(
+            suggested_fixes=[],
+            session_id=None,
+            suppressed_fix_count=0,
+            confidence=0.0,
+            repair_script_available=False,
+        )
+
+        service = AITroubleshootService(provider=mock_provider)
+        audit_calls = []
+
+        async def capture_log_audit(db, *, session_id, input_hash,
+                                    safety_passed, safety_violation,
+                                    provider, tokens_used, latency_ms):
+            audit_calls.append({
+                "safety_passed": safety_passed,
+                "safety_violation": safety_violation,
+            })
+
+        with patch.object(service, "_validate_response_safety"):
+            with patch.object(service, "_persist_session", new_callable=AsyncMock):
+                with patch.object(service, "_log_audit",
+                                  side_effect=capture_log_audit):
+                    with patch("app.ai.service.record_ai_token_usage"):
+                        mock_db = AsyncMock()
+                        mock_request = MagicMock()
+                        mock_request.session_id = None
+                        mock_request.model_dump_json.return_value = "{}"
+
+                        await service.troubleshoot(mock_request, mock_db)
+
+        final_audit = audit_calls[0]
+        assert final_audit["safety_passed"] is True
+        assert final_audit["safety_violation"] is None
+
+    @pytest.mark.asyncio
+    async def test_safety_passed_false_on_real_safety_violation(self):
+        """Real SafetyViolationError must still set safety_passed=False."""
+        from app.ai.service import AITroubleshootService
+        from app.templates.safety import SafetyViolationError
+
+        mock_provider = AsyncMock()
+        mock_provider.model = "gpt-4"
+        mock_provider.complete.return_value = MagicMock(suggested_fixes=[])
+
+        service = AITroubleshootService(provider=mock_provider)
+        audit_calls = []
+
+        async def capture_log_audit(db, *, session_id, input_hash,
+                                    safety_passed, safety_violation,
+                                    provider, tokens_used, latency_ms):
+            audit_calls.append({
+                "safety_passed": safety_passed,
+                "safety_violation": safety_violation,
+            })
+
+        with patch.object(service, "_validate_response_safety",
+                          side_effect=SafetyViolationError("rm -rf detected")):
+            with patch.object(service, "_log_audit",
+                              side_effect=capture_log_audit):
+                with patch("app.ai.service.record_ai_token_usage"):
+                    mock_db = AsyncMock()
+                    mock_request = MagicMock()
+                    mock_request.session_id = None
+                    mock_request.model_dump_json.return_value = "{}"
+
+                    with pytest.raises(SafetyViolationError):
+                        await service.troubleshoot(mock_request, mock_db)
+
+        assert audit_calls[0]["safety_passed"] is False
+        assert "rm -rf" in audit_calls[0]["safety_violation"]

--- a/backend/tests/ai/test_issue_483_safety_passed.py
+++ b/backend/tests/ai/test_issue_483_safety_passed.py
@@ -3,8 +3,9 @@ Tests for Issue #483 — safety_passed misused for DB persistence failure tracki
 Branch: fix/483-safety-passed-misuse
 """
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch, call
 
 
 class TestSafetyPassedNotMisused:

--- a/backend/tests/unit/ai/test_persist_session.py
+++ b/backend/tests/unit/ai/test_persist_session.py
@@ -1,12 +1,11 @@
-"""Unit tests for _persist_session bug fix (Issue #300).
-
-Verifies that:
-1. A DB constraint error is logged with full traceback (logger.exception).
-2. db.rollback() is called when persistence fails.
-3. The exception is re-raised so the caller can react.
-4. troubleshoot() marks the audit log as failed (safety_passed=False)
-   when _persist_session raises.
-"""
+# Unit tests for _persist_session bug fix (Issue #300).
+#
+# Verifies that:
+# 1. A DB constraint error is logged with full traceback (logger.exception).
+# 2. db.rollback() is called when persistence fails.
+# 3. The exception is re-raised so the caller can react.
+# 4. troubleshoot() marks the audit log as safety_passed=True with
+#    safety_violation="DB persistence failure" when _persist_session raises.
 
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -118,7 +117,7 @@ async def test_persist_session_logs_full_traceback_on_error():
 
 @pytest.mark.asyncio
 async def test_troubleshoot_audit_marked_failed_when_persist_fails():
-    """When _persist_session raises, _log_audit must be called with safety_passed=False."""
+    """When _persist_session raises, _log_audit must be called with safety_passed=True."""
     service = AITroubleshootService()
 
     llm_result = _make_llm_result()
@@ -153,7 +152,7 @@ async def test_troubleshoot_audit_marked_failed_when_persist_fails():
         # Audit MUST record the failure
         mock_log_audit.assert_awaited_once()
         call_kwargs = mock_log_audit.call_args.kwargs
-        assert call_kwargs["safety_passed"] is False
+        assert call_kwargs["safety_passed"] is True
         assert call_kwargs["safety_violation"] == "DB persistence failure"
 
 


### PR DESCRIPTION
## Description
The `_log_audit` call after `_persist_session` was using `safety_passed=not persist_failed`. This was incorrect because the AI safety check had already passed successfully at this point in the execution pipeline (if there had been a safety violation, a `SafetyViolationError` would have been raised earlier and the function would have returned).

Marking the audit log as having failed safety (`safety_passed=False`) when only a database write/persistence operation failed incorrectly conflates infrastructure errors with content moderation/AI safety violations in the audit trail.

This PR decouples the two by setting `safety_passed=True` (since the AI safety check indeed passed) and relies on the `safety_violation` field setting `"DB persistence failure"` to capture database-specific errors for operational logging and alerting.

## Related Issues
Closes #483

## Changes Made
- Modified `backend/app/ai/service.py` to change `safety_passed=not persist_failed` to `safety_passed=True` in the post-persistence audit logging block.
- Added comprehensive unit tests in `backend/tests/ai/test_issue_483_safety_passed.py` to verify that `safety_passed` remains `True` and `safety_violation` logs the database failure correctly when database write operations fail.

## Verification
- [x] Added unit tests (`backend/tests/ai/test_issue_483_safety_passed.py`)
- [x] Ran `pytest tests/` successfully (all tests passed)
- [x] Manually tested via the API / CLI

## Documentation
- [x] Code is fully documented and type-hinted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected audit logging to properly distinguish between AI safety violations and database failures. Database persistence errors are now recorded as infrastructure issues rather than safety concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->