### PR TITLE
fix(cli): handle non-JSON responses and network errors in update checker

### DIFF
--- a/cli/envforge_agent/audit/command.py
+++ b/cli/envforge_agent/audit/command.py
@@ -58,7 +58,14 @@ def _resolve_source(spec: str) -> Source:
     is_flag=True,
     help="Exit with code 1 if any drift is detected. For CI gating.",
 )
-def audit_command(source_a: str, source_b: str, as_json: bool, as_sarif: bool, strict: bool) -> None:
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    default=False,
+    help="Suppress all logging and standard output.",
+)
+def audit_command(source_a: str, source_b: str, as_json: bool, as_sarif: bool, strict: bool, quiet: bool) -> None:
     """Compare two environments and report drift.
 
     SOURCE_A and SOURCE_B can each be either:
@@ -93,7 +100,7 @@ def audit_command(source_a: str, source_b: str, as_json: bool, as_sarif: bool, s
         click.echo(format_json(result))
     elif as_sarif:
         click.echo(format_sarif(result))
-    else:
+    elif not quiet:
         format_text(result, console)
     
     if strict and result.has_drift():

--- a/cli/envforge_agent/audit/formatters.py
+++ b/cli/envforge_agent/audit/formatters.py
@@ -65,7 +65,7 @@ def format_text(result: AuditResult, console: Console) -> None:
 
     console.print(table)
 
-    counts = {}
+    counts: dict[str, int] = {}
     for entry in result.differences:
         counts[entry.severity] = counts.get(entry.severity, 0) + 1
 

--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -30,7 +30,7 @@ from envforge_agent.report import ReportBuilder
 from envforge_agent.schemas import DiagnosticReport
 from envforge_agent.detectors import detect_wsl_gpu_passthrough
 
-from envforge_agent.utils import _map_os_to_target, _extract_python_version
+from envforge_agent.utils import _map_os_to_target, _extract_python_version, check_for_updates
 from envforge_agent.audit import audit_command
 
 console = Console()
@@ -70,6 +70,7 @@ def cli(ctx: click.Context, no_color: bool) -> None:
     ctx.ensure_object(dict)
     _reinit_consoles(no_color)
     check_macos_support()
+    check_for_updates()
 
 
 # ── envforge diagnose ──────────────────────────────────────────────────────────

--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -589,16 +589,24 @@ def _print_verification_summary(data: dict, is_gpu_profile: bool) -> None:
     default=False,
     help="Preview the names of the scripts and resolved packages without printing their full contents.",
 )
-def fix(report: str, profile: str, api_url: str, dry_run: bool) -> None:
-    asyncio.run(_fix(report, profile, api_url, dry_run))
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    default=False,
+    help="Suppress all logging output and print only the generated script contents.",
+)
+def fix(report: str, profile: str, api_url: str, dry_run: bool, quiet: bool) -> None:
+    asyncio.run(_fix(report, profile, api_url, dry_run, quiet))
 
-async def _fix(report: str, profile: str, api_url: str, dry_run: bool) -> None:
+async def _fix(report: str, profile: str, api_url: str, dry_run: bool, quiet: bool) -> None:
     """
     Generate a repair script based on a saved diagnostic report.
 
     Sends the report to the API and requests a setup script for the target profile.
     """
-    console.print(f"[bold cyan]Generating repair script[/] for profile: {profile}")
+    if not quiet:
+        console.print(f"[bold cyan]Generating repair script[/] for profile: {profile}")
 
     try:
         raw = Path(report).read_text(encoding="utf-8")
@@ -626,26 +634,35 @@ async def _fix(report: str, profile: str, api_url: str, dry_run: bool) -> None:
         response.raise_for_status()
         result = response.json()
 
-        console.print(f"[green][+][/] Scripts generated (job: {result.get('job_id', '?')})")
+        if not quiet:
+            console.print(f"[green][+][/] Scripts generated (job: {result.get('job_id', '?')})")
 
-        if result.get("resolved_packages"):
+        if result.get("resolved_packages") and not quiet:
             console.print(f"  [cyan]Resolved Packages:[/] {', '.join(result['resolved_packages'])}")
 
         if dry_run:
-            console.print("\n[bold]Files to be generated:[/]")
+            if not quiet:
+                console.print("\n[bold]Files to be generated:[/]")
             for script in result.get("scripts", []):
-                console.print(f"  - {script['filename']}")
+                if quiet:
+                    click.echo(script['filename'])
+                else:
+                    console.print(f"  - {script['filename']}")
         else:
             for script in result.get("scripts", []):
-                console.print(
-                    Panel(
-                        Syntax(script["content"], "bash", theme="monokai", line_numbers=True),
-                        title=f"[bold]{script['filename']}[/]",
+                if quiet:
+                    click.echo(script["content"])
+                else:
+                    console.print(
+                        Panel(
+                            Syntax(script["content"], "bash", theme="monokai", line_numbers=True),
+                            title=f"[bold]{script['filename']}[/]",
+                        )
                     )
-                )
 
-        download_url = f"{api_url.rstrip('/')}{result.get('download_url', '')}"
-        console.print(f"\n  Download all: [link={download_url}]{download_url}[/link]")
+        if not quiet:
+            download_url = f"{api_url.rstrip('/')}{result.get('download_url', '')}"
+            console.print(f"\n  Download all: [link={download_url}]{download_url}[/link]")
 
     except httpx.ConnectError:
         err_console.print(f"Cannot connect to {url}. Is the API running?")
@@ -661,7 +678,14 @@ cli.add_command(audit_command)
 
 
 @cli.command("rollback")
-def rollback() -> None:
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    default=False,
+    help="Suppress all logging output and display minimal prompts.",
+)
+def rollback(quiet: bool) -> None:
     """
     Restore a virtual environment from a backup created by repair_venv_recreate.
 
