### PR TITLE
Add rate limiting to authentication endpoints

### DIFF
--- a/backend/app/api/v1/authentication.py
+++ b/backend/app/api/v1/authentication.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime, timedelta
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from jose import jwt
 from passlib.context import CryptContext
 from pydantic import BaseModel, EmailStr, Field, field_validator
@@ -8,10 +8,19 @@ from sqlalchemy.exc import IntegrityError
 
 from app.api.deps import DB
 from app.config import get_settings
+from app.middleware.rate_limit import RateLimiter
 from app.services.user_repository import UserRepository
 
 router = APIRouter()
 pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+# Rate limiters for authentication endpoints
+# Prevent credential brute force and account enumeration attacks
+# Signup: 5 attempts per 15 minutes per IP
+auth_signup_limiter = RateLimiter(max_requests=5, window_seconds=900)
+
+# Signin: 10 attempts per 15 minutes per IP (slightly more lenient for legitimate users)
+auth_signin_limiter = RateLimiter(max_requests=10, window_seconds=900)
 
 
 # ── Request schemas ────────────────────────────────────────────────────────────
@@ -57,7 +66,27 @@ class TokenResponse(BaseModel):
 # ── Routes ────────────────────────────────────────────────────────────────────
 
 @router.post("/signup", response_model=MessageResponse)
-async def signup(data: RegData, db: DB) -> MessageResponse:
+async def signup(
+    data: RegData,
+    db: DB,
+    _rate_limit: None = Depends(auth_signup_limiter),
+) -> MessageResponse:
+    """Create a new user account with rate limiting against brute force.
+
+    Prevents account enumeration and signup abuse through rate limiting.
+    Limits to 5 signup attempts per 15 minutes per IP address.
+
+    Args:
+        data: Registration data (fname, lname, email, password)
+        db: Database session
+        _rate_limit: Rate limiting dependency (raises 429 if limit exceeded)
+
+    Returns:
+        MessageResponse with success message
+
+    Raises:
+        HTTPException: 400 if email already registered, 429 if rate limited
+    """
     repo = UserRepository(db)
     if await repo.user_exists(data.email):
         raise HTTPException(status_code=400, detail="Email already registered")
@@ -77,7 +106,27 @@ async def signup(data: RegData, db: DB) -> MessageResponse:
 
 
 @router.post("/signin", response_model=TokenResponse)
-async def signin(data: LoginData, db: DB) -> TokenResponse:
+async def signin(
+    data: LoginData,
+    db: DB,
+    _rate_limit: None = Depends(auth_signin_limiter),
+) -> TokenResponse:
+    """Authenticate user and return JWT token with rate limiting.
+
+    Prevents credential brute force attacks through rate limiting.
+    Limits to 10 signin attempts per 15 minutes per IP address.
+
+    Args:
+        data: Login credentials (email, password)
+        db: Database session
+        _rate_limit: Rate limiting dependency (raises 429 if limit exceeded)
+
+    Returns:
+        TokenResponse with JWT token and email
+
+    Raises:
+        HTTPException: 401 if credentials invalid, 429 if rate limited
+    """
     repo = UserRepository(db)
     user = await repo.get_user_by_email(data.email)
     if not user or not pwd.verify(data.password, user.password):

--- a/backend/tests/unit/test_auth.py
+++ b/backend/tests/unit/test_auth.py
@@ -51,7 +51,13 @@ def _make_client(db_session: AsyncSession, monkeypatch) -> TestClient:
     async def override_get_db():
         yield db_session
 
+    # Mock the rate limiters so tests bypass rate limiting
+    async def mock_rate_limiter():
+        return None
+
     test_app.dependency_overrides[get_db] = override_get_db
+    test_app.dependency_overrides[auth_module.auth_signup_limiter] = mock_rate_limiter
+    test_app.dependency_overrides[auth_module.auth_signin_limiter] = mock_rate_limiter
     return TestClient(test_app, raise_server_exceptions=True)
 
 


### PR DESCRIPTION
## Summary
Implements rate limiting on signup and signin endpoints to prevent credential brute force and account enumeration attacks. Uses existing RateLimiter middleware with per-IP tracking.

## Detailed Technical Analysis
Authentication endpoints currently have no rate limiting. An attacker can make unlimited login attempts against a single email address or enumerate valid accounts by checking registration availability. Rate limiting prevents both attacks by limiting requests per IP per time window.

## Real-World Scenarios
- Attacker makes 1000 signin attempts in seconds
- Password dictionary tested against target email in minutes
- Account compromised through brute force
- Attacker enumerates valid users by testing signup endpoint

## Complete Implementation
- Signup: 5 attempts per 15 minutes per IP (prevents account enumeration)
- Signin: 10 attempts per 15 minutes per IP (prevents brute force)
- Uses existing RateLimiter middleware infrastructure
- Automatic fallback to in-memory limiter if Redis unavailable
- Proper HTTP 429 response with Retry-After header
- IP detection with X-Forwarded-For support for proxies

## Testing Strategy
1. Test that 6th signup request is rejected with 429
2. Test that 11th signin request is rejected with 429
3. Test Retry-After header is set correctly
4. Test different IPs have separate limit tracking
5. Test X-Forwarded-For header respected from trusted proxies
6. Test Redis backend distributes limits across workers
7. Test fallback to in-memory when Redis unavailable
8. Load test with concurrent requests
9. Verify cleanup of expired rate limit entries

## Related Standards
- OWASP: Brute Force Protection
- CWE-307: Improper Restriction of Rendered UI Layers
- RFC 6585: Additional HTTP Status Codes

Fixes #509

/assign anshul23102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-IP rate limiting added to signup and signin flows; excessive requests are temporarily blocked until limits reset to reduce abuse.
* **Tests**
  * Authentication tests updated to bypass rate limiting so test runs aren’t affected by throttling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->