### PR TITLE
fix: correct duplicate step number in README Steps To Run section

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ kubectl port-forward svc/envforage-frontend 3000:3000
 
 🚀 The API is now running at `http://localhost:8000`.
 
-### 3. Generate a Script
+### 4. Generate a Script
 Generate a PyTorch CUDA setup script for Linux:
 ```bash
 curl -X POST http://localhost:8000/api/v1/scripts/generate \


### PR DESCRIPTION
## Description
This PR corrects a typographical error in the `README.md` file where the "Steps To Run" section contained two consecutive "Step 3" headings.

## Related Issues
Closes #1013

## Changes Made
* Updated the duplicate `### 3. Generate a Script` heading to `### 4. Generate a Script` to maintain sequential order.

## Verification
I manually reviewed the markdown diff to confirm the numbering sequence is now correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated step numbering in the Getting Started guide to reflect the correct sequence of setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->