### PR TITLE
Fix #766: refactor: log worker recovery error

### DIFF
--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -151,7 +151,9 @@ def run_diagnose_task(
                     docs_url=None,
                 )
             )
-        except Exception:
+        except Exception as e:
+            import logging
+            logging.error(f"Worker error: {e}")
             logger.exception("Unexpected error resolving profile %s", profile_slug)
             raise
 


### PR DESCRIPTION
Resolves #766. The worker.py contains a bare exception masking recovery errors. Replacing with logging implementation.