### PR TITLE
fix: validate package names in profile schema

### DIFF
--- a/backend/app/schemas/profile.py
+++ b/backend/app/schemas/profile.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 class PackageSpecSchema(BaseModel):
     package_name: str = Field(
         ...,
+        pattern=r"^[A-Za-z0-9._-]+$",
         description="Name of the package to install.",
         examples=["torch"],
     )

--- a/backend/app/schemas/profile.py
+++ b/backend/app/schemas/profile.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 class PackageSpecSchema(BaseModel):
     package_name: str = Field(
         ...,
-        pattern=r"^[A-Za-z0-9._-]+$",
+        pattern=r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$",
         description="Name of the package to install.",
         examples=["torch"],
     )

--- a/backend/tests/integration/test_profiles.py
+++ b/backend/tests/integration/test_profiles.py
@@ -221,7 +221,7 @@ async def test_create_profile_with_invalid_package_name_returns_422(client):
         "python_versions": ["3.11"],
         "packages": [
             {
-                "package_name": " ",
+                "package_name": "-torch",
                 "version_spec": "==2.3.0",
                 "is_optional": False,
                 "install_order": 1,
@@ -236,4 +236,3 @@ async def test_create_profile_with_invalid_package_name_returns_422(client):
     )
 
     assert response.status_code == 422
-    

--- a/backend/tests/integration/test_profiles.py
+++ b/backend/tests/integration/test_profiles.py
@@ -212,3 +212,28 @@ async def test_delete_profile_with_wrong_admin_key_returns_401(client):
     response = await client.delete("/api/v1/profiles/any-slug", headers=wrong_headers)
     assert response.status_code == 401
     assert response.json()["detail"]["error"]["code"] == "INVALID_ADMIN_KEY"
+
+async def test_create_profile_with_invalid_package_name_returns_422(client):
+    profile_data = {
+        "slug": "invalid-package-test",
+        "name": "Invalid Package Test",
+        "os_support": ["LINUX"],
+        "python_versions": ["3.11"],
+        "packages": [
+            {
+                "package_name": " ",
+                "version_spec": "==2.3.0",
+                "is_optional": False,
+                "install_order": 1,
+            }
+        ],
+    }
+
+    response = await client.post(
+        "/api/v1/profiles",
+        json=profile_data,
+        headers=ADMIN_HEADERS,
+    )
+
+    assert response.status_code == 422
+    


### PR DESCRIPTION
## Description

Adds validation for `package_name` in `PackageSpecSchema` to prevent empty or whitespace-only package names from being accepted.

Without validation, invalid package names could be included in generated setup scripts, resulting in broken `pip install` commands and script execution failures.

## Related Issues

Fixes #554

## Changes Made

* Added a regex pattern constraint to `PackageSpecSchema.package_name`
* Added an integration test to verify invalid package names return HTTP 422 validation errors

## Verification

* [x] Added unit/integration tests
* [x] Ran `pytest tests/integration/test_profiles.py` successfully
* [x] Manually verified schema validation behavior
* [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation

* [ ] Updated `docs/FEATURES.md` (not required)
* [ ] Updated `CHANGELOG.md` (not required)
* [x] Code is fully documented and type-hinted

## Screenshots (if applicable)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Package names are now validated to contain only alphanumeric characters, dots, underscores, and hyphens. Invalid package names will be rejected with a validation error.

* **Tests**
  * Added test coverage for package name validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->