### PR TITLE
Fix #742: refactor: add logging to main app exceptions

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -132,7 +132,9 @@ def create_app() -> FastAPI:
             async with asyncio.timeout(2):
                 async with AsyncSessionLocal() as session:
                     await session.execute(text("SELECT 1"))
-        except Exception:
+        except Exception as e:
+            import logging
+            logging.error(f"Main app error: {e}")
             db_status = "unavailable"
             overall = "degraded"
         try:


### PR DESCRIPTION
Resolves #742. The main.py file contains a bare except Exception: block. This should log the error properly instead of just passing or returning generic errors.