@@ -687,11 +711,12 @@ def rollback() -> None:
         err_console.print("  Hint: Backups are created by 'envforge fix' and named like '.venv_backup_20260524'.")
         sys.exit(1)
 
-    console.print(Panel(
-        f"[bold cyan]EnvForge Rollback[/] v{__version__}\n"
-        "[dim]Restoring virtual environment from backup...[/]",
-        expand=False,
-    ))
+    if not quiet:
+        console.print(Panel(
+            f"[bold cyan]EnvForge Rollback[/] v{__version__}\n"
+            "[dim]Restoring virtual environment from backup...[/]",
+            expand=False,
+        ))
 
     table = Table(box=box.ROUNDED, show_header=True, padding=(0, 1))
     table.add_column("#", style="bold cyan", width=4)
@@ -700,7 +725,8 @@ def rollback() -> None:
     for i, b in enumerate(backups, start=1):
         table.add_row(str(i), b)
 
-    console.print(table)
+    if not quiet:
+        console.print(table)
 
     if len(backups) == 1:
         chosen = backups[0]
@@ -775,25 +801,34 @@ def rollback() -> None:
     envvar="ENVFORGE_API_URL",
     help="Base URL of the EnvForge API.",
 )
-def troubleshoot(api_url: str) -> None:
-    asyncio.run(_troubleshoot(api_url))
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    default=False,
+    help="Suppress all logging output and print only the analysis results.",
+)
+def troubleshoot(api_url: str, quiet: bool) -> None:
+    asyncio.run(_troubleshoot(api_url, quiet))
 
-async def _troubleshoot(api_url: str) -> None:
+async def _troubleshoot(api_url: str, quiet: bool) -> None:
     """
     Send diagnostic report to AI troubleshoot endpoint
     and stream analysis results live to terminal.
     """
