### PR TITLE
Fix #750: fix: remove any type from Heading.tsx

### DIFF
--- a/frontend/src/components/mdx/Heading.tsx
+++ b/frontend/src/components/mdx/Heading.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const Heading = ({ level, children, ...props }: any) => {
+export const Heading = ({ level, children, ...props }: { level: number, children: React.ReactNode, [key: string]: unknown }) => {
   const Tag = `h${level}` as keyof React.JSX.IntrinsicElements;
   const id = typeof children === 'string' 
     ? children.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')


### PR DESCRIPTION
Resolves #750. The Heading.tsx component uses ny for props which violates type safety rules. We should type it properly as Record<string, unknown>.