### PR TITLE
fix: add timeout for async database queries

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -43,6 +43,19 @@ class Settings(BaseSettings):
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/envforge"
     database_command_timeout_seconds: float = 30.0
 
+@field_validator("database_command_timeout_seconds")
+@classmethod
+def validate_database_command_timeout_seconds(cls, v: float) -> float:
+    if v <= 0:
+        raise ValueError(
+            "database_command_timeout_seconds must be greater than 0"
+        )
+    if v > 300:
+        raise ValueError(
+            "database_command_timeout_seconds must be less than or equal to 300"
+        )
+    return v
+
     # ── Redis ─────────────────────────────────────────────────
     # If set, the rate limiter will use Redis instead of in-memory storage.
     # Required in production for multi-worker correctness.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -41,6 +41,7 @@ class Settings(BaseSettings):
 
     # ── Database ──────────────────────────────────────────────
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/envforge"
+    database_command_timeout_seconds: float = 30.0
 
     # ── Redis ─────────────────────────────────────────────────
     # If set, the rate limiter will use Redis instead of in-memory storage.

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -31,14 +31,13 @@ def _make_engine() -> AsyncEngine:
         pool_size=10,
         max_overflow=20,
         pool_recycle=1800,
-        connect_args={
+                connect_args={
+            # asyncpg client-side timeout in seconds
             "command_timeout": settings.database_command_timeout_seconds,
             "prepared_statement_cache_size": 0,
             "statement_cache_size": 0,
         },
     )
-
-
 engine = _make_engine()
 
 AsyncSessionLocal = async_sessionmaker(

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -32,6 +32,7 @@ def _make_engine() -> AsyncEngine:
         max_overflow=20,
         pool_recycle=1800,
         connect_args={
+            "command_timeout": settings.database_command_timeout_seconds,
             "prepared_statement_cache_size": 0,
             "statement_cache_size": 0,
         },


### PR DESCRIPTION
closes #553 


## Summary

Added a configurable timeout for async database queries to prevent requests from hanging indefinitely when database operations become blocked.

### Changes Made

* Added `database_command_timeout_seconds` configuration setting.
* Configured asyncpg `command_timeout` in SQLAlchemy async engine.
* Keeps timeout configurable through environment variables.

### Result

Database operations will no longer wait forever if a query becomes blocked, helping prevent stalled API requests and resource exhaustion.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database command timeout is now configurable via environment settings, with a default of 30 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->