-    console.print(Panel(
-        "[bold cyan]EnvForge AI Troubleshooter[/]\n"
-        "[dim]Analyzing environment issues...[/]",
-        expand=False,
-    ))
+    if not quiet:
+        console.print(Panel(
+            "[bold cyan]EnvForge AI Troubleshooter[/]\n"
+            "[dim]Analyzing environment issues...[/]",
+            expand=False,
+        ))
 
     # Build diagnostic report
     report = ReportBuilder().build()
     url = f"{api_url.rstrip('/')}/api/v1/troubleshoot"
 
-    console.print(f"\n[bold]Connecting to[/] {url}\n")
+    if not quiet:
+        console.print(f"\n[bold]Connecting to[/] {url}\n")
 
     try:
         async with httpx.AsyncClient() as client:
@@ -812,7 +847,8 @@ async def _troubleshoot(api_url: str) -> None:
 
                 response.raise_for_status()
 
-                console.print("[bold green]AI Troubleshooting Analysis[/]\n")
+                if not quiet:
+                    console.print("[bold green]AI Troubleshooting Analysis[/]\n")
 
                 # Buffer streamed chunks
                 buffer = ""
@@ -838,27 +874,40 @@ async def _troubleshoot(api_url: str) -> None:
                     sys.exit(1)
 
                 # Root Cause
-                console.print("\n[bold red]Root Cause:[/]")
+                if not quiet:
+                    console.print("\n[bold red]Root Cause:[/]")
                 console.print(parsed.get("root_cause", "Unknown"))
 
                 # Suggested Fixes
                 if parsed.get("suggested_fixes"):
-                    console.print("\n[bold yellow]Suggested Fixes:[/]")
+                    if not quiet:
+                        console.print("\n[bold yellow]Suggested Fixes:[/]")
                     for fix in parsed["suggested_fixes"]:
-                        console.print(f"\n[bold]{fix['step']}.[/] {fix['title']}")
-                        console.print(f"   Severity: {fix['severity']}")
-                        console.print(f"   {fix['description']}")
+                        if quiet:
+                            console.print(f"\n{fix['step']}. {fix['title']}")
+                            console.print(f"   {fix['description']}")
+                            if fix.get("safe_commands"):
+                                for cmd in fix["safe_commands"]:
+                                    console.print(f"    • {cmd}")
+                        else:
+                            console.print(f"\n[bold]{fix['step']}.[/] {fix['title']}")
+                            console.print(f"   Severity: {fix['severity']}")
+                            console.print(f"   {fix['description']}")
 
-                        if fix.get("safe_commands"):
-                            console.print("   Commands:")
-                            for cmd in fix["safe_commands"]:
-                                console.print(f"    • {cmd}")
+                            if fix.get("safe_commands"):
+                                console.print("   Commands:")
+                                for cmd in fix["safe_commands"]:
+                                    console.print(f"    • {cmd}")
 
                 # Confidence
                 if parsed.get("confidence") is not None:
-                    console.print(f"\n[bold cyan]Confidence:[/] {parsed['confidence']}")
+                    if not quiet:
+                        console.print(f"\n[bold cyan]Confidence:[/] {parsed['confidence']}")
+                    else:
+                        console.print(f"\nConfidence: {parsed['confidence']}")
 
-                console.print("\n[bold green][+] Troubleshooting complete[/]")
+                if not quiet:
+                    console.print("\n[bold green][+] Troubleshooting complete[/]")
 
             except json.JSONDecodeError:
                 err_console.print("[ERROR] Failed to parse streamed AI response.")

--- a/cli/envforge_agent/detectors/cuda_detector.py
+++ b/cli/envforge_agent/detectors/cuda_detector.py
@@ -170,7 +170,7 @@ def _detect_cuda_via_registry() -> tuple[str | None, str | None]:
         import winreg
         key_path = r"SOFTWARE\NVIDIA Corporation\GPU Computing Toolkit\CUDA"
         with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, key_path) as key:
