### PR TITLE
feat(cli): add retry logic to diagnose --send on transient network failure

### DIFF
--- a/cli/envforge_agent/cli.py
+++ b/cli/envforge_agent/cli.py
@@ -349,35 +349,50 @@ def _print_recommendations(report: DiagnosticReport) -> None:
 
 
 async def _send_report(report: DiagnosticReport, api_url: str, quiet: bool) -> None:
-    """POST the DiagnosticReport to the EnvForge API."""
+    """POST the DiagnosticReport to the EnvForge API with retry logic."""
     url = f"{api_url.rstrip('/')}/api/v1/diagnose"
     if not quiet:
         console.print(f"\n[bold]Sending report to[/] {url} ...")
 
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                url,
-                content=report.to_json(),
-                headers={"Content-Type": "application/json"},
-                timeout=30,
-            )
-        response.raise_for_status()
-        result = response.json()
+    max_attempts = 3
+    delays = [2, 4]  # seconds between retries
 
-        if not quiet:
-            _print_diagnose_response(result)
-        else:
-            click.echo(json.dumps(result, indent=2))
+    for attempt in range(1, max_attempts + 1):
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    url,
+                    content=report.to_json(),
+                    headers={"Content-Type": "application/json"},
+                    timeout=30,
+                )
+            response.raise_for_status()
+            result = response.json()
 
-    except httpx.ConnectError:
-        err_console.print(f"[ERROR] Cannot connect to {url}")
-        err_console.print("  Hint: Is the EnvForge API running? Check ENVFORGE_API_URL.")
-        sys.exit(1)
-    except httpx.HTTPStatusError as e:
-        err_console.print(f"[ERROR] API returned {e.response.status_code}")
-        err_console.print(e.response.text)
-        sys.exit(1)
+            if not quiet:
+                _print_diagnose_response(result)
+            else:
+                click.echo(json.dumps(result, indent=2))
+            return
+
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            if attempt < max_attempts:
+                delay = delays[attempt - 1]
+                if not quiet:
+                    console.print(
+                        f"  [yellow][Attempt {attempt}/{max_attempts}] "
+                        f"Connection failed, retrying in {delay}s...[/]"
+                    )
+                await asyncio.sleep(delay)
+            else:
+                err_console.print(f"[ERROR] Cannot connect to {url}")
+                err_console.print("  Hint: Is the EnvForge API running? Check ENVFORGE_API_URL.")
+                sys.exit(1)
+
+        except httpx.HTTPStatusError as e:
+            err_console.print(f"[ERROR] API returned {e.response.status_code}")
+            err_console.print(e.response.text)
+            sys.exit(1)
 
 
 def _print_diagnose_response(result: dict) -> None:


### PR DESCRIPTION
## Description
Adds retry logic with exponential backoff to `_send_report()` in the
`envforge diagnose --send` flow. Previously a single transient network
failure caused the entire command to fail immediately, forcing users to
re-run the full hardware scan just to retry a network call.

## Related Issues
Closes #1002

## Changes Made
- `cli/envforge_agent/cli.py` only — `_send_report()` function

## Retry Behaviour
| Scenario | Behaviour |
|----------|-----------|
| `ConnectError` or `TimeoutException` on attempt 1 | Retry after 2s |
| `ConnectError` or `TimeoutException` on attempt 2 | Retry after 4s |
| `ConnectError` or `TimeoutException` on attempt 3 | Fail with error |
| `HTTPStatusError` (4xx/5xx) on any attempt | Fail immediately — no retry |

## User-Facing Output
Sending report to http://localhost:8000/api/v1/diagnose ...

[Attempt 1/3] Connection failed, retrying in 2s...

[Attempt 2/3] Connection failed, retrying in 4s...

[ERROR] Cannot connect to http://localhost:8000/api/v1/diagnose

Hint: Is the EnvForge API running? Check ENVFORGE_API_URL.
## Verification
- [ ] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [x] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated `docs/FEATURES.md`
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted

## Screenshots 
<img width="1482" height="831" alt="image" src="https://github.com/user-attachments/assets/05ba8bc9-1d78-44a2-9b93-68be1112722e" />

