### PR TITLE
fix: validate session_id format in troubleshoot API

### DIFF
--- a/backend/app/ai/models.py
+++ b/backend/app/ai/models.py
@@ -12,6 +12,7 @@ Changes (Confidence Scoring Issue):
 
 from __future__ import annotations
 
+import uuid
 from enum import StrEnum
 from typing import Any, Literal
 
@@ -166,7 +167,7 @@ class TroubleshootRequest(BaseModel):
     target_os: str | None = None
     python_version: str | None = None
     cuda_version: str | None = None
-    session_id: str | None = None
+    session_id: uuid.UUID | None = None
     user_description: str = Field(default="", max_length=500)
     max_words: int = Field(default=500, ge=50, le=2000)
     repair_script_available: bool = False

--- a/backend/app/ai/service.py
+++ b/backend/app/ai/service.py
@@ -282,13 +282,13 @@ class AITroubleshootService:
     async def _fetch_session_history(
         self,
         db: AsyncSession,
-        session_id: str,
+        session_id: uuid.UUID,
     ) -> list[AISuggestion]:
         """Fetch previous AI suggestions for a given session ID."""
         try:
             stmt = (
                 select(AISuggestion)
-                .where(AISuggestion.session_id == uuid.UUID(session_id))
+                .where(AISuggestion.session_id == session_id)
                 .order_by(AISuggestion.step_number.asc())
             )
             result = await db.execute(stmt)

--- a/backend/tests/unit/ai/test_models.py
+++ b/backend/tests/unit/ai/test_models.py
@@ -1,5 +1,7 @@
 """Tests for AI Pydantic models."""
 
+import uuid
+
 import pytest
 from pydantic import ValidationError
 
@@ -30,6 +32,20 @@ class TestTroubleshootRequest:
         )
         assert req.profile_slug == "pytorch-cuda"
         assert req.cuda_version == "12.1"
+
+    def test_session_id_is_validated_as_uuid(self):
+        req = TroubleshootRequest(
+            diagnostic={"os": {"name": "Ubuntu"}},
+            session_id="550e8400-e29b-41d4-a716-446655440000",
+        )
+        assert req.session_id == uuid.UUID("550e8400-e29b-41d4-a716-446655440000")
+
+    def test_session_id_rejects_invalid_uuid(self):
+        with pytest.raises(ValidationError):
+            TroubleshootRequest(
+                diagnostic={"os": {"name": "Ubuntu"}},
+                session_id="invalid-uuid",
+            )
 
     def test_user_description_max_length(self):
         with pytest.raises(ValidationError):


### PR DESCRIPTION

Fixes Issue #556 by validating the "session_id" field at the API boundary.

Changes

- Changed "TroubleshootRequest.session_id" from "str | None" to "uuid.UUID | None".
- Removed redundant UUID conversion in "_fetch_session_history".
- Added tests to verify:
  - Valid UUIDs are accepted.
  - Invalid UUIDs are rejected with validation errors.

Why

Previously, malformed UUID strings could reach the service layer and trigger an unhandled exception, resulting in a 500 Internal Server Error. With this change, invalid UUIDs are rejected during request validation, resulting in proper API behavior.

Closes #556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Suggested troubleshooting fixes now include confidence scoring metrics (level, score, and uncertainty reasons) to help prioritize the most reliable solutions
  * Added fallback recommendations for low-confidence fixes to provide alternative guidance when primary suggestions lack certainty
  * Troubleshooting responses now display count of suppressed fixes for improved transparency into AI recommendations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->