### PR TITLE
feat: implement PATCH /profiles/{slug} partial profile update endpoint

### DIFF
--- a/backend/app/api/v1/profiles.py
+++ b/backend/app/api/v1/profiles.py
@@ -14,6 +14,7 @@ from app.schemas.profile import (
     ProfileFilters,
     ProfileListResponse,
     ProfileSummarySchema,
+    ProfileUpdateSchema,
 )
 from app.services import profile_service
 
@@ -198,3 +199,46 @@ async def delete_profile(
             error_code="PROFILE_NOT_FOUND",
         )
     logger.info("Profile deleted: slug=%s", slug)
+
+
+@router.patch(
+    "/profiles/{slug}",
+    response_model=ProfileDetailSchema,
+    status_code=status.HTTP_200_OK,
+    summary="Update environment profile",
+    description="Partially update an environment profile using its slug. Only the fields provided in the request body are changed.",
+    tags=["Profiles"],
+    responses={
+        200: {"description": "Profile updated successfully."},
+        401: {"description": "Missing or invalid admin API key."},
+        404: {"description": "Profile not found."},
+        422: {"description": "Request validation error."},
+        503: {"description": "Admin API key not configured on this server."},
+    },
+)
+async def update_profile(
+    profile_in: ProfileUpdateSchema,
+    db: DB,
+    slug: str = Path(
+        ...,
+        description="Unique slug of the environment profile to update.",
+        examples=["pytorch-cu121"],
+    ),
+    _rate_limit: None = Depends(general_rate_limit),
+    _auth: None = Depends(require_admin),
+) -> ProfileDetailSchema:
+    """
+    Partially update an environment profile by slug.
+
+    Only the fields included in the request body are modified;
+    omitted fields retain their current values.
+    """
+    logger.info("Admin write: updating profile slug=%s", slug)
+    updated = await profile_service.update_profile(db, slug, profile_in)
+    if updated is None:
+        raise EntityNotFoundError(
+            resource=f"Profile '{slug}'",
+            error_code="PROFILE_NOT_FOUND",
+        )
+    logger.info("Profile updated: slug=%s", slug)
+    return ProfileDetailSchema.model_validate(updated)

--- a/backend/app/schemas/profile.py
+++ b/backend/app/schemas/profile.py
@@ -127,6 +127,60 @@ class ProfileCreateSchema(BaseModel):
     }
 
 
+class ProfileUpdateSchema(BaseModel):
+    """Schema for partially updating an existing profile (all fields optional)."""
+
+    name: str | None = Field(
+        None,
+        max_length=128,
+        description="Human-readable name of the environment profile.",
+        examples=["PyTorch CUDA 12.1"],
+    )
+    description: str | None = Field(
+        None,
+        description="Optional summary describing the profile purpose.",
+        examples=["GPU-ready PyTorch environment for CUDA 12.1."],
+    )
+    tags: list[str] | None = Field(
+        None,
+        description="Tags used to categorize and filter the profile.",
+        examples=[["ml", "cuda", "pytorch"]],
+    )
+    os_support: list[str] | None = Field(
+        None,
+        description="Supported operating systems for this profile.",
+        examples=[["LINUX", "WSL"]],
+    )
+    cuda_required: bool | None = Field(
+        None,
+        description="Whether this profile requires CUDA support.",
+        examples=[True],
+    )
+    python_versions: list[str] | None = Field(
+        None,
+        description="Supported Python versions for this profile.",
+        examples=[["3.10", "3.11"]],
+    )
+    cuda_versions: list[str] | None = Field(
+        None,
+        description="Supported CUDA versions for this profile, if applicable.",
+        examples=[["12.1"]],
+    )
+    packages: list[PackageSpecSchema] | None = Field(
+        None,
+        description="Ordered list of packages required by this profile. Replaces all existing packages when provided.",
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "name": "PyTorch CUDA 12.1 (Updated)",
+                "tags": ["ml", "cuda", "pytorch", "updated"],
+            }
+        }
+    }
+
+
 class ProfileSummarySchema(BaseModel):
     """Lightweight profile for list responses."""
 

--- a/backend/app/services/profile_service.py
+++ b/backend/app/services/profile_service.py
@@ -18,6 +18,7 @@ from app.schemas.profile import (
     ProfileDetailSchema,
     ProfileFilters,
     ProfileSummarySchema,
+    ProfileUpdateSchema,
 )
 
 
