### PR TITLE
fix(templates): register Makefile in TEMPLATE_MAP. Closes #1007

### DIFF
--- a/backend/app/templates/engine.py
+++ b/backend/app/templates/engine.py
@@ -29,6 +29,7 @@ TEMPLATE_MAP: dict[str, str] = {
     "requirements.txt": "config/requirements.j2",
     "Dockerfile": "config/dockerfile.j2",
     "docker-compose.yml": "config/docker-compose.yml.j2",
+    "Makefile": "config/makefile.j2",
     "devcontainer.json": "config/devcontainer.j2",
     "verify.sh": "verify/verify_generic.sh.j2",
     "verify_torch.sh": "verify/verify_torch.sh.j2",

--- a/backend/tests/unit/templates/test_makefile_template.py
+++ b/backend/tests/unit/templates/test_makefile_template.py
@@ -1,0 +1,83 @@
+"""Tests for the Makefile output format.
+
+Regression: "Makefile" is a valid OutputFormat with a template on disk, but it
+was missing from TEMPLATE_MAP, so requests for it raised KeyError -> HTTP 500.
+Also includes a contract test ensuring the schema's OutputFormat values and the
+renderer's TEMPLATE_MAP cannot drift apart again.
+"""
+from app.compatibility.models import ResolvedEnvironment, ResolvedPackage
+from app.templates.engine import TEMPLATE_MAP, TemplateRenderer
+from app.templates.models import TemplateContext
+
+
+def make_context(
+    profile_name="myenv",
+    python_version="3.11",
+    cuda_version=None,
+    target_os="LINUX",
+    packages=None,
+):
+    if packages is None:
+        packages = []
+    resolved = ResolvedEnvironment(
+        python_version=python_version,
+        cuda_version=cuda_version,
+        target_os=target_os,
+        packages=packages,
+    )
+    return TemplateContext(
+        profile_id="test-id",
+        profile_name=profile_name,
+        resolved=resolved,
+    )
+
+
+def test_makefile_is_registered():
+    # The core regression: "Makefile" must be in TEMPLATE_MAP.
+    assert "Makefile" in TEMPLATE_MAP
+
+
+def test_makefile_renders_expected_targets():
+    context = make_context(
+        profile_name="myenv",
+        python_version="3.11",
+        packages=[ResolvedPackage(name="numpy", version="1.26.0", cuda_variant=None)],
+    )
+    renderer = TemplateRenderer()
+    result = renderer.render("Makefile", context)
+    # Standard make targets the template defines.
+    assert ".PHONY:" in result.content
+    assert "install:" in result.content
+    assert "verify:" in result.content
+    assert "clean:" in result.content
+    assert "help:" in result.content
+    # Header carries profile/python metadata.
+    assert "myenv" in result.content
+    assert "3.11" in result.content
+
+
+def test_all_output_formats_have_registered_templates():
+    """Contract test: every API-accepted OutputFormat must map to a template
+    in TEMPLATE_MAP, and each mapped template file must exist on disk. This is
+    the guard that prevents the schema/renderer drift that caused #1007.
+    """
+    import typing
+    from pathlib import Path
+
+    from app.schemas.script import OutputFormat
+    from app.templates import engine as engine_module
+
+    output_formats = typing.get_args(OutputFormat)
+    assert output_formats, "OutputFormat literal should not be empty"
+
+    jinja_root = Path(engine_module.__file__).parent / "jinja"
+    for fmt in output_formats:
+        assert fmt in TEMPLATE_MAP, (
+            f"OutputFormat '{fmt}' is accepted by the API but missing from "
+            f"TEMPLATE_MAP"
+        )
+        template_file = jinja_root / TEMPLATE_MAP[fmt]
+        assert template_file.is_file(), (
+            f"TEMPLATE_MAP['{fmt}'] points to '{TEMPLATE_MAP[fmt]}', which does "
+            f"not exist at {template_file}"
+        )


### PR DESCRIPTION
## Description

`"Makefile"` is a valid `OutputFormat` in `backend/app/schemas/script.py` and the template `backend/app/templates/jinja/config/makefile.j2` exists, but the format was missing from `TEMPLATE_MAP` in `backend/app/templates/engine.py`. As a result, a request with `output_formats: ["Makefile"]` passed schema validation and compatibility resolution, then raised `KeyError` in `TemplateRenderer.render()` — which the scripts endpoint doesn't catch (it only handles compatibility exceptions), so it surfaced as a `500 Internal Server Error`.

This registers the missing `Makefile` entry so the format renders correctly, and adds tests — including a contract test that prevents the schema and renderer registries from drifting apart again (the root cause of this class of bug).

## Related Issues

Closes #1007

## Changes Made

- Registered `"Makefile": "config/makefile.j2"` in `TEMPLATE_MAP` (`backend/app/templates/engine.py`).
- Added `backend/tests/unit/templates/test_makefile_template.py` with three tests:
  - `test_makefile_is_registered` — the core regression guard.
  - `test_makefile_renders_expected_targets` — renders the Makefile and asserts its `install` / `verify` / `clean` / `help` targets and header metadata.
  - `test_all_output_formats_have_registered_templates` — a contract test asserting every API-accepted `OutputFormat` maps to a `TEMPLATE_MAP` entry whose template file exists on disk.

## Verification

- [x] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

Ran the new tests: `pytest tests/unit/templates/test_makefile_template.py -v` — all 3 pass. In particular, the contract test passing confirms all 10 current `OutputFormat` values are registered with existing templates.

I could not run the full `pytest tests/` suite: on current `main` it fails at collection with `AttributeError: 'Settings' object has no attribute 'redis_url'`, raised at import time in `app/middleware/rate_limit.py` (line 253, inside `_make_backend()` called at module load). This is unrelated to this change — my tests live in `tests/unit/templates/` and don't import that chain — and it appears to be a pre-existing issue on `main` (it may also be what's failing the Backend Tests CI check on other PRs). Flagging it in case it's not already known.

## Documentation

- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted

This is a bug fix (restoring a missing registry entry), not a new feature, so no `docs/FEATURES.md` or `CHANGELOG.md` change. The added test module has a module docstring and the contract test is documented inline.

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Makefile as a new supported output format. Generated Makefiles include pre-configured make targets and environment-specific settings such as Python version and package dependencies.

* **Tests**
  * Added comprehensive test suite for Makefile template functionality. Tests also verify that all output formats are properly registered to prevent future configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->