### PR TITLE
fix: expose cleanup task status via Prometheus metrics fixes

### DIFF
--- a/backend/app/services/cleanup_service.py
+++ b/backend/app/services/cleanup_service.py
@@ -1,8 +1,10 @@
 """Background cleanup service for expired script generation records."""
 
 import logging
+import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from prometheus_client import Counter, Gauge
 
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -14,6 +16,25 @@ logger = logging.getLogger(__name__)
 
 SCRIPT_GENERATION_JOBS_RETENTION_DAYS = 30
 GENERATED_SCRIPTS_RETENTION_DAYS = 7
+
+# Cleanup Task Metrics
+
+CLEANUP_RUNS_TOTAL = Counter(
+    "cleanup_runs_total",
+    "Total number of cleanup task executions",
+    ["status"], 
+)
+
+CLEANUP_LAST_RUN_TIMESTAMP = Gauge(
+    "cleanup_last_run_timestamp_seconds",
+    "Unix timestamp of the last cleanup task attempt",
+)
+
+CLEANUP_LAST_RUN_SUCCESS = Gauge(
+    "cleanup_last_run_success",
+    "1 if the last cleanup run succeeded, 0 if it failed",
+)
+
 
 
 async def delete_expired_records(db: AsyncSession) -> dict[str, Any]:
@@ -48,10 +69,16 @@ async def delete_expired_records(db: AsyncSession) -> dict[str, Any]:
 async def run_cleanup() -> None:
     """Entry point for the scheduler — manages its own DB session."""
     logger.info("Running scheduled database cleanup...")
+    CLEANUP_LAST_RUN_TIMESTAMP.set(time.time()) 
     async with AsyncSessionLocal() as db:
         try:
             result = await delete_expired_records(db)
             logger.info(f"Cleanup result: {result}")
+            CLEANUP_RUNS_TOTAL.labels(status="success").inc()
+            CLEANUP_LAST_RUN_SUCCESS.set(1)
         except Exception as e:
             logger.error(f"Cleanup task failed: {e}", exc_info=True)
             await db.rollback()
+            CLEANUP_RUNS_TOTAL.labels(status="failure").inc() 
+            CLEANUP_LAST_RUN_SUCCESS.set(0)
+            raise   

--- a/backend/tests/unit/services/test_cleanup_service.py
+++ b/backend/tests/unit/services/test_cleanup_service.py
@@ -1,0 +1,63 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _make_db(rowcount: int = 3):
+    result = MagicMock()
+    result.rowcount = rowcount
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=result)
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    return db
+
+
+def _make_session_cm(db):
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=db)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+async def test_success_sets_last_run_success_to_1():
+    from app.services import cleanup_service
+
+    db = _make_db()
+    with patch("app.services.cleanup_service.AsyncSessionLocal", return_value=_make_session_cm(db)):
+        await cleanup_service.run_cleanup()
+
+    assert cleanup_service.CLEANUP_LAST_RUN_SUCCESS._value.get() == 1.0
+
+
+async def test_failure_sets_last_run_success_to_0():
+    from app.services import cleanup_service
+
+    db = _make_db()
+    db.execute = AsyncMock(side_effect=Exception("DB connection lost"))
+    with patch("app.services.cleanup_service.AsyncSessionLocal", return_value=_make_session_cm(db)):
+        with pytest.raises(Exception):
+            await cleanup_service.run_cleanup()
+
+    assert cleanup_service.CLEANUP_LAST_RUN_SUCCESS._value.get() == 0.0
+
+
+async def test_failure_reraises_exception():
+    from app.services import cleanup_service
+
+    db = _make_db()
+    db.execute = AsyncMock(side_effect=RuntimeError("disk full"))
+    with patch("app.services.cleanup_service.AsyncSessionLocal", return_value=_make_session_cm(db)):
+        with pytest.raises(RuntimeError, match="disk full"):
+            await cleanup_service.run_cleanup()
+
+
+async def test_rollback_called_on_failure():
+    from app.services import cleanup_service 
+
+    db = _make_db()
+    db.execute = AsyncMock(side_effect=Exception("error"))
+    with patch("app.services.cleanup_service.AsyncSessionLocal", return_value=_make_session_cm(db)):
+        with pytest.raises(Exception):
+            await cleanup_service.run_cleanup()
+
+    db.rollback.assert_awaited_once()  


### PR DESCRIPTION
## Problem
`run_cleanup` was silently swallowing exceptions — scheduler was never 
notified of failures and no health status was exposed.

## Changes
- Added Prometheus metrics to `cleanup_service.py`:
-   - `cleanup_last_run_success` → 1 on success, 0 on failure
  - `cleanup_runs_total` → tracks success/failure count
  - `cleanup_last_run_timestamp_seconds` → tracks last run time
- Added `raise` so APScheduler is notified of failures
- Added unit tests covering success/failure metric states

## Files Changed
- `backend/app/services/cleanup_service.py`
- `backend/tests/unit/services/test_cleanup_service.py`

## Test Results
All 4 tests passed 

tests/unit/services/test_cleanup_service.py::test_success_sets_last_run_success_to_1 PASSED [ 25%]
tests/unit/services/test_cleanup_service.py::test_failure_sets_last_run_success_to_0 PASSED [ 50%]
tests/unit/services/test_cleanup_service.py::test_failure_reraises_exception PASSED [ 75%]
tests/unit/services/test_cleanup_service.py::test_rollback_called_on_failure PASSED [100%]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Prometheus metrics for cleanup operations monitoring, tracking run counts, timestamps, and success status.

* **Tests**
  * Added comprehensive unit tests for cleanup service to verify success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->