### PR TITLE
Fix #797: refactor: log cuda framework fetch errors

### DIFF
--- a/backend/app/api/v1/compatibility.py
+++ b/backend/app/api/v1/compatibility.py
@@ -205,7 +205,9 @@ async def get_framework_cuda_support(db: DB) -> dict[str, Any]:
     try:
         res = await db.execute(select(PythonMatrixDBModel))
         entries = res.scalars().all()
-    except Exception:
+    except Exception as e:
+        import logging
+        logging.error(f"CUDA Framework DB fetch: {e}")
         pass
 
     if entries:


### PR DESCRIPTION
Resolves #797. When fetching the CUDA framework dependencies, errors shouldn't be swallowed silently.