### PR TITLE
Fix #789: refactor: log cuda compatibility summary errors

### DIFF
--- a/backend/app/api/v1/compatibility.py
+++ b/backend/app/api/v1/compatibility.py
@@ -57,7 +57,9 @@ async def get_compatibility_summary(db: DB) -> dict[str, Any]:
     try:
         cuda_res = await db.execute(select(CUDAMatrixDBModel))
         cuda_entries = cuda_res.scalars().all()
-    except Exception:
+    except Exception as e:
+        import logging
+        logging.error(f"CUDA summary DB fetch: {e}")
         pass
 
     if cuda_entries:


### PR DESCRIPTION
Resolves #789. The compatibility matrix API suppresses DB fetch errors for CUDA. Let's add logging.