### PR TITLE
fix: apply rate limiting to admin delete endpoint

### DIFF
--- a/backend/app/api/v1/profiles.py
+++ b/backend/app/api/v1/profiles.py
@@ -186,6 +186,7 @@ async def delete_profile(
         description="Unique slug of the environment profile to delete.",
         examples=["pytorch-cu121"],
     ),
+    _rate_limit: None = Depends(general_rate_limit),
     _auth: None = Depends(require_admin),
 ) -> None:
     """


### PR DESCRIPTION
## Description

This PR applies rate limiting to the `DELETE /profiles/{slug}` admin endpoint.

Previously, the `POST` and `PATCH` profile management endpoints were protected by `general_rate_limit`, while the `DELETE` endpoint only enforced admin authentication. This change ensures that all profile management admin routes consistently apply rate limiting, helping prevent excessive administrative requests.

## Related Issues

Fixes #557

## Changes Made

* Added `general_rate_limit` dependency to the `DELETE /profiles/{slug}` endpoint.
* Aligned the delete endpoint with the existing `POST` and `PATCH` admin routes for consistent rate limiting behavior.

## Verification

* [ ] Added unit tests
* [ ] Ran `pytest tests/` successfully
* [] Manually tested via code review
* [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation

* [ ] Updated `docs/FEATURES.md` (not applicable)
* [ ] Updated `CHANGELOG.md` (not applicable)
* [] Code is fully documented and type-hinted

## Screenshots (if applicable)

N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added rate limiting to profile deletion requests to prevent excessive usage and protect system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->