### PR TITLE
Fix #782: refactor: add shutdown logging to main.py

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -149,7 +149,9 @@ def create_app() -> FastAPI:
         except TimeoutError:
             redis_status = "unavailable"
             overall = "degraded"
-        except Exception:
+        except Exception as e:
+        import logging
+        logging.error(f"Main shutdown error: {e}")
             redis_status = "unavailable"
             overall = "degraded"
         return JSONResponse(


### PR DESCRIPTION
Resolves #782. The app lifecycle shutdown routine uses a bare exception. Needs logging.