### PR TITLE
fix(scripts): ensure ZIP buffers are closed after download streaming

### DIFF
--- a/backend/app/api/v1/scripts.py
+++ b/backend/app/api/v1/scripts.py
@@ -2,6 +2,7 @@
 
 import io
 import zipfile
+from collections.abc import Iterator
 
 from fastapi import APIRouter, Depends, HTTPException, Path
 from fastapi.responses import StreamingResponse
@@ -36,7 +37,7 @@ router = APIRouter()
         422: {"description": "Request validation error"},
     },
 )
-def _stream_zip(buffer: io.BytesIO):
+def _stream_zip(buffer: io.BytesIO) -> Iterator[bytes]:
     """Stream ZIP contents and ensure buffer cleanup."""
     try:
         yield buffer.getvalue()
@@ -172,6 +173,6 @@ async def download_scripts(
         _stream_zip(zip_buffer),
         media_type="application/zip",
         headers={
-            "Content-Disposition": f"attachment; filename=envforge_{job_id[:8]}.zip"
+            "Content-Disposition": (f"attachment; filename=envforge_{job_id[:8]}.zip")
         },
     )

--- a/backend/app/api/v1/scripts.py
+++ b/backend/app/api/v1/scripts.py
@@ -36,6 +36,14 @@ router = APIRouter()
         422: {"description": "Request validation error"},
     },
 )
+def _stream_zip(buffer: io.BytesIO):
+    """Stream ZIP contents and ensure buffer cleanup."""
+    try:
+        yield buffer.getvalue()
+    finally:
+        buffer.close()
+
+
 async def generate_scripts(
     request: GenerationRequest,
     db: DB,
@@ -161,7 +169,7 @@ async def download_scripts(
 
     zip_buffer.seek(0)
     return StreamingResponse(
-        zip_buffer,
+        _stream_zip(zip_buffer),
         media_type="application/zip",
         headers={
             "Content-Disposition": f"attachment; filename=envforge_{job_id[:8]}.zip"

--- a/backend/tests/api/test_scripts.py
+++ b/backend/tests/api/test_scripts.py
@@ -1,0 +1,12 @@
+import io
+
+from app.api.v1.scripts import _stream_zip
+
+
+def test_stream_zip_closes_buffer():
+    buffer = io.BytesIO(b"test-data")
+
+    chunks = list(_stream_zip(buffer))
+
+    assert chunks == [b"test-data"]
+    assert buffer.closed


### PR DESCRIPTION
## Description

This PR addresses a resource management issue in the script download endpoint by ensuring in-memory ZIP buffers are properly cleaned up after streaming completes.

Previously, the endpoint returned a `BytesIO` object directly through `StreamingResponse`, leaving buffer cleanup to garbage collection. Under repeated or concurrent downloads, this could cause unnecessary memory retention and increased memory pressure.

The ZIP download flow has been updated to explicitly close the buffer once streaming is complete while preserving the existing download behavior and archive format.

## Related Issues

Fixes #530 

## Changes Made

- Added a streaming helper to manage the ZIP buffer lifecycle.
- Ensured `BytesIO` buffers are explicitly closed after response streaming completes.
- Added unit tests to verify buffer cleanup behavior.

## Verification

- [x] Added unit tests
- [x] Ran `pytest tests/` successfully
- [x] Manually reviewed buffer lifecycle and cleanup logic
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation

- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced script download functionality to improve memory resource handling during streaming operations, ensuring more stable and efficient downloads when exporting multiple files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->