### PR TITLE
Fix #787: refactor: add logging to troubleshoot API

### DIFF
--- a/backend/app/api/v1/troubleshoot.py
+++ b/backend/app/api/v1/troubleshoot.py
@@ -55,7 +55,9 @@ async def troubleshoot(
                 yield (
                     f'data: {{"error":"PROVIDER_ERROR","message":"{exc.reason}"}}\n\n'
                 )
-            except Exception:
+            except Exception as e:
+            import logging
+            logging.error(f"Troubleshoot API error: {e}")
                 logger.exception("Error in troubleshoot stream generator")
                 yield (
                     'data: {"error":"STREAM_ERROR",'


### PR DESCRIPTION
Resolves #787. The troubleshoot API should log its internal execution errors. Resolving bare exception block.