### PR TITLE
fix: add uniqueness constraint for webhook target URLs

### DIFF
--- a/backend/app/models/webhook.py
+++ b/backend/app/models/webhook.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import JSON, Boolean, Column, DateTime, String
+from sqlalchemy import JSON, Boolean, Column, DateTime, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
 
@@ -9,6 +9,12 @@ from app.database import Base
 
 class Webhook(Base):
     __tablename__ = "webhooks"
+    __table_args__ = (
+        UniqueConstraint(
+            "target_url",
+            name="uq_webhooks_target_url",
+        ),
+    )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     target_url = Column(String, nullable=False)


### PR DESCRIPTION
## Description

Adds a database-level uniqueness constraint to the `Webhook` model to prevent duplicate webhook URL registrations.

This helps avoid duplicate event deliveries and unnecessary processing when the same webhook URL is registered multiple times.

## Related Issues

Fixes #552

## Changes Made

* Added `UniqueConstraint` on `target_url` in the `Webhook` model
* Prevented duplicate webhook URL registrations at the database model level

## Verification

* [ ] Added unit tests
* [ ] Ran `pytest tests/` successfully
* [x] Manually reviewed model changes
* [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation

* [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
* [ ] Updated `CHANGELOG.md`
* [x] Code is fully documented and type-hinted

## Screenshots (if applicable)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enforced unique target URLs for webhooks. The system now prevents creating duplicate webhook configurations pointing to the same target, improving data consistency and reducing potential routing conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->