### PR TITLE
Fix #872: Refactor: Frontend Axios Retry Interceptor

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -203,3 +203,42 @@ export const api = {
 		return response.json();
 	},
 };
+
+// --- Axios Retry Interceptor ---
+import axios, { AxiosError } from 'axios';
+
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+export const apiClient = axios.create({
+    baseURL: process.env.NEXT_PUBLIC_API_URL || '/api/v1',
+    timeout: 10000,
+});
+
+apiClient.interceptors.response.use(
+    (response) => response,
+    async (error: AxiosError) => {
+        const config = error.config as any;
+        
+        if (!config || !config.retryCount) {
+            config.retryCount = 0;
+        }
+
+        const shouldRetry = 
+            error.response?.status && 
+            error.response.status >= 500 && 
+            config.retryCount < MAX_RETRIES;
+
+        if (shouldRetry) {
+            config.retryCount += 1;
+            const delay = BASE_DELAY_MS * (2 ** (config.retryCount - 1));
+            
+            console.warn(`[API] Transient error. Retrying request (${config.retryCount}/${MAX_RETRIES}) in ${delay}ms...`);
+            
+            await new Promise((resolve) => setTimeout(resolve, delay));
+            return apiClient(config);
+        }
+
+        return Promise.reject(error);
+    }
+);


### PR DESCRIPTION
Resolves #872. Injecting an Axios interceptor within api.ts providing exponential backoff retries for transient 500-level network errors.