### PR TITLE
fix: add validation for negative and zero RAM/VRAM values in recommend_profiles

### DIFF
--- a/backend/app/recommendation/engine.py
+++ b/backend/app/recommendation/engine.py
@@ -29,6 +29,12 @@ def recommend_profiles(report: DiagnosticReportSchema) -> dict[str, Any]:
     total_ram = report.ram.total_gb
     is_apple_silicon = _is_apple_silicon(report)
 
+    if total_ram <= 0:
+        raise ValueError(f"Invalid RAM value: total_gb={total_ram}. RAM must be a positive number.")
+
+    if max_vram is not None and max_vram <= 0:
+        raise ValueError(f"Invalid VRAM value: vram_gb={max_vram}. VRAM must be a positive number.")
+
     if total_ram < 8:
         warnings.append(
             "Low system RAM (<8 GB). Heavy ML workloads may fail or swap heavily. "

--- a/backend/app/recommendation/engine.py
+++ b/backend/app/recommendation/engine.py
@@ -32,8 +32,9 @@ def recommend_profiles(report: DiagnosticReportSchema) -> dict[str, Any]:
     if total_ram <= 0:
         raise ValueError(f"Invalid RAM value: total_gb={total_ram}. RAM must be a positive number.")
 
-    if max_vram is not None and max_vram <= 0:
-        raise ValueError(f"Invalid VRAM value: vram_gb={max_vram}. VRAM must be a positive number.")
+    for gpu in report.gpus:
+        if gpu.vram_gb is not None and gpu.vram_gb <= 0:
+            raise ValueError(f"Invalid VRAM value: vram_gb={gpu.vram_gb}. VRAM must be a positive number.")
 
     if total_ram < 8:
         warnings.append(

--- a/backend/tests/unit/recommendation/test_engine.py
+++ b/backend/tests/unit/recommendation/test_engine.py
@@ -1,5 +1,7 @@
 """Unit tests for the ML Framework Recommendation Engine."""
 
+import pytest
+
 from app.recommendation.engine import recommend_profiles
 from app.schemas.diagnostic import DiagnosticReportSchema
 
@@ -100,23 +102,19 @@ class TestRankOrdering:
 
 class TestNegativeValues:
     def test_negative_ram_raises(self):
-        import pytest
         with pytest.raises(ValueError, match="RAM"):
             recommend_profiles(_make_report(ram_gb=-16.0))
 
     def test_zero_ram_raises(self):
-        import pytest
         with pytest.raises(ValueError, match="RAM"):
             recommend_profiles(_make_report(ram_gb=0.0))
 
     def test_negative_vram_raises(self):
-        import pytest
         with pytest.raises(ValueError, match="VRAM"):
             gpus = [{"name": "RTX 4090", "vram_gb": -8.0, "index": 0}]
             recommend_profiles(_make_report(gpus=gpus))
 
     def test_zero_vram_raises(self):
-        import pytest
         with pytest.raises(ValueError, match="VRAM"):
             gpus = [{"name": "RTX 4090", "vram_gb": 0.0, "index": 0}]
             recommend_profiles(_make_report(gpus=gpus))

--- a/backend/tests/unit/recommendation/test_engine.py
+++ b/backend/tests/unit/recommendation/test_engine.py
@@ -96,3 +96,27 @@ class TestRankOrdering:
         result = recommend_profiles(_make_report(gpus=gpus))
         ranks = [p["rank"] for p in result["recommended_profiles"]]
         assert ranks == sorted(ranks)
+
+
+class TestNegativeValues:
+    def test_negative_ram_raises(self):
+        import pytest
+        with pytest.raises(ValueError, match="RAM"):
+            recommend_profiles(_make_report(ram_gb=-16.0))
+
+    def test_zero_ram_raises(self):
+        import pytest
+        with pytest.raises(ValueError, match="RAM"):
+            recommend_profiles(_make_report(ram_gb=0.0))
+
+    def test_negative_vram_raises(self):
+        import pytest
+        with pytest.raises(ValueError, match="VRAM"):
+            gpus = [{"name": "RTX 4090", "vram_gb": -8.0, "index": 0}]
+            recommend_profiles(_make_report(gpus=gpus))
+
+    def test_zero_vram_raises(self):
+        import pytest
+        with pytest.raises(ValueError, match="VRAM"):
+            gpus = [{"name": "RTX 4090", "vram_gb": 0.0, "index": 0}]
+            recommend_profiles(_make_report(gpus=gpus))


### PR DESCRIPTION
## Description
Adds input validation for RAM and VRAM values in the `recommend_profiles` function. Previously, negative or zero values could be passed without error, causing incorrect recommendations (e.g. a negative RAM value would silently trigger the low RAM warning path). This PR raises a `ValueError` early with a descriptive message for any non-positive hardware capacity metric.

## Related Issues
Fixes #542 

## Changes Made
- Added validation in `backend/app/recommendation/engine.py` to raise `ValueError` if `total_ram <= 0`
- Added validation to raise `ValueError` if any GPU's `vram_gb <= 0`
- Added 4 new unit tests in `backend/tests/unit/recommendation/test_engine.py` covering negative RAM, zero RAM, negative VRAM, and zero VRAM cases

## Verification
<!-- Describe how you verified that your changes work. -->
- [x] Added unit tests
- [x] Ran `pytest tests/unit/recommendation/test_engine.py` successfully — 17 passed

## Documentation
- [x] Code is fully documented and type-hinted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened memory validation in the recommendation engine to reject configurations with invalid or missing RAM and VRAM specifications, ensuring only valid hardware configurations are processed.

* **Tests**
  * Added test coverage for memory validation logic to verify proper rejection of invalid memory values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->