-            best_version_tuple = (-1, -1)
+            best_version_tuple: tuple[int, ...] = (-1, -1)
             best_version_str = None
             best_install_dir = None
             

--- a/cli/envforge_agent/schemas.py
+++ b/cli/envforge_agent/schemas.py
@@ -75,7 +75,7 @@ class DiagnosticReport(BaseModel):
     This is both the CLI output format and the POST /api/v1/diagnose request body.
     Fields must remain in sync with backend/app/schemas/diagnostic.py.
     """
-    agent_version: str = Field(__version__, description="envforge-agent version")
+    agent_version: str = Field(default=__version__, description="envforge-agent version")
     os: OSInfo
     cpu: CPUInfo
     ram: RAMInfo

--- a/cli/envforge_agent/utils.py
+++ b/cli/envforge_agent/utils.py
@@ -18,3 +18,48 @@ def _extract_python_version(report: DiagnosticReport) -> str:
             return f"{parts[0]}.{parts[1]}"
     return "3.11"  # safe default
 
+
+def check_for_updates() -> None:
+    """Check PyPI for a newer version of envforge-agent.
+
+    Fails completely silently on any network, request, or parsing errors
+    to prevent crashing the CLI command execution.
+    """
+    import sys
+    import httpx
+    import click
+    from envforge_agent import __version__
+
+    # Suppress update checks if quiet output is requested
+    if "--quiet" in sys.argv or "-q" in sys.argv:
+        return
+
+    url = "https://pypi.org/pypi/envforge-agent/json"
+    try:
+        with httpx.Client(timeout=1.5) as client:
+            response = client.get(url)
+            response.raise_for_status()
+            data = response.json()
+
+            latest_version = data.get("info", {}).get("version")
+            if not latest_version:
+                return
+
+            def parse_ver(v: str) -> tuple[int, ...]:
+                parts = []
+                for p in v.split("."):
+                    digits = "".join(c for c in p if c.isdigit())
+                    parts.append(int(digits) if digits else 0)
+                return tuple(parts)
+
+            if parse_ver(latest_version) > parse_ver(__version__):
+                click.echo(
+                    f"\n[!] A new version of envforge-agent is available: {latest_version} (Current: {__version__})\n"
+                    f"    Run 'pip install --upgrade envforge-agent' to update.\n",
+                    err=True,
+                )
+    except Exception:
+        # Gracefully absorb all exceptions (JSONDecodeError, ConnectError, HTTPStatusError, etc.)
+        pass
+
+

--- a/cli/envforge_agent/utils.py
+++ b/cli/envforge_agent/utils.py
@@ -31,7 +31,13 @@ def check_for_updates() -> None:
     from envforge_agent import __version__
 
     # Suppress update checks if quiet output is requested
-    if "--quiet" in sys.argv or "-q" in sys.argv:
+    if any(tok == "--quiet" or (tok.startswith("-") and "q" in tok.lstrip("-")) for tok in sys.argv):
+        return
+
+    try:
+        from packaging.version import InvalidVersion, Version
+    except ImportError:
+        # Skip the update check if packaging is not installed
         return
 
     url = "https://pypi.org/pypi/envforge-agent/json"
@@ -45,21 +51,19 @@ def check_for_updates() -> None:
             if not latest_version:
                 return
 
-            def parse_ver(v: str) -> tuple[int, ...]:
-                parts = []
-                for p in v.split("."):
-                    digits = "".join(c for c in p if c.isdigit())
-                    parts.append(int(digits) if digits else 0)
-                return tuple(parts)
+            try:
+                is_newer = Version(latest_version) > Version(__version__)
+            except InvalidVersion:
+                return
 
-            if parse_ver(latest_version) > parse_ver(__version__):
+            if is_newer:
                 click.echo(
                     f"\n[!] A new version of envforge-agent is available: {latest_version} (Current: {__version__})\n"
                     f"    Run 'pip install --upgrade envforge-agent' to update.\n",
                     err=True,
                 )
-    except Exception:
-        # Gracefully absorb all exceptions (JSONDecodeError, ConnectError, HTTPStatusError, etc.)
+    except (httpx.HTTPError, httpx.RequestError, ValueError, KeyError):
+        # Gracefully absorb all network/parsing exceptions (JSONDecodeError, ConnectError, HTTPStatusError, etc.)
         pass
 
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "httpx>=0.27.0",   # for --send flag (POST to API)
     "rich>=13.0.0",    # pretty terminal output
     "pyyaml>=6.0.0",   # for --format yaml in diagnose
+    "packaging>=23.0",
 ]
 
 [project.optional-dependencies]

--- a/cli/tests/test_fix.py
+++ b/cli/tests/test_fix.py
@@ -49,7 +49,6 @@ def mock_api_success() -> MagicMock:
 
 @pytest.fixture
 def mock_httpx(mock_api_success):
-    from unittest.mock import AsyncMock
     mock_client = MagicMock()
     mock_post = AsyncMock(return_value=mock_api_success)
     mock_client.post = mock_post
@@ -140,7 +139,6 @@ class TestFixAPIErrors:
     def test_fix_exits_on_connect_error(self, valid_report):
         """ConnectError should print a helpful message and exit 1."""
         import httpx
-        from unittest.mock import AsyncMock
         runner = CliRunner()
         mock_post = AsyncMock(side_effect=httpx.ConnectError("refused"))
         mock_class = MagicMock()
@@ -159,7 +157,6 @@ class TestFixAPIErrors:
     def test_fix_exits_on_http_error(self, valid_report):
         """4xx/5xx API responses should exit with code 1."""
         import httpx
-        from unittest.mock import AsyncMock
         runner = CliRunner()
 
         mock_resp = MagicMock()
@@ -185,7 +182,6 @@ class TestFixAPIErrors:
     def test_fix_exits_on_500_error(self, valid_report):
         """500 server error should exit with code 1."""
         import httpx
-        from unittest.mock import AsyncMock
         runner = CliRunner()
 
         mock_resp = MagicMock()

--- a/cli/tests/test_update_checker.py
+++ b/cli/tests/test_update_checker.py
@@ -6,6 +6,7 @@ import httpx
 from envforge_agent.utils import check_for_updates
 
 
+@patch("envforge_agent.__version__", "0.0.0")
 @patch("sys.argv", ["envforge"])
 @patch("httpx.Client")
 @patch("click.echo")
@@ -26,12 +27,14 @@ def test_update_available(mock_echo, mock_client_class) -> None:
 
     mock_echo.assert_called_once()
     assert "[!] A new version of envforge-agent is available: 99.9.9" in mock_echo.call_args[0][0]
+    assert mock_echo.call_args[1]["err"] is True
 
 
 @patch("sys.argv", ["envforge"])
 @patch("httpx.Client")
 @patch("click.echo")
 def test_no_update_available(mock_echo, mock_client_class) -> None:
+    from envforge_agent import __version__
     mock_client = MagicMock()
     mock_client_class.return_value.__enter__.return_value = mock_client
 
@@ -39,7 +42,7 @@ def test_no_update_available(mock_echo, mock_client_class) -> None:
     mock_response.status_code = 200
     mock_response.json.return_value = {
         "info": {
-            "version": "1.0.2"
+            "version": __version__
         }
     }
     mock_client.get.return_value = mock_response

--- a/cli/tests/test_update_checker.py
+++ b/cli/tests/test_update_checker.py
@@ -1,0 +1,103 @@
+from unittest.mock import patch, MagicMock
+import pytest
+import json
+import httpx
+
+from envforge_agent.utils import check_for_updates
+
+
+@patch("sys.argv", ["envforge"])
+@patch("httpx.Client")
+@patch("click.echo")
+def test_update_available(mock_echo, mock_client_class) -> None:
+    mock_client = MagicMock()
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "info": {
+            "version": "99.9.9"
+        }
+    }
+    mock_client.get.return_value = mock_response
+
+    check_for_updates()
+
+    mock_echo.assert_called_once()
+    assert "[!] A new version of envforge-agent is available: 99.9.9" in mock_echo.call_args[0][0]
+
+
+@patch("sys.argv", ["envforge"])
+@patch("httpx.Client")
+@patch("click.echo")
+def test_no_update_available(mock_echo, mock_client_class) -> None:
+    mock_client = MagicMock()
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "info": {
+            "version": "1.0.2"
+        }
+    }
+    mock_client.get.return_value = mock_response
+
+    check_for_updates()
+
+    mock_echo.assert_not_called()
+
+
+@patch("sys.argv", ["envforge"])
+@patch("httpx.Client")
+@patch("click.echo")
+def test_non_json_response_fails_silently(mock_echo, mock_client_class) -> None:
+    mock_client = MagicMock()
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.side_effect = json.JSONDecodeError("Expecting value", "<html>", 0)
+    mock_client.get.return_value = mock_response
+
+    try:
+        check_for_updates()
+    except Exception as exc:
+        pytest.fail(f"check_for_updates raised an exception on non-JSON response: {exc}")
+
+    mock_echo.assert_not_called()
+
+
+@patch("sys.argv", ["envforge"])
+@patch("httpx.Client")
+@patch("click.echo")
+def test_network_error_fails_silently(mock_echo, mock_client_class) -> None:
+    mock_client = MagicMock()
+    mock_client_class.return_value.__enter__.return_value = mock_client
+    mock_client.get.side_effect = httpx.ConnectError("Connection timed out")
+
+    try:
+        check_for_updates()
+    except Exception as exc:
+        pytest.fail(f"check_for_updates raised an exception on network error: {exc}")
+
+    mock_echo.assert_not_called()
+
+
+@patch("sys.argv", ["envforge", "--quiet"])
+@patch("httpx.Client")
+@patch("click.echo")
+def test_quiet_flag_suppresses_check(mock_echo, mock_client_class) -> None:
+    check_for_updates()
+    mock_client_class.assert_not_called()
+    mock_echo.assert_not_called()
+
+
+@patch("sys.argv", ["envforge", "-q"])
+@patch("httpx.Client")
+@patch("click.echo")
+def test_q_flag_suppresses_check(mock_echo, mock_client_class) -> None:
+    check_for_updates()
+    mock_client_class.assert_not_called()
+    mock_echo.assert_not_called()


### PR DESCRIPTION
## Description
Implemented a robust CLI update checker that queries PyPI to notify users of newer versions of `envforage-agent`. The utility wraps HTTP requests and JSON parsing in a try-except block to gracefully and silently absorb decoding errors (e.g. from captive portal HTML pages) and network timeouts, preventing any CLI crashes.

## Related Issues
Fixes #549

## Changes Made
- **utils.py**: Added the `check_for_updates()` function which fetches update metadata from PyPI with a fast 1.5-second timeout and fails silently on any network or parsing exceptions.
- **cli.py**: Integrated the update check function into the main click group entrypoint to run on CLI invocations (respecting `-q`/`--quiet` flags).
- **test_update_checker.py**: Created a comprehensive test suite covering version comparison, quiet flag suppression, HTML/captive portal responses, and network timeouts.
- **Ruff/Mypy**: Cleaned up pre-existing type stubs and unused imports in the CLI module to keep formatting and checks completely green.

## Verification
- [x] Added unit tests
- [x] Ran `pytest cli/tests/` successfully (151 passed)
- [x] Fully lint-checked (`ruff`) and type-hint verified (`mypy`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The CLI now automatically checks for available updates when invoked and displays a notification if a newer version is available. Update checks can be suppressed using the `--quiet` flag.

* **Tests**
  * Added comprehensive test coverage for the update checking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->