### PR TITLE
feat: graceful shutdown for active SSE streams (#192)

### DIFF
--- a/backend/app/api/v1/troubleshoot.py
+++ b/backend/app/api/v1/troubleshoot.py
@@ -3,7 +3,7 @@
 import logging
 from collections.abc import AsyncIterator
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import StreamingResponse
 
 from app.ai.models import TroubleshootRequest
@@ -37,6 +37,7 @@ _service = AITroubleshootService()
 )
 async def troubleshoot(
     request: TroubleshootRequest,
+    http_request: Request,
     db: DB,
     _rate_limit: None = Depends(ai_rate_limit),
 ) -> StreamingResponse:
@@ -62,8 +63,13 @@ async def troubleshoot(
                     '"message":"Internal streaming error."}\n\n'
                 )
 
+        stream: AsyncIterator[str] = event_generator()
+        tracker = getattr(http_request.app.state, "stream_tracker", None)
+        if tracker is not None:
+            stream = tracker.track(stream)
+
         return StreamingResponse(
-            event_generator(),
+            stream,
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,7 +12,7 @@ import tempfile
 import urllib.parse
 from functools import lru_cache
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from dotenv import load_dotenv
 from pydantic import field_validator, model_validator
@@ -38,6 +38,24 @@ class Settings(BaseSettings):
     app_name: str = "EnvForage"
     app_version: str = "1.0.0"
     custom_template_dir: Path | None = None
+
+    # ── Graceful shutdown ─────────────────────────────────────
+    # Max seconds to wait for in-flight SSE streams to finish before the
+    # process exits (e.g. on SIGTERM during a Kubernetes rolling update).
+    graceful_shutdown_timeout_seconds: float = 30.0
+
+    @field_validator("graceful_shutdown_timeout_seconds")
+    @classmethod
+    def validate_graceful_shutdown_timeout_seconds(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError(
+                "graceful_shutdown_timeout_seconds must be greater than 0"
+            )
+        if v > 300:
+            raise ValueError(
+                "graceful_shutdown_timeout_seconds must be less than or equal to 300"
+            )
+        return v
 
     # ── Database ──────────────────────────────────────────────
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/envforge"

--- a/backend/app/core/stream_tracker.py
+++ b/backend/app/core/stream_tracker.py
@@ -1,0 +1,66 @@
+"""In-flight SSE stream tracking for graceful shutdown.
+
+Active streaming responses register themselves with a :class:`StreamTracker`
+stored on ``app.state`` so the application lifespan can wait for them to finish
+before the process exits — e.g. on a SIGTERM during a Kubernetes rolling
+update — instead of abruptly severing live LLM streams.
+"""
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+
+logger = logging.getLogger(__name__)
+
+
+class StreamTracker:
+    """Count in-flight streaming responses and wait for them to drain."""
+
+    def __init__(self) -> None:
+        self._active = 0
+        self._idle = asyncio.Event()
+        self._idle.set()
+
+    @property
+    def active(self) -> int:
+        """Number of streams currently in flight."""
+        return self._active
+
+    def track(self, stream: AsyncIterator[str]) -> AsyncIterator[str]:
+        """Wrap *stream*, counting it as active until it is exhausted or closed."""
+        self._active += 1
+        self._idle.clear()
+        return self._guard(stream)
+
+    async def _guard(self, stream: AsyncIterator[str]) -> AsyncIterator[str]:
+        try:
+            async for item in stream:
+                yield item
+        finally:
+            self._active -= 1
+            if self._active <= 0:
+                self._active = 0
+                self._idle.set()
+
+    async def drain(self, timeout: float) -> bool:
+        """Wait until all active streams finish or *timeout* seconds elapse.
+
+        Returns ``True`` if every stream drained, ``False`` if the timeout was
+        reached while streams were still active.
+        """
+        if self._active == 0:
+            return True
+        logger.info(
+            "Waiting up to %.1fs for %d active stream(s) to finish",
+            timeout,
+            self._active,
+        )
+        try:
+            await asyncio.wait_for(self._idle.wait(), timeout)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Shutdown timeout reached with %d stream(s) still active",
+                self._active,
+            )
+            return False
+        return True

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,6 +32,7 @@ from app.cache import get_redis_client
 from app.config import get_settings
 from app.core.handlers import register_exception_handlers
 from app.core.logging import setup_logging
+from app.core.stream_tracker import StreamTracker
 from app.database import AsyncSessionLocal
 from app.middleware.metrics import setup_metrics
 from app.middleware.payload_size import PayloadSizeLimitMiddleware
@@ -52,6 +53,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         version=settings.app_version,
         environment=settings.environment,
     )
