### PR TITLE
Fix #764: refactor: add logging to conftest error 3

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -130,7 +130,9 @@ async def test_engine():
                 if isinstance(item, list):
                     return all(x in arr for x in item)
                 return item in arr
-            except Exception:
+            except Exception as e:
+                import logging
+                logging.error(f"Test fixture error: {e}")
                 return False
 
         dbapi_connection.create_function("array_contains", 2, array_contains)


### PR DESCRIPTION
Resolves #764. A third bare exception in conftest.py. Implementing standard logging.