### PR TITLE
Fix #799: refactor: log cuda version lookup errors

### DIFF
--- a/backend/app/api/v1/compatibility.py
+++ b/backend/app/api/v1/compatibility.py
@@ -267,7 +267,9 @@ async def get_cuda_version(
                 "notes": entry.notes or "",
                 "source_url": entry.source_url or "",
             }
-    except Exception:
+    except Exception as e:
+        import logging
+        logging.error(f"CUDA version lookup: {e}")
         pass
 
     # Fallback to static


### PR DESCRIPTION
Resolves #799. When looking up a specific CUDA version, fallback failures need proper logging.