### PR TITLE
Fixed unhandled OpenAI bad gateway (502/503) in streaming mode

### DIFF
--- a/backend/app/ai/providers/openai.py
+++ b/backend/app/ai/providers/openai.py
@@ -188,6 +188,20 @@ class OpenAIProvider(LLMProvider):
 
                             if response.status_code in (502, 503):
                                 error_body = await response.aread()
+
+                                if attempt >= max_retries - 1:
+                                    logger.warning(
+                                        "OpenAI returned %d on final attempt (%d/%d).",
+                                        response.status_code,
+                                        attempt + 1,
+                                        max_retries,
+                                    )
+                                    raise LLMProviderError(
+                                        "openai",
+                                        f"HTTP {response.status_code} (Bad Gateway/Service Unavailable) - "
+                                        f"retry attempts exhausted: {error_body.decode(errors='replace')[:500]}",
+                                    )
+
                                 logger.warning(
                                     "OpenAI returned %d. Retrying in %s seconds... (Attempt %d/%d)",
                                     response.status_code,
@@ -195,14 +209,6 @@ class OpenAIProvider(LLMProvider):
                                     attempt + 1,
                                     max_retries,
                                 )
-
-                                if attempt >= max_retries - 1:
-                                    raise LLMProviderError(
-                                        "openai",
-                                        f"HTTP {response.status_code} (Bad Gateway/Service Unavailable) - "
-                                        f"retry attempts exhausted: {error_body.decode(errors='replace')[:500]}",
-                                    )
-
                                 await asyncio.sleep(base_delay ** attempt)
                                 continue
 

--- a/backend/app/ai/providers/openai.py
+++ b/backend/app/ai/providers/openai.py
@@ -186,6 +186,26 @@ class OpenAIProvider(LLMProvider):
                                 await asyncio.sleep(delay)
                                 continue
 
