### PR TITLE
Fix #778: refactor: profile service logging 1

### DIFF
--- a/backend/app/services/profile_service.py
+++ b/backend/app/services/profile_service.py
@@ -284,7 +284,9 @@ async def delete_profile(
 
     try:
         await db.commit()
-    except Exception:
+    except Exception as e:
+    import logging
+    logging.error(f"Profile error 1: {e}")
         await db.rollback()
         raise
 


### PR DESCRIPTION
Resolves #778. Profile service uses bare exception blocks. Adding explicit logging to track profile fetch failures.