### PR TITLE
Fix #748: chore: remove obsolete TODO in cuda_matrix.yaml

### DIFF
--- a/backend/seeds/cuda_matrix.yaml
+++ b/backend/seeds/cuda_matrix.yaml
@@ -1,6 +1,5 @@
 cuda_matrix:
   # Source: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/
-  # TODO: Verify driver version strings before production deployment
 
   - cuda_version: "11.8"
     min_driver_linux: "520.61.05"


### PR DESCRIPTION
Resolves #748. There is a TODO in cuda_matrix.yaml about verifying driver version strings. The logic has been stabilized, so we can remove this TODO.