### PR TITLE
Fix #791: refactor: log rocm compatibility summary errors

### DIFF
--- a/backend/app/api/v1/compatibility.py
+++ b/backend/app/api/v1/compatibility.py
@@ -74,7 +74,9 @@ async def get_compatibility_summary(db: DB) -> dict[str, Any]:
     try:
         rocm_res = await db.execute(select(RocmMatrixDBModel))
         rocm_entries = rocm_res.scalars().all()
-    except Exception:
+    except Exception as e:
+        import logging
+        logging.error(f"ROCm summary DB fetch: {e}")
         pass
 
     if rocm_entries:


### PR DESCRIPTION
Resolves #791. The compatibility matrix API suppresses DB fetch errors for ROCm. Let's add logging.