@@ -62,9 +63,15 @@ async def list_cached_profiles(
     profiles, total = await list_profiles(db, filters, include_packages)
 
     if include_packages:
-        profiles_data = [ProfileDetailSchema.model_validate(p).model_dump(mode="json") for p in profiles]
+        profiles_data = [
+            ProfileDetailSchema.model_validate(p).model_dump(mode="json")
+            for p in profiles
+        ]
     else:
-        profiles_data = [ProfileSummarySchema.model_validate(p).model_dump(mode="json") for p in profiles]
+        profiles_data = [
+            ProfileSummarySchema.model_validate(p).model_dump(mode="json")
+            for p in profiles
+        ]
 
     if redis and cache_key:
         cache_data = {"profiles": profiles_data, "total": total}
@@ -143,11 +150,15 @@ async def list_profiles(
     profiles = list(result.scalars().all())
 
     if redis and cache_key:
-        profiles_data = [ProfileSummarySchema.model_validate(p).model_dump(mode="json") for p in profiles]
+        profiles_data = [
+            ProfileSummarySchema.model_validate(p).model_dump(mode="json")
+            for p in profiles
+        ]
         cache_data = {"profiles": profiles_data, "total": total}
         await redis.setex(cache_key, 300, json.dumps(cache_data))
 
     return profiles, total
+
 
 async def get_cached_profile_by_slug(
     db: AsyncSession,
@@ -194,10 +205,13 @@ async def get_profile_by_slug(
     profile = result.scalar_one_or_none()
 
     if redis and profile:
-        profile_data = ProfileDetailSchema.model_validate(profile).model_dump(mode="json")
+        profile_data = ProfileDetailSchema.model_validate(profile).model_dump(
+            mode="json"
+        )
         await redis.setex(cache_key, 300, json.dumps(profile_data))
 
     return profile
+
 
 async def get_profile_by_id(
     db: AsyncSession,
@@ -274,3 +288,48 @@ async def delete_profile(
 
     await _invalidate_profile_caches(slug)
     return True
+
+
+async def update_profile(
+    db: AsyncSession,
+    slug: str,
+    profile_in: ProfileUpdateSchema,
+) -> EnvironmentProfile | None:
+    """Partially update a profile by slug.
+
+    Only fields explicitly set in ``profile_in`` are applied.
+    If ``packages`` is provided the existing package list is replaced entirely.
+    Returns the updated profile, or ``None`` if not found.
+    """
+    profile = await get_profile_by_slug(db, slug)
+    if not profile:
+        return None
+
+    update_data = profile_in.model_dump(exclude_unset=True)
+
+    # Handle package replacement separately
+    new_packages = update_data.pop("packages", None)
+
+    for field, value in update_data.items():
+        setattr(profile, field, value)
+
+    if new_packages is not None:
+        # Replace package list in-place (cascade delete-orphan handles old rows)
+        profile.packages.clear()
+        for pkg_data in new_packages:
+            profile.packages.append(ProfilePackage(**pkg_data))
+
+    profile.updated_at = datetime.now(UTC)
+
+    try:
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+
+    updated = await get_profile_by_id(db, profile.id)
+    if not updated:
+        raise ValueError("Failed to retrieve updated profile")
+
+    await _invalidate_profile_caches(slug)
+    return updated

--- a/backend/tests/unit/test_profiles.py
+++ b/backend/tests/unit/test_profiles.py
@@ -1,0 +1,104 @@
+"""Unit tests for the PATCH /profiles/{slug} profile update endpoint."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.profile import EnvironmentProfile, ProfilePackage
+from app.schemas.profile import ProfileUpdateSchema
+from app.services import profile_service
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+async def _create_test_profile(
+    db: AsyncSession, slug: str = "test-profile"
+) -> EnvironmentProfile:
+    """Insert a minimal active profile directly into the test DB."""
+    profile = EnvironmentProfile(
+        slug=slug,
+        name="Test Profile",
+        description="A profile for testing.",
+        tags=["ml"],
+        os_support=["LINUX"],
+        cuda_required=False,
+        python_versions=["3.11"],
+        cuda_versions=None,
+        status="ACTIVE",
+    )
+    pkg = ProfilePackage(
+        package_name="numpy",
+        version_spec=">=1.24",
+        cuda_variant=None,
+        is_optional=False,
+        install_order=0,
+    )
+    profile.packages.append(pkg)
+    db.add(profile)
+    await db.commit()
+    await db.refresh(profile)
+    return profile
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_profile_partial_fields(db_session: AsyncSession) -> None:
+    """Only the supplied fields are changed; untouched fields are preserved."""
+    await _create_test_profile(db_session, slug="patch-partial")
+
+    update = ProfileUpdateSchema(name="Renamed Profile", tags=["ml", "updated"])
+    result = await profile_service.update_profile(db_session, "patch-partial", update)
+
+    assert result is not None
+    assert result.name == "Renamed Profile"
+    assert result.tags == ["ml", "updated"]
+    # Unchanged fields are preserved
+    assert result.description == "A profile for testing."
+    assert result.os_support == ["LINUX"]
+    assert result.cuda_required is False
+
+
+@pytest.mark.asyncio
+async def test_update_profile_replaces_packages(db_session: AsyncSession) -> None:
+    """When packages are supplied the entire package list is replaced."""
+    await _create_test_profile(db_session, slug="patch-packages")
+
+    new_packages = [
+        {
+            "package_name": "torch",
+            "version_spec": "==2.1.0",
+            "cuda_variant": None,
+            "is_optional": False,
+            "install_order": 0,
+        }
+    ]
+    update = ProfileUpdateSchema(packages=new_packages)  # type: ignore[arg-type]
+    result = await profile_service.update_profile(db_session, "patch-packages", update)
+
+    assert result is not None
+    assert len(result.packages) == 1
+    assert result.packages[0].package_name == "torch"
+
+
+@pytest.mark.asyncio
+async def test_update_profile_not_found(db_session: AsyncSession) -> None:
+    """update_profile returns None for a slug that does not exist."""
+    update = ProfileUpdateSchema(name="Ghost")
+    result = await profile_service.update_profile(
+        db_session, "nonexistent-slug", update
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_update_profile_empty_body_is_noop(db_session: AsyncSession) -> None:
+    """Sending an empty update body leaves the profile unchanged."""
+    await _create_test_profile(db_session, slug="patch-noop")
+
+    update = ProfileUpdateSchema()
+    result = await profile_service.update_profile(db_session, "patch-noop", update)
+
+    assert result is not None
+    assert result.name == "Test Profile"
+    assert result.description == "A profile for testing."


### PR DESCRIPTION
## Overview

Implements the `PATCH /profiles/{slug}` endpoint for partial profile updates, closing #297. This is a clean, production-ready implementation that fixes all bugs identified by CodeRabbit in PR #452.

---

## Bugs Fixed from PR #452

| Bug | Fix |
|-----|-----|
| `@router.patch` decorator nested **inside** `delete_profile` function — invalid Python | Moved to **module level** |
| Route path `/{slug}` inconsistent with other routes | Fixed to `/profiles/{slug}` |
| `"Profile ({slug})"` not an f-string — literal `{slug}` in error message | Fixed to `f"Profile '{slug}'"` |
| No unit tests | 4 comprehensive unit tests added |

---

## Changes Made

### `backend/app/schemas/profile.py`
- Added **`ProfileUpdateSchema`** — all fields are `Optional` so clients only send what they want to change
- `packages` field, when provided, replaces the entire package list

### `backend/app/services/profile_service.py`
- Added **`update_profile(db, slug, profile_in)`** service function:
  - Uses `model_dump(exclude_unset=True)` for true partial updates
  - Package list fully replaced only when `packages` is explicitly supplied
  - Invalidates Redis cache after successful commit
  - Returns `None` when slug not found (404 handled at endpoint layer)

### `backend/app/api/v1/profiles.py`
- Added **`PATCH /profiles/{slug}`** endpoint at module level
  - `200 OK` + `ProfileDetailSchema` on success
  - `404` with proper f-string error when profile not found
  - Requires admin API key (`require_admin`) and rate limiting (`general_rate_limit`)
  - Full OpenAPI response documentation

### `backend/tests/unit/test_profiles.py` *(new)*

| Test | What it covers |
|------|----------------|
| `test_update_profile_partial_fields` | Only supplied fields change; untouched fields preserved |
| `test_update_profile_replaces_packages` | Package list fully replaced when supplied |
| `test_update_profile_not_found` | Returns `None` for unknown slug |
| `test_update_profile_empty_body_is_noop` | Empty body leaves profile unchanged |

---

## Verification

```
pytest tests/unit/test_profiles.py -v
4 passed in 1.08s
```

- ✅ Ruff (import ordering, whitespace)
- ✅ Black formatting