### PR TITLE
Fix #768: refactor: add logging to safety template

### DIFF
--- a/backend/app/templates/safety.py
+++ b/backend/app/templates/safety.py
@@ -236,7 +236,9 @@ def _validate_bash_ast(content: str, template_name: str = "") -> None:
                                                         ):
                                                             is_whitelisted = True
                                                             break
-                                                    except Exception:
+                                                    except Exception as e:
+                                                    import logging
+                                                    logging.error(f"Safety parse error: {e}")
                                                         pass
                             if not is_whitelisted:
                                 violations.append(


### PR DESCRIPTION
Resolves #768. The safety.py template compiler suppresses exceptions natively. Logging must be introduced.