### PR TITLE
Fix #795: refactor: log cuda matrix fetch errors

### DIFF
--- a/backend/app/api/v1/compatibility.py
+++ b/backend/app/api/v1/compatibility.py
@@ -153,7 +153,9 @@ async def get_cuda_matrix(db: DB) -> dict[str, Any]:
     try:
         res = await db.execute(select(CUDAMatrixDBModel))
         cuda_entries = res.scalars().all()
-    except Exception:
+    except Exception as e:
+        import logging
+        logging.error(f"CUDA Matrix DB fetch: {e}")
         pass
 
     if cuda_entries:


### PR DESCRIPTION
Resolves #795. When fetching the full CUDA matrix, errors shouldn't be swallowed silently.