### PR TITLE
Reduce Ollama timeout to 30s and add timeout exception handling

### DIFF
--- a/backend/app/ai/providers/ollama.py
+++ b/backend/app/ai/providers/ollama.py
@@ -54,7 +54,7 @@ class OllamaProvider(LLMProvider):
         }
 
         try:
-            async with httpx.AsyncClient(timeout=120.0) as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
                 response = await client.post(self._generate_url, json=payload)
                 response.raise_for_status()
 
@@ -91,6 +91,12 @@ class OllamaProvider(LLMProvider):
                 f"Could not connect to Ollama at {self.base_url}. "
                 f"Ensure Ollama is running: ollama serve",
             )
+
+        except httpx.TimeoutException:
+            raise LLMProviderError(
+                 "ollama",
+                 "Ollama request timed out. The provider may be overloaded or unavailable."
+            )
         except httpx.HTTPStatusError as e:
             raise LLMProviderError(
                 "ollama",
@@ -120,8 +126,8 @@ class OllamaProvider(LLMProvider):
         }
 
         try:
-            async with httpx.AsyncClient(timeout=120.0) as client:
-                async with client.stream(
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0))as client:
+                async with client.stream
                     "POST", self._generate_url, json=payload
                 ) as response:
                     response.raise_for_status()
@@ -148,6 +154,12 @@ class OllamaProvider(LLMProvider):
                 "ollama",
                 f"Could not connect to Ollama at {self.base_url}. "
                 f"Ensure Ollama is running: ollama serve",
+            )
+
+        except httpx.TimeoutException:
+            raise LLMProviderError(
+                "ollama",
+                "Ollama streaming request timed out."
             )
         except httpx.HTTPStatusError as e:
             raise LLMProviderError(

--- a/backend/app/ai/providers/ollama.py
+++ b/backend/app/ai/providers/ollama.py
@@ -127,7 +127,7 @@ class OllamaProvider(LLMProvider):
 
         try:
             async with httpx.AsyncClient(timeout=httpx.Timeout(30.0))as client:
-                async with client.stream
+                async with client.stream(
                     "POST", self._generate_url, json=payload
                 ) as response:
                     response.raise_for_status()


### PR DESCRIPTION
1)Updated Ollama provider timeout from 120s to 30s. 2)Added Timeout Exception handling in complete() and stream() to raise LLM Provider Error instead of crashing.

## Description
<!-- Describe your changes in detail -->
<!-- What does this PR do? Why is it needed? -->

## Related Issues
<!-- Link to any related issues. Use "Fixes #123" or "Resolves #123" to auto-close the issue on merge. -->

## Changes Made
<!-- List the main changes made in this PR -->
- 
- 

## Verification
<!-- Describe how you verified that your changes work. -->
- [ ] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for request timeouts when communicating with the AI provider, with more descriptive timeout-specific error messages.

* **Performance**
  * Reduced timeout threshold from 120 to 30 seconds to enable faster detection of slow requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->