+                            if response.status_code in (502, 503):
+                                error_body = await response.aread()
+                                logger.warning(
+                                    "OpenAI returned %d. Retrying in %s seconds... (Attempt %d/%d)",
+                                    response.status_code,
+                                    base_delay ** attempt,
+                                    attempt + 1,
+                                    max_retries,
+                                )
+
+                                if attempt >= max_retries - 1:
+                                    raise LLMProviderError(
+                                        "openai",
+                                        f"HTTP {response.status_code} (Bad Gateway/Service Unavailable) - "
+                                        f"retry attempts exhausted: {error_body.decode(errors='replace')[:500]}",
+                                    )
+
+                                await asyncio.sleep(base_delay ** attempt)
+                                continue
+
                             if response.status_code != 200:
                                 error_body = await response.aread()
                                 raise LLMProviderError(

--- a/backend/app/api/v1/troubleshoot.py
+++ b/backend/app/api/v1/troubleshoot.py
@@ -50,6 +50,12 @@ async def troubleshoot(
             try:
                 async for chunk in _service.stream_troubleshoot(request, db):
                     yield f"data: {chunk}\n\n"
+            except LLMProviderError as exc:
+                logger.error("LLM provider error in stream: %s", exc)
+                yield (
+                    f'data: {{"error":"PROVIDER_ERROR",'
+                    f'"message":"{exc.reason}"}}\n\n'
+                )
             except Exception:
                 logger.exception("Error in troubleshoot stream generator")
                 yield (

--- a/backend/tests/unit/ai/test_openai_provider.py
+++ b/backend/tests/unit/ai/test_openai_provider.py
@@ -106,6 +106,7 @@ async def test_openai_stream_502_bad_gateway_retry_and_exhaustion():
 
         assert "HTTP 502" in str(exc_info.value)
         assert "retry attempts exhausted" in str(exc_info.value)
+        assert "Bad Gateway" in str(exc_info.value)
         assert mock_stream_call.call_count == 3
         assert mock_sleep.call_count == 2
         mock_sleep.assert_has_calls([call(1.0), call(2.0)])
@@ -142,6 +143,7 @@ async def test_openai_stream_503_service_unavailable_retry_and_exhaustion():
 
         assert "HTTP 503" in str(exc_info.value)
         assert "retry attempts exhausted" in str(exc_info.value)
+        assert "Service Unavailable" in str(exc_info.value)
         assert mock_stream_call.call_count == 3
         assert mock_sleep.call_count == 2
         mock_sleep.assert_has_calls([call(1.0), call(2.0)])

--- a/backend/tests/unit/ai/test_openai_provider.py
+++ b/backend/tests/unit/ai/test_openai_provider.py
@@ -73,3 +73,75 @@ async def test_openai_stream_network_error_retry_and_exhaustion():
         assert mock_stream_call.call_count == 3
         assert mock_sleep.call_count == 2
         mock_sleep.assert_has_calls([call(1.0), call(2.0)])
+
+
+async def test_openai_stream_502_bad_gateway_retry_and_exhaustion():
+    """Verify that OpenAIProvider.stream retries on HTTP 502 (Bad Gateway) and exhausts all retries."""
+    provider = OpenAIProvider(api_key="test_key")
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 502
+    mock_response.headers = httpx.Headers({})
+    mock_response.aread = AsyncMock(return_value=b"Bad Gateway")
+
+    mock_stream_ctx = MagicMock()
+    mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_stream_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "httpx.AsyncClient.stream", return_value=mock_stream_ctx
+        ) as mock_stream_call,
+        patch("asyncio.sleep", AsyncMock()) as mock_sleep,
+    ):
+        generator = provider.stream(
+            system_prompt="Test system",
+            user_message="Test user",
+            response_model=DummyModel,
+        )
+
+        with pytest.raises(LLMProviderError) as exc_info:
+            async for _ in generator:
+                pass
+
+        assert "HTTP 502" in str(exc_info.value)
+        assert "retry attempts exhausted" in str(exc_info.value)
+        assert mock_stream_call.call_count == 3
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_has_calls([call(1.0), call(2.0)])
+
+
+async def test_openai_stream_503_service_unavailable_retry_and_exhaustion():
+    """Verify that OpenAIProvider.stream retries on HTTP 503 (Service Unavailable) and exhausts all retries."""
+    provider = OpenAIProvider(api_key="test_key")
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 503
+    mock_response.headers = httpx.Headers({})
+    mock_response.aread = AsyncMock(return_value=b"Service Unavailable")
+
+    mock_stream_ctx = MagicMock()
+    mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_stream_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "httpx.AsyncClient.stream", return_value=mock_stream_ctx
+        ) as mock_stream_call,
+        patch("asyncio.sleep", AsyncMock()) as mock_sleep,
+    ):
+        generator = provider.stream(
+            system_prompt="Test system",
+            user_message="Test user",
+            response_model=DummyModel,
+        )
+
+        with pytest.raises(LLMProviderError) as exc_info:
+            async for _ in generator:
+                pass
+
+        assert "HTTP 503" in str(exc_info.value)
+        assert "retry attempts exhausted" in str(exc_info.value)
+        assert mock_stream_call.call_count == 3
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_has_calls([call(1.0), call(2.0)])


### PR DESCRIPTION
## Description

The `stream` method in `OpenAIProvider` previously only retried on HTTP 429 (Rate Limited) and transient network/connection errors. Any HTTP 502 (Bad Gateway) or 503 (Service Unavailable) response from the upstream OpenAI API would immediately raise an `LLMProviderError`, crashing the streaming session instead of recovering gracefully.

This PR adds explicit retry handling for 502 and 503 status codes, treating them as transient upstream errors and retrying them with the same exponential backoff strategy already used for connection-level errors (`base_delay ** attempt`). After all retries are exhausted, a descriptive `LLMProviderError` is raised that includes the status code and the error body.

## Related Issues

Fixes #539 

## Changes Made

- Added a `response.status_code in (502, 503)` check in `OpenAIProvider.stream` (in `backend/app/ai/providers/openai.py`) that retries with exponential backoff before raising on the final attempt, consistent with existing transient error handling.
- Added two new unit tests in `backend/tests/unit/ai/test_openai_provider.py`:
  - `test_openai_stream_502_bad_gateway_retry_and_exhaustion` — verifies 3 retry attempts, 2 exponential backoff sleeps, and the correct error message for HTTP 502.
  - `test_openai_stream_503_service_unavailable_retry_and_exhaustion` — same coverage for HTTP 503.

## Verification

- [x] Added unit tests
- [x] Ran `pytest tests/unit/ai/test_openai_provider.py` successfully — all 4 tests passed (2 pre-existing + 2 new)
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation

- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced resilience by implementing automatic retry logic with exponential backoff for temporary server errors (HTTP 502 and 503). Errors are now properly reported when retry attempts are exhausted.

* **Tests**
  * Added unit tests for the new retry behavior, covering both HTTP 502 and HTTP 503 scenarios, including retry exhaustion cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->