### PR TITLE
Fix #752: fix: proper typing for CodeBlock component

### DIFF
--- a/frontend/src/components/mdx/CodeBlock.tsx
+++ b/frontend/src/components/mdx/CodeBlock.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 // Simplified wrapper for MDX code blocks
-export const CodeBlock = ({ children, className }: any) => {
+export const CodeBlock = ({ children, className }: { children: React.ReactNode, className?: string }) => {
   const language = className ? className.replace(/language-/, '') : '';
   
   return (


### PR DESCRIPTION
Resolves #752. The CodeBlock.tsx component is typed with ny. We should use proper types for children and className.