### PR TITLE
feat(cli): add Python and OS info to --version output

### DIFF
--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -56,8 +56,25 @@ def check_macos_support():
 # ── Root command group ─────────────────────────────────────────────────────────
 
 
+def _version_callback(ctx: click.Context, _param: click.Parameter, value: bool) -> None:
+    if not value or ctx.resilient_parsing:
+        return
+    python_ver = sys.version.split()[0]
+    os_info = f"{platform.system()} {platform.release()} {platform.machine()}"
+    click.echo(f"envforge-agent {__version__}")
+    click.echo(f"Python {python_ver} · {os_info}")
+    ctx.exit()
+
+
 @click.group()
-@click.version_option(__version__, prog_name="envforge-agent")
+@click.option(
+    "--version",
+    is_flag=True,
+    is_eager=True,
+    expose_value=False,
+    callback=_version_callback,
+    help="Show the version and exit.",
+)
 @click.option(
     "--no-color",
     is_flag=True,


### PR DESCRIPTION
## Description
Replaces the default `@click.version_option` with a custom `--version`
callback that includes Python version and OS platform info alongside the
agent version. Previously `envforge --version` only showed the agent
version string, making it unhelpful for bug reports — users had to run
multiple commands to gather environment context.

## Related Issues
Closes #1001

## Changes Made
- `cli/envforge_agent/cli.py` only — replaced `@click.version_option` with
  a custom `_version_callback` and `--version` Click option on the root
  `cli` group

## Before vs After
**Before:**
envforge-agent, version 1.0.2

**After:**
envforge-agent 1.0.2

Python 3.14.2 · Windows 11 AMD64

## Verification
- [ ] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [x] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

Verified both `--version` and `--help` work correctly after the change.

## Documentation
- [ ] Updated `docs/FEATURES.md`
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted

## Screenshots 
<img width="1156" height="558" alt="image" src="https://github.com/user-attachments/assets/7b02a8c6-24d6-42b1-8737-20a9bd9cc77f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `--version` flag now displays enhanced system information, including the installed Python version and operating system details alongside the envforge-agent version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->