### PR TITLE
Fix #776: refactor: sync service logging 4

### DIFF
--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -268,7 +268,9 @@ async def sync_nvidia_cuda_releases(db: AsyncSession) -> None:
                         latest_existing = max(
                             cuda_rows, key=lambda r: Version(r.cuda_version)
                         )
-                    except Exception:
+                    except Exception as e:
+                    import logging
+                    logging.error(f"Sync error 4: {e}")
                         latest_existing = cuda_rows[0]
 
                 min_linux = (


### PR DESCRIPTION
Resolves #776. Fourth instance of a bare exception in sync service. Let's fix it.