### PR TITLE
Fix #760: refactor: add logging to conftest error 1

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -79,7 +79,9 @@ def new_result_processor(self, dialect, coltype):
                 return None
             try:
                 return json.loads(value)
-            except Exception:
+            except Exception as e:
+                import logging
+                logging.error(f"Test fixture error: {e}")
                 return value
 
         return process


### PR DESCRIPTION
Resolves #760. Found a bare exception handler in conftest.py. We should capture and log the exception.