+    # Track in-flight SSE streams so shutdown can drain them gracefully.
+    app.state.stream_tracker = StreamTracker()
+
     # ── Background cleanup scheduler ─────────────────────────
     scheduler = AsyncIOScheduler()
     scheduler.add_job(
@@ -70,6 +74,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         sync_task = asyncio.create_task(matrix_sync_loop(AsyncSessionLocal))
 
     yield
+
+    # Let active SSE streams finish before tearing resources down
+    # (e.g. on SIGTERM during a rolling update) — see issue #192.
+    drained = await app.state.stream_tracker.drain(
+        settings.graceful_shutdown_timeout_seconds
+    )
+    if not drained:
+        logger_instance.warning(
+            "Graceful shutdown timed out while waiting for active streams"
+        )
 
     if sync_task:
         sync_task.cancel()

--- a/backend/tests/unit/test_stream_tracker.py
+++ b/backend/tests/unit/test_stream_tracker.py
@@ -1,0 +1,71 @@
+"""Unit tests for StreamTracker (graceful SSE shutdown drain)."""
+
+import asyncio
+
+from app.core.stream_tracker import StreamTracker
+
+
+async def _consume(stream) -> list[str]:
+    return [item async for item in stream]
+
+
+async def test_track_counts_active_then_releases() -> None:
+    tracker = StreamTracker()
+
+    async def gen():
+        yield "a"
+        yield "b"
+
+    wrapped = tracker.track(gen())
+    assert tracker.active == 1  # counted as soon as it is handed over
+
+    assert await _consume(wrapped) == ["a", "b"]
+    assert tracker.active == 0  # released once exhausted
+
+
+async def test_drain_returns_immediately_when_idle() -> None:
+    tracker = StreamTracker()
+    assert await tracker.drain(timeout=0.1) is True
+
+
+async def test_drain_waits_for_active_stream_to_finish() -> None:
+    tracker = StreamTracker()
+    started = asyncio.Event()
+
+    async def slow():
+        started.set()
+        await asyncio.sleep(0.05)
+        yield "done"
+
+    wrapped = tracker.track(slow())
+    consumer = asyncio.create_task(_consume(wrapped))
+
+    await started.wait()
+    assert tracker.active == 1
+
+    assert await tracker.drain(timeout=1.0) is True
+    assert tracker.active == 0
+    await consumer
+
+
+async def test_drain_times_out_when_stream_is_stuck() -> None:
+    tracker = StreamTracker()
+    release = asyncio.Event()
+
+    async def stuck():
+        yield "first"
+        await release.wait()  # not released within the drain timeout
+        yield "second"
+
+    wrapped = tracker.track(stuck())
+    consumer = asyncio.create_task(_consume(wrapped))
+
+    await asyncio.sleep(0.01)  # let it start and yield "first"
+    assert tracker.active == 1
+
+    assert await tracker.drain(timeout=0.05) is False
+    assert tracker.active == 1  # still in flight
+
+    release.set()
+    await consumer
+    assert tracker.active == 0


### PR DESCRIPTION
Closes #192

## What
On `SIGTERM` (e.g. a Kubernetes rolling update), active `/api/v1/troubleshoot`
SSE streams were severed mid-response. This drains them gracefully: in-flight
streams are tracked on `app.state` and awaited (up to a configurable timeout)
in the `lifespan` shutdown block, so live LLM streams can finish.

## Changes
- **`app/core/stream_tracker.py`** (new): `StreamTracker` counts active streams
  and exposes an awaitable `drain(timeout)` (returns `False` on timeout).
- **`main.py`**: create the tracker on startup; `drain()` it at the start of the
  lifespan shutdown, before background tasks/scheduler are torn down.
- **`api/v1/troubleshoot.py`**: wrap the SSE generator with `tracker.track(...)`.
- **`config.py`**: add `graceful_shutdown_timeout_seconds` (default `30.0`, validated).
- **tests**: unit tests for stream counting + both drain paths (clean + timeout).

Set the timeout below the pod's `terminationGracePeriodSeconds`.

## Note (pre-existing, out of scope)
`config.py` didn't import on `main` due to a missing `Any` import
(`NameError` at `ConfigurationHealthCheck`), which blocked the whole app/test
suite. I added the one-line import so this PR's code and tests load. Other
pre-existing `config.py` issues (e.g. `allowed_origins_list` dedented out of
`Settings`) are unrelated and left untouched.

## Testing
`StreamTracker` unit tests pass (tracking, clean drain, timeout). Full app-level
integration couldn't run locally because of the pre-existing `config.py` issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented graceful shutdown support for active streaming responses with configurable timeout duration.
  * Added new `graceful_shutdown_timeout_seconds` configuration setting (default 30 seconds, maximum 300 seconds) to control how long the system waits for active streams to complete during shutdown.
  * Troubleshoot API endpoint enhanced with improved stream tracking capabilities.

* **Tests**
  * Added comprehensive unit tests covering graceful shutdown behavior for streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Note on the failing checks — none are introduced by this PR:

- **Frontend Build & Lint**: this PR only changes the backend (graceful SSE
  shutdown, issue #192); the frontend is untouched.
- **Vercel**: "Authorization required to deploy" — a fork deploy-permission
  issue, not a code problem.
- **Backend Tests**: fails on pre-existing issues in `config.py` on `main` —
  notably `Settings.allowed_origins_list` is dedented out of the class, so
  `create_app()` raises `AttributeError` and every app-importing test errors.
  This PR adds the one missing `Any` import so `config.py` at least imports;
  the rest is out of scope for #192. The new `StreamTracker` unit tests pass.

Happy to open a separate issue/PR for the `config.py` breakage if useful.