### PR TITLE
fix(compatibility): add missing torch 2.3.1 to Python matrix, add reg…

### DIFF
--- a/backend/app/compatibility/matrix/python.py
+++ b/backend/app/compatibility/matrix/python.py
@@ -93,6 +93,16 @@ _HARDCODED_MATRIX: dict[str, list[FrameworkVersionEntry]] = {
             supported_python=["3.8", "3.9", "3.10", "3.11"],
             supported_cuda=["11.8", "12.1"],
         ),
+        # torch 2.3.1 — patch release of 2.3.0, same Python/CUDA support.
+        # Source: https://pytorch.org/get-started/previous-versions/
+        FrameworkVersionEntry(
+            framework="torch",
+            version="2.3.1",
+            min_python="3.8",
+            max_python="3.11",
+            supported_python=["3.8", "3.9", "3.10", "3.11"],
+            supported_cuda=["11.8", "12.1"],
+        ),
         FrameworkVersionEntry(
             framework="torch",
             version="2.4.0",

--- a/backend/tests/unit/compatibility/test_resolver.py
+++ b/backend/tests/unit/compatibility/test_resolver.py
@@ -438,3 +438,59 @@ async def test_no_matching_semver_range():
             os_support=["LINUX", "WSL"],
             cuda_required=True,
         )
+
+
+# ── Regression: torch 2.3.1 silent validation bypass ─────────────────────────
+# torch 2.3.1 was previously missing from the Python compatibility matrix.
+# Without this entry, _get_framework_entry() returned None and the resolver
+# silently skipped all Python/CUDA guards — allowing invalid combinations
+# to produce scripts without any error.
+# See: https://pytorch.org/get-started/previous-versions/ (torch 2.3.1)
+
+
+@pytest.mark.asyncio
+async def test_torch_231_rejects_unsupported_python():
+    """torch 2.3.1 only supports Python 3.8–3.11; 3.12 must be rejected."""
+    with pytest.raises(IncompatibilityError) as exc:
+        await R.resolve(
+            packages=[PackageConstraint("torch", "2.3.1")],
+            python_version="3.12",
+            cuda_version="12.1",
+            target_os="LINUX",
+            profile_slug="pytorch-cuda",
+            os_support=["LINUX", "WSL"],
+            cuda_required=True,
+        )
+    assert exc.value.component == "python"
+
+
+@pytest.mark.asyncio
+async def test_torch_231_rejects_unsupported_cuda():
+    """torch 2.3.1 only supports CUDA 11.8 and 12.1; 12.4 must be rejected."""
+    with pytest.raises(IncompatibilityError) as exc:
+        await R.resolve(
+            packages=[PackageConstraint("torch", "2.3.1")],
+            python_version="3.11",
+            cuda_version="12.4",
+            target_os="LINUX",
+            profile_slug="pytorch-cuda",
+            os_support=["LINUX", "WSL"],
+            cuda_required=True,
+        )
+    assert exc.value.component == "cuda"
+
+
+@pytest.mark.asyncio
+async def test_torch_231_valid_combination_succeeds():
+    """torch 2.3.1 + Python 3.11 + CUDA 12.1 is a valid combination."""
+    result = await R.resolve(
+        packages=[PackageConstraint("torch", "2.3.1")],
+        python_version="3.11",
+        cuda_version="12.1",
+        target_os="LINUX",
+        profile_slug="pytorch-cuda",
+        os_support=["LINUX", "WSL"],
+        cuda_required=True,
+    )
+    assert result.packages[0].version == "2.3.1"
+    assert result.packages[0].cuda_variant == "cu121"


### PR DESCRIPTION
## Description

This PR fixes a compatibility matrix inconsistency where `torch==2.3.1` was present in the CUDA compatibility matrix but missing from the Python compatibility matrix.

Because of the missing entry, the Compatibility Resolver treated `torch 2.3.1` as an unknown version and skipped Python and CUDA compatibility validation. This allowed unsupported combinations to pass validation and generate invalid installation scripts.

The fix adds the missing `FrameworkVersionEntry` for `torch 2.3.1` with the correct Python and CUDA support metadata. Additionally, regression tests have been added to ensure unsupported Python and CUDA versions are properly rejected and valid configurations continue to resolve successfully.

---

## Related Issues

Fixes #987 

---

## Changes Made

* Added missing `torch 2.3.1` entry to `backend/app/compatibility/matrix/python.py`
* Added regression tests for Python and CUDA compatibility validation
* Added a positive test case to verify valid `torch 2.3.1` configurations resolve correctly
* Restored proper compatibility checks for `torch 2.3.1`

---

## Verification

* [x] Added unit tests
* [x] Ran `pytest tests/` successfully
* [x] Manually verified resolver behavior for supported and unsupported combinations
* [ ] (If applicable) Generated scripts pass `SafetyFilter`

---

## Documentation

* [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
* [ ] Updated `CHANGELOG.md`
* [x] Code is fully documented and type-hinted

---

## Screenshots (if applicable)

N/A – Backend-only change with no UI modifications.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for PyTorch 2.3.1 with Python 3.8–3.11 and CUDA 11.8, 12.1 compatibility.

* **Tests**
  * Added regression tests to validate compatibility resolution for PyTorch 2.3.1 across supported Python and CUDA versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->