### PR TITLE
fix(rate-limit): use snapshot when iterating cleanup entries

### DIFF
--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -135,7 +135,7 @@ class InMemoryBackend(RateLimitBackend):
         now = time.monotonic()
         empty_keys = [
             key
-            for key, timestamps in self._requests.items()
+            for key, timestamps in list(self._requests.items())
             if not timestamps or max(timestamps) < now - 300
         ]
         for key in empty_keys:


### PR DESCRIPTION
## Description

Fixes a potential `RuntimeError: dictionary changed size during iteration` in `InMemoryBackend.cleanup`.

### Changes Made

* Updated cleanup iteration to use a static snapshot via `list(self._requests.items())`.
* Prevents iteration over a live dictionary view while concurrent modifications may occur.
* Preserves existing cleanup behavior.

Closes #306

### Testing

* Reviewed cleanup logic after the change.
* Verified iteration now operates on a snapshot of dictionary entries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Performed routine maintenance optimization on internal rate-limiting cleanup logic with no impact to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->