### PR TITLE
Fix #864: Refactor: Frontend Component Memoization

### DIFF
--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -26,3 +26,43 @@ export const Button: React.FC<ButtonProps> = ({ children, variant = 'primary', c
     </button>
   );
 };
+
+// --- Memoized Button Component ---
+import React, { ButtonHTMLAttributes } from 'react';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+    variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
+    size?: 'sm' | 'md' | 'lg';
+    isLoading?: boolean;
+}
+
+const ButtonComponent = React.forwardRef<HTMLButtonElement, ButtonProps>(
+    ({ className = '', variant = 'primary', size = 'md', isLoading, children, disabled, ...props }, ref) => {
+        const baseStyles = 'inline-flex items-center justify-center font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2';
+        
+        // Example dynamic classes based on props (in a real app, use clsx/tailwind-merge)
+        const variantStyles = {
+            primary: 'bg-brand-primary text-white hover:bg-brand-primary/90',
+            secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-300',
+            danger: 'bg-red-600 text-white hover:bg-red-700',
+            ghost: 'bg-transparent text-gray-700 hover:bg-gray-100'
+        };
+
+        return (
+            <button
+                ref={ref}
+                disabled={isLoading || disabled}
+                className={`${baseStyles} ${variantStyles[variant]} ${className}`}
+                {...props}
+            >
+                {isLoading ? <span className="animate-spin mr-2">⏳</span> : null}
+                {children}
+            </button>
+        );
+    }
+);
+
+ButtonComponent.displayName = 'Button';
+
+// Memoize to prevent unnecessary re-renders when parent state changes
+export const Button = React.memo(ButtonComponent);


### PR DESCRIPTION
Resolves #864. Wrapping frequently re-rendering display components in React.memo to optimize the render tree.