### PR TITLE
Fix #762: refactor: add logging to conftest error 2

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -122,7 +122,9 @@ async def test_engine():
                 arr = json.loads(arr_str)
                 try:
                     item = json.loads(item_str)
-                except Exception:
+                except Exception as e:
+                import logging
+                logging.error(f"Test fixture error: {e}")
                     item = item_str
 
                 if isinstance(item, list):


### PR DESCRIPTION
Resolves #762. Another bare exception in conftest.py suppressing potential teardown failures. Logging should be added.