### PR TITLE
Fix #784: refactor: add logging for database connection

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -55,7 +55,9 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
         try:
             yield session
             await session.commit()
-        except Exception:
+        except Exception as e:
+        import logging
+        logging.error(f"DB connection error: {e}")
             await session.rollback()
             raise
         finally:


### PR DESCRIPTION
Resolves #784. Database session fallback swallows errors. We need to print them clearly to the logger.