### PR TITLE
fix: restore backend pytest collection

### DIFF
--- a/backend/app/api/v1/compatibility.py
+++ b/backend/app/api/v1/compatibility.py
@@ -212,11 +212,11 @@ async def get_framework_cuda_support(db: DB) -> dict[str, Any]:
 
     if entries:
         data: dict[str, dict[str, list[str]]] = {}
-        for e in entries:
-            if e.supported_cuda:
-                if e.framework not in data:
-                    data[e.framework] = {}
-                data[e.framework][e.version] = e.supported_cuda
+        for entry in entries:
+            if entry.supported_cuda:
+                if entry.framework not in data:
+                    data[entry.framework] = {}
+                data[entry.framework][entry.version] = entry.supported_cuda
     else:
         data = FRAMEWORK_CUDA_SUPPORT
 

--- a/backend/app/api/v1/troubleshoot.py
+++ b/backend/app/api/v1/troubleshoot.py
@@ -56,8 +56,8 @@ async def troubleshoot(
                     f'data: {{"error":"PROVIDER_ERROR","message":"{exc.reason}"}}\n\n'
                 )
             except Exception as e:
-            import logging
-            logging.error(f"Troubleshoot API error: {e}")
+                import logging
+                logging.error(f"Troubleshoot API error: {e}")
                 logger.exception("Error in troubleshoot stream generator")
                 yield (
                     'data: {"error":"STREAM_ERROR",'

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -56,8 +56,8 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
             yield session
             await session.commit()
         except Exception as e:
-        import logging
-        logging.error(f"DB connection error: {e}")
+            import logging
+            logging.error(f"DB connection error: {e}")
             await session.rollback()
             raise
         finally:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -150,8 +150,8 @@ def create_app() -> FastAPI:
             redis_status = "unavailable"
             overall = "degraded"
         except Exception as e:
-        import logging
-        logging.error(f"Main shutdown error: {e}")
+            import logging
+            logging.error(f"Main shutdown error: {e}")
             redis_status = "unavailable"
             overall = "degraded"
         return JSONResponse(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -151,7 +151,7 @@ def create_app() -> FastAPI:
             overall = "degraded"
         except Exception as e:
             import logging
-            logging.error(f"Main shutdown error: {e}")
+            logging.error(f"Redis health check failure: {e}")
             redis_status = "unavailable"
             overall = "degraded"
         return JSONResponse(

--- a/backend/app/services/cleanup_service.py
+++ b/backend/app/services/cleanup_service.py
@@ -4,8 +4,8 @@ import logging
 import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from prometheus_client import Counter, Gauge
 
+from prometheus_client import Counter, Gauge
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -22,7 +22,7 @@ GENERATED_SCRIPTS_RETENTION_DAYS = 7
 CLEANUP_RUNS_TOTAL = Counter(
     "cleanup_runs_total",
     "Total number of cleanup task executions",
-    ["status"], 
+    ["status"],
 )
 
 CLEANUP_LAST_RUN_TIMESTAMP = Gauge(
@@ -34,7 +34,6 @@ CLEANUP_LAST_RUN_SUCCESS = Gauge(
     "cleanup_last_run_success",
     "1 if the last cleanup run succeeded, 0 if it failed",
 )
-
 
 
 async def delete_expired_records(db: AsyncSession) -> dict[str, Any]:
@@ -69,7 +68,7 @@ async def delete_expired_records(db: AsyncSession) -> dict[str, Any]:
 async def run_cleanup() -> None:
     """Entry point for the scheduler — manages its own DB session."""
     logger.info("Running scheduled database cleanup...")
-    CLEANUP_LAST_RUN_TIMESTAMP.set(time.time()) 
+    CLEANUP_LAST_RUN_TIMESTAMP.set(time.time())
     async with AsyncSessionLocal() as db:
         try:
             result = await delete_expired_records(db)
@@ -79,6 +78,6 @@ async def run_cleanup() -> None:
         except Exception as e:
             logger.error(f"Cleanup task failed: {e}", exc_info=True)
             await db.rollback()
-            CLEANUP_RUNS_TOTAL.labels(status="failure").inc() 
+            CLEANUP_RUNS_TOTAL.labels(status="failure").inc()
             CLEANUP_LAST_RUN_SUCCESS.set(0)
-            raise   
+            raise

--- a/backend/app/services/profile_service.py
+++ b/backend/app/services/profile_service.py
@@ -256,8 +256,8 @@ async def create_profile(
     try:
         await db.commit()
     except Exception as e:
-            import logging
-            logging.error(f"Profile service error: {e}")
+        import logging
+        logging.error(f"Profile service error: {e}")
         await db.rollback()
         raise
 
@@ -285,8 +285,8 @@ async def delete_profile(
     try:
         await db.commit()
     except Exception as e:
-    import logging
-    logging.error(f"Profile error 1: {e}")
+        import logging
+        logging.error(f"Profile error 1: {e}")
         await db.rollback()
         raise
 
@@ -328,8 +328,8 @@ async def update_profile(
     try:
         await db.commit()
     except Exception as e:
-    import logging
-    logging.error(f"Profile error 2: {e}")
+        import logging
+        logging.error(f"Profile error 2: {e}")
         await db.rollback()
         raise
 

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -91,8 +91,8 @@ def parse_supported_python(requires_python: str | None) -> list[str]:
         supported = [v for v in all_py_versions if Version(v) in spec]
         return supported
     except Exception as e:
-            import logging
-            logging.error(f"Sync service error: {e}")
+        import logging
+        logging.error(f"Sync service error: {e}")
         return []
 
 
@@ -131,8 +131,8 @@ async def sync_pypi_releases(db: AsyncSession) -> None:
                     try:
                         sorted_releases.append((Version(v_str), v_str))
                     except Exception as e:
-                    import logging
-                    logging.error(f"Sync error 1: {e}")
+                        import logging
+                        logging.error(f"Sync error 1: {e}")
                         pass
                 sorted_releases.sort()
 
@@ -163,8 +163,8 @@ async def sync_pypi_releases(db: AsyncSession) -> None:
                                     .get("requires_python")
                                 )
                         except Exception as e:
-                        import logging
-                        logging.error(f"Sync error 2: {e}")
+                            import logging
+                            logging.error(f"Sync error 2: {e}")
                             pass
 
                     supported_py = parse_supported_python(requires_python)
@@ -195,8 +195,8 @@ async def sync_pypi_releases(db: AsyncSession) -> None:
                                     best_match = entry
                                     break
                             except Exception as e:
-                            import logging
-                            logging.error(f"Sync error 3: {e}")
+                                import logging
+                                logging.error(f"Sync error 3: {e}")
                                 pass
                         closest_cuda = best_match.supported_cuda
                         closest_rocm = best_match.supported_rocm
@@ -269,8 +269,8 @@ async def sync_nvidia_cuda_releases(db: AsyncSession) -> None:
                             cuda_rows, key=lambda r: Version(r.cuda_version)
                         )
                     except Exception as e:
-                    import logging
-                    logging.error(f"Sync error 4: {e}")
+                        import logging
+                        logging.error(f"Sync error 4: {e}")
                         latest_existing = cuda_rows[0]
 
                 min_linux = (

--- a/backend/app/templates/safety.py
+++ b/backend/app/templates/safety.py
@@ -237,8 +237,8 @@ def _validate_bash_ast(content: str, template_name: str = "") -> None:
                                                             is_whitelisted = True
                                                             break
                                                     except Exception as e:
-                                                    import logging
-                                                    logging.error(f"Safety parse error: {e}")
+                                                        import logging
+                                                        logging.error(f"Safety parse error: {e}")
                                                         pass
                             if not is_whitelisted:
                                 violations.append(

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -92,8 +92,8 @@ def run_diagnose_task(
     try:
         profiles = asyncio.run(_fetch_profiles())
     except Exception as e:
-            import logging
-            logging.error(f"Worker component error: {e}")
+        import logging
+        logging.error(f"Worker component error: {e}")
         logger.exception("Failed to fetch profiles for run_diagnose_task")
         raise
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -123,8 +123,8 @@ async def test_engine():
                 try:
                     item = json.loads(item_str)
                 except Exception as e:
-                import logging
-                logging.error(f"Test fixture error: {e}")
+                    import logging
+                    logging.error(f"Test fixture error: {e}")
                     item = item_str
 
                 if isinstance(item, list):

--- a/backend/tests/unit/services/test_cleanup_service.py
+++ b/backend/tests/unit/services/test_cleanup_service.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 def _make_db(rowcount: int = 3):
@@ -52,7 +53,7 @@ async def test_failure_reraises_exception():
 
 
 async def test_rollback_called_on_failure():
-    from app.services import cleanup_service 
+    from app.services import cleanup_service
 
     db = _make_db()
     db.execute = AsyncMock(side_effect=Exception("error"))
@@ -60,4 +61,4 @@ async def test_rollback_called_on_failure():
         with pytest.raises(Exception):
             await cleanup_service.run_cleanup()
 
-    db.rollback.assert_awaited_once()  
+    db.rollback.assert_awaited_once()


### PR DESCRIPTION
## Summary

- restores malformed exception-handler indentation across backend modules that blocked imports
- fixes the test fixture indentation error that prevented pytest collection
- includes additional import-time blockers found while rerunning collection

## Verification

- env PYTHONPYCACHEPREFIX=/private/tmp/envforage-pycache python3 -m py_compile tests/conftest.py app/database.py app/templates/safety.py app/main.py app/services/profile_service.py app/worker.py
- env UV_CACHE_DIR=/private/tmp/uv-cache PYTHONPYCACHEPREFIX=/private/tmp/envforage-pycache uv run --extra dev python -m compileall -q app tests
- env UV_CACHE_DIR=/private/tmp/uv-cache PYTHONPYCACHEPREFIX=/private/tmp/envforage-pycache uv run --extra dev python -m pytest --collect-only
- env UV_CACHE_DIR=/private/tmp/uv-cache PYTHONPYCACHEPREFIX=/private/tmp/envforage-pycache uv run --extra dev ruff check app/database.py app/main.py app/services/profile_service.py app/templates/safety.py app/worker.py app/api/v1/troubleshoot.py app/services/sync_service.py tests/conftest.py

Fixes #814


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced error logging and exception handling across core backend services including database operations, API troubleshooting, health monitoring, profile management, package synchronization, and worker tasks
* Improved system observability to provide better visibility into error conditions for operational support and debugging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->