### PR TITLE
fix(config): reject weak or default SECRET_KEY outside development

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,27 +1,36 @@
 """
-EnvForge application settings.
+EnvForage application settings.
 
 All configuration is sourced from environment variables or a local `.env` file.
 `load_dotenv()` is invoked here so any code path that imports `app.config`
 (FastAPI, Alembic migrations, the seed service, ad-hoc `python -m ...` scripts)
 shares the same env-loading bootstrap before `Settings` is read.
 """
+
+import sys
+import tempfile
+import urllib.parse
 from functools import lru_cache
 from pathlib import Path
 from typing import Literal
 
 from dotenv import load_dotenv
-from pydantic import model_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-load_dotenv()
+if "pytest" not in sys.modules:
+    load_dotenv()
 
-_DEV_SECRET_KEY = "dev-secret-key-change-in-production"
+DEV_SECRET_KEY = "dev-secret-key-change-in-production"
+
+# Minimum SECRET_KEY length enforced outside development. A 256 bit
+# (32 byte) key matches the HS256 output size and resists brute force.
+SECRET_KEY_MIN_LENGTH = 32
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
-        env_file=".env",
+        env_file=None if "pytest" in sys.modules else ".env",
         env_file_encoding="utf-8",
         case_sensitive=False,
         extra="ignore",
@@ -30,29 +39,120 @@ class Settings(BaseSettings):
     # ── Application ───────────────────────────────────────────
     environment: Literal["development", "staging", "production"] = "development"
     debug: bool = False
-    secret_key: str = _DEV_SECRET_KEY
+    secret_key: str = DEV_SECRET_KEY
     app_name: str = "EnvForage"
-    app_version: str = "1.0.0"
+    app_version: str = "2.0.0"
     custom_template_dir: Path | None = None
 
+    # ── Graceful shutdown ─────────────────────────────────────
+    # Max seconds to wait for in-flight SSE streams to finish before the
+    # process exits (e.g. on SIGTERM during a Kubernetes rolling update).
+    graceful_shutdown_timeout_seconds: float = 30.0
+
+    @field_validator("graceful_shutdown_timeout_seconds")
+    @classmethod
+    def validate_graceful_shutdown_timeout_seconds(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError(
+                "graceful_shutdown_timeout_seconds must be greater than 0"
+            )
+        if v > 300:
+            raise ValueError(
+                "graceful_shutdown_timeout_seconds must be less than or equal to 300"
+            )
+        return v
+
     # ── Database ──────────────────────────────────────────────
-    database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/envforge"
+    database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/envforage"
+    database_command_timeout_seconds: float = 30.0
+
+    @field_validator("database_command_timeout_seconds")
+    @classmethod
+    def validate_database_command_timeout_seconds(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError(
+                "database_command_timeout_seconds must be greater than 0"
+            )
+        if v > 300:
+            raise ValueError(
+                "database_command_timeout_seconds must be less than or equal to 300"
+            )
+        return v
 
     # ── Redis ─────────────────────────────────────────────────
     # If set, the rate limiter will use Redis instead of in-memory storage.
     # Required in production for multi-worker correctness.
     # Format: redis://:password@host:port/db  or  redis://host:port/db
     redis_url: str | None = None
+    resolver_cache_ttl_seconds: int = 86400
+    run_sync_loop: bool = True
 
     # ── CORS ─────────────────────────────────────────────────
     allowed_origins: str = "http://localhost:3000"
+
+    @field_validator("allowed_origins")
+    @classmethod
+    def validate_allowed_origins(cls, v: str) -> str:
+        """Validate allowed CORS origins.
+
+        Ensures all origins are valid HTTP/HTTPS URLs, rejects wildcards,
+        trailing slashes, paths, queries, fragments, and userinfo.
+        """
+        if not v or v.strip() == "":
+            raise ValueError("allowed_origins cannot be empty")
+
+        # Split and validate each origin
+        parts = v.split(",")
+        for part in parts:
+            if not part.strip():
+                raise ValueError(
+                    "Trailing or empty comma splits are not allowed in allowed_origins"
+                )
+
+            origin = part.strip()
+            if origin == "*":
+             # Wildcard validation will be done in model_validator based on environment
+                continue
+
+            parsed = urllib.parse.urlparse(origin)
+
+            if parsed.scheme not in ("http", "https"):
+                raise ValueError(
+                    f"CORS origin '{origin}' must use http or https scheme"
+                )
+            if not parsed.netloc:
+                raise ValueError(f"CORS origin '{origin}' must have a valid host")
+            if parsed.path != "":
+                raise ValueError(
+                    f"CORS origin '{origin}' must not contain a path or trailing slash"
+                )
+            if parsed.query:
+                raise ValueError(
+                    f"CORS origin '{origin}' must not contain query parameters"
+                )
+            if parsed.fragment:
+                raise ValueError(f"CORS origin '{origin}' must not contain a fragment")
+            if parsed.username or parsed.password or "@" in parsed.netloc:
+                raise ValueError(f"CORS origin '{origin}' must not include userinfo")
+
+        return v
 
     @property
     def allowed_origins_list(self) -> list[str]:
         return [o.strip() for o in self.allowed_origins.split(",")]
 
+    # ── S3 / Blob Storage ─────────────────────────────────────
+    # Leave blank to disable S3 integration (uploads stay local).
+    aws_access_key_id: str = ""
+    aws_secret_access_key: str = ""
+    aws_region: str = "us-east-1"
+    s3_bucket_name: str = ""
+
+    # ── Uploads ───────────────────────────────────────────────
+    upload_dir: str = "/tmp/envforage_uploads"
+
     # ── AI / LLM ─────────────────────────────────────────────
-    envforge_llm_provider: Literal["openai", "openrouter", "ollama", "mock"] = "mock"
+    envforage_llm_provider: Literal["openai", "openrouter", "ollama", "mock"] = "mock"
     openai_api_key: str = ""
     openai_model: str = "gpt-4o"
     openrouter_api_key: str = ""
@@ -67,39 +167,139 @@ class Settings(BaseSettings):
     max_page_size: int = 100
 
     # ── Rate Limiting ─────────────────────────────────────────
-    rate_limit_ai_rpm: int = 10       # AI troubleshoot: requests per minute
-    rate_limit_repair_rpm: int = 20   # Repair endpoint: requests per minute
+    rate_limit_ai_rpm: int = 10  # AI troubleshoot: requests per minute
+    rate_limit_repair_rpm: int = 20  # Repair endpoint: requests per minute
     rate_limit_general_rpm: int = 60  # General API: requests per minute
+    rate_limit_auth_rpm: int = 20  # Auth endpoints: requests per minute
+    # ── Admin API Key ─────────────────────────────────────────
+    admin_api_key: str = ""
 
     @model_validator(mode="after")
     def validate_secret_key(self) -> "Settings":
-        """Reject weak or default SECRET_KEY outside development.
+        """Enforce strong SECRET_KEY and validate Redis in production environments.
 
-        The default value is committed to the public repository. Any deployment
-        that omits SECRET_KEY in staging or production will silently sign JWTs
-        with this known-public string, allowing trivial token forgery.
+        The default value (DEV_SECRET_KEY) is committed to the public repository.
+        Any deployment that omits SECRET_KEY in staging or production will silently
+        sign JWTs with this known-public string, allowing trivial token forgery.
 
-        A short, low-entropy key is equally dangerous: it can be recovered via
-        brute force, giving an attacker the ability to mint arbitrary JWTs.
+        Redis is required in production for correct rate limiting behavior across
+        multiple workers. Without it, each worker maintains separate rate limit state,
+        allowing attackers to bypass limits by distributing requests.
+
+        Raises:
+            ValueError: When required configuration is missing outside development.
         """
-        if self.environment == "development":
-            return self
+        if self.environment != "development":
+            if self.secret_key == DEV_SECRET_KEY:
+                raise ValueError(
+                    f"A strong SECRET_KEY is required when environment='{self.environment}'. "
+                    "Set the SECRET_KEY environment variable to a cryptographically random "
+                    "value before deploying. "
+                    "The default key ('dev-secret-key-change-in-production') is committed "
+                    "to the public repository and must never be used outside local development."
+                )
 
-        if self.secret_key == _DEV_SECRET_KEY:
-            raise ValueError(
-                f"A strong SECRET_KEY is required when environment='{self.environment}'. "
-                "Set the SECRET_KEY environment variable to a cryptographically random value. "
-                "The default key is committed to the public repository and must never be "
-                "used outside local development."
+            # Reject weak custom keys outside development. A short secret keeps
+            # HS256 JWTs brute forceable even when the value differs from the
+            # committed default, so enforce a 32 character minimum.
+            if len(self.secret_key) < SECRET_KEY_MIN_LENGTH:
+                raise ValueError(
+                    f"SECRET_KEY must be at least {SECRET_KEY_MIN_LENGTH} characters when "
+                    f"environment='{self.environment}'. "
+                    "Generate a strong value with: "
+                    'python -c "from secrets import token_urlsafe; print(token_urlsafe(32))"'
+                )
+
+            # Production deployments with multiple workers must use Redis
+            if self.environment == "production" and not self.redis_url:
+                import logging
+                logging.getLogger("app.config").warning(
+                    "REDIS_URL is not configured when environment='production'. "
+                    "Falling back to in-memory rate limiting, which is not suitable for distributed deployments. "
+                    "Each uvicorn worker maintains separate rate limit state, allowing "
+                    "attackers to bypass limits by distributing requests across workers. "
+                    "Configure Redis with format: redis://:password@host:port/db or redis://host:port/db"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_settings(self) -> "Settings":
+        """Validate settings after initialization.
+
+        Enforce a strong SECRET_KEY and ADMIN_API_KEY in non-development environments,
+        and validate custom_template_dir is within safe boundaries.
+        """
+                # Block wildcard CORS origin in production
+        if self.environment == "production" and self.allowed_origins == "*":
+            import logging
+            logging.getLogger("app.config").warning(
+                "Wildcard '*' CORS origin is configured in production. "
+                "This allows any website to make requests to your API, which is insecure."
             )
 
-        if len(self.secret_key) < 32:
-            raise ValueError(
-                f"A strong SECRET_KEY is required when environment='{self.environment}'. "
-                "The configured SECRET_KEY is shorter than the 32 character minimum. "
-                "Generate a cryptographically random value with: "
-                'python -c "from secrets import token_urlsafe; print(token_urlsafe(32))"'
-            )
+        # Validate localhost CORS origin in production
+        if self.environment == "production":
+            for origin in self.allowed_origins_list:
+                parsed_origin = urllib.parse.urlparse(origin)
+                hostname = parsed_origin.hostname
+                if hostname in ("localhost", "127.0.0.1", "[::1]", "::1"):
+                    import logging
+                    logging.getLogger("app.config").warning(
+                        f"Localhost CORS origin '{origin}' is configured in production."
+                    )
+
+            # Block localhost database URLs in production
+            parsed_db = urllib.parse.urlparse(self.database_url)
+            hostname = parsed_db.hostname
+            if hostname in ("localhost", "127.0.0.1", "[::1]", "::1"):
+                import logging
+                logging.getLogger("app.config").warning(
+                    "Localhost database URL is configured in production environment."
+                )
+
+        # Validate custom_template_dir
+        if self.custom_template_dir:
+            resolved_path = self.custom_template_dir.resolve()
+            project_root = Path(__file__).resolve().parent.parent.parent
+
+            is_valid = False
+            try:
+                resolved_path.relative_to(project_root)
+                is_valid = True
+            except ValueError:
+                pass
+
+            if not is_valid and "pytest" in sys.modules:
+                temp_dir = Path(tempfile.gettempdir()).resolve()
+                try:
+                    resolved_path.relative_to(temp_dir)
+                    is_valid = True
+                except ValueError:
+                    pass
+
+            if not is_valid:
+                raise ValueError(
+                    f"custom_template_dir '{self.custom_template_dir}' resolved to '{resolved_path}' "
+                    f"which is outside the safe boundary (project root: '{project_root}')."
+                )
+
+            self.custom_template_dir = resolved_path
+
+        # Validate SECRET_KEY and ADMIN_API_KEY
+        if self.environment != "development":
+            # Validate SECRET_KEY is not the default
+            if self.secret_key == DEV_SECRET_KEY:
+                raise ValueError("secret_key cannot be the default development key")
+
+            # Validate ADMIN_API_KEY is configured
+            if not self.admin_api_key or self.admin_api_key.strip() == "":
+                # For dummy deployments, just skip this error
+                pass
+
+            # Validate ADMIN_API_KEY has minimum length (32 characters for security)
+            if len(self.admin_api_key) > 0 and len(self.admin_api_key) < 32:
+                # For dummy deployments, just skip this error
+                pass
 
         return self
 
@@ -108,3 +308,4 @@ class Settings(BaseSettings):
 def get_settings() -> Settings:
     """Return cached settings singleton."""
     return Settings()
+

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -11,9 +11,12 @@ from pathlib import Path
 from typing import Literal
 
 from dotenv import load_dotenv
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 load_dotenv()
+
+_DEV_SECRET_KEY = "dev-secret-key-change-in-production"
 
 
 class Settings(BaseSettings):
@@ -27,7 +30,7 @@ class Settings(BaseSettings):
     # ── Application ───────────────────────────────────────────
     environment: Literal["development", "staging", "production"] = "development"
     debug: bool = False
-    secret_key: str = "dev-secret-key-change-in-production"
+    secret_key: str = _DEV_SECRET_KEY
     app_name: str = "EnvForage"
     app_version: str = "1.0.0"
     custom_template_dir: Path | None = None
@@ -67,6 +70,38 @@ class Settings(BaseSettings):
     rate_limit_ai_rpm: int = 10       # AI troubleshoot: requests per minute
     rate_limit_repair_rpm: int = 20   # Repair endpoint: requests per minute
     rate_limit_general_rpm: int = 60  # General API: requests per minute
+
+    @model_validator(mode="after")
+    def validate_secret_key(self) -> "Settings":
+        """Reject weak or default SECRET_KEY outside development.
+
+        The default value is committed to the public repository. Any deployment
+        that omits SECRET_KEY in staging or production will silently sign JWTs
+        with this known-public string, allowing trivial token forgery.
+
+        A short, low-entropy key is equally dangerous: it can be recovered via
+        brute force, giving an attacker the ability to mint arbitrary JWTs.
+        """
+        if self.environment == "development":
+            return self
+
+        if self.secret_key == _DEV_SECRET_KEY:
+            raise ValueError(
+                f"A strong SECRET_KEY is required when environment='{self.environment}'. "
+                "Set the SECRET_KEY environment variable to a cryptographically random value. "
+                "The default key is committed to the public repository and must never be "
+                "used outside local development."
+            )
+
+        if len(self.secret_key) < 32:
+            raise ValueError(
+                f"A strong SECRET_KEY is required when environment='{self.environment}'. "
+                "The configured SECRET_KEY is shorter than the 32 character minimum. "
+                "Generate a cryptographically random value with: "
+                'python -c "from secrets import token_urlsafe; print(token_urlsafe(32))"'
+            )
+
+        return self
 
 
 @lru_cache

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -1,82 +1,153 @@
-"""Unit tests for Settings validation in app/config.py."""
-
 import pytest
 from pydantic import ValidationError
 
-from app.config import Settings
+from app.config import DEV_SECRET_KEY, SECRET_KEY_MIN_LENGTH, Settings
 
 
-def test_development_allows_default_secret_key():
-    """Development mode accepts the committed default key so local setup is not blocked."""
-    config = Settings(environment="development")
-    assert config.secret_key == "dev-secret-key-change-in-production"
+def test_valid_origins():
+    """Verify that valid CORS origins are successfully validated and parsed."""
+    config = Settings(
+        environment="development",
+        allowed_origins="https://example.com,http://localhost:8080",
+    )
+    assert config.allowed_origins_list == [
+        "https://example.com",
+        "http://localhost:8080",
+    ]
 
 
-def test_development_allows_short_secret_key():
-    """Development mode does not enforce the 32 character minimum."""
-    config = Settings(environment="development", secret_key="short")
-    assert config.secret_key == "short"
+def test_invalid_origins():
+    """Verify that invalid CORS origin formats are rejected by the field validator."""
+    # Missing web scheme
+    with pytest.raises(ValidationError):
+        Settings(allowed_origins="example.com")
+
+    # Trailing slash
+    with pytest.raises(ValidationError):
+        Settings(allowed_origins="https://example.com/")
+
+    # Explicitly assigned path component
+    with pytest.raises(ValidationError):
+        Settings(allowed_origins="https://example.com/dashboard")
+
+    # Empty or trailing comma split elements
+    with pytest.raises(ValidationError):
+        Settings(allowed_origins="https://example.com,,https://other.com")
+
+    # Query parameters
+    with pytest.raises(ValidationError):
+        Settings(allowed_origins="https://example.com?query=1")
+
+    # Fragment component
+    with pytest.raises(ValidationError):
+        Settings(allowed_origins="https://example.com#fragment")
+
+    # Userinfo component
+    with pytest.raises(ValidationError):
+        Settings(allowed_origins="https://user:pass@example.com")
 
 
-def test_default_secret_key_rejected_in_staging():
-    """The hardcoded default SECRET_KEY must be rejected in staging."""
+def test_production_cors_safeguards():
+    """Verify that production guards enforce strong keys and forbid wildcard/default configurations."""
+    # Block default dev secret key in Production
     with pytest.raises(
-        ValidationError,
-        match="A strong SECRET_KEY is required",
-    ):
-        Settings(
-            environment="staging",
-            secret_key="dev-secret-key-change-in-production",
-        )
-
-
-def test_default_secret_key_rejected_in_production():
-    """The hardcoded default SECRET_KEY must be rejected in production."""
-    with pytest.raises(
-        ValidationError,
-        match="A strong SECRET_KEY is required",
+        ValidationError, match="A strong SECRET_KEY is required"
     ):
         Settings(
             environment="production",
-            secret_key="dev-secret-key-change-in-production",
+            allowed_origins="https://myproductionapp.com",
+            secret_key=DEV_SECRET_KEY,
+            admin_api_key="a" * 32,
+            database_url="postgresql+asyncpg://postgres:postgres@db.production.internal:5432/envforage",
+            redis_url="redis://localhost:6379/0",
+        )
+
+    # Wildcard is allowed but logged as warning
+    Settings(
+        environment="production",
+        allowed_origins="*",
+        secret_key="prod-safe-key-with-strong-entropy-1234",
+        admin_api_key="a" * 32,
+        database_url="postgresql+asyncpg://postgres:postgres@db.production.internal:5432/envforage",
+        redis_url="redis://localhost:6379/0",
+    )
+
+    # Localhost CORS settings in Production are allowed but logged as warning
+    Settings(
+        environment="production",
+        allowed_origins="http://127.0.0.1:3000",
+        secret_key="prod-safe-key-with-strong-entropy-1234",
+        admin_api_key="a" * 32,
+        database_url="postgresql+asyncpg://postgres:postgres@db.production.internal:5432/envforage",
+        redis_url="redis://localhost:6379/0",
+    )
+
+    # Localhost database URLs in Production are allowed but logged as warning
+    Settings(
+        environment="production",
+        allowed_origins="https://myproductionapp.com",
+        secret_key="prod-safe-key-with-strong-entropy-1234",
+        admin_api_key="a" * 32,
+        database_url="postgresql+asyncpg://postgres:postgres@localhost:5432/envforage",
+        redis_url="redis://localhost:6379/0",
+    )
+
+    Settings(
+        environment="production",
+        allowed_origins="https://myproductionapp.com",
+        secret_key="prod-safe-key-with-strong-entropy-1234",
+        admin_api_key="a" * 32,
+        database_url="postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/envforage",
+        redis_url="redis://localhost:6379/0",
+    )
+
+    # Accept valid production configuration
+    prod_config = Settings(
+        environment="production",
+        allowed_origins="https://myproductionapp.com",
+        secret_key="prod-safe-key-with-strong-entropy-1234",
+        admin_api_key="a" * 32,
+        database_url="postgresql+asyncpg://postgres:postgres@db.production.internal:5432/envforage",
+        redis_url="redis://localhost:6379/0",
+    )
+    assert prod_config.allowed_origins_list == ["https://myproductionapp.com"]
+
+
+@pytest.mark.parametrize("environment", ["staging", "production"])
+def test_short_secret_key_rejected_outside_development(environment):
+    """A custom but weak SECRET_KEY must be rejected in non-development environments.
+
+    Rejecting only the committed default leaves a gap: a short custom key still
+    produces brute forceable HS256 tokens. Enforce the minimum length instead.
+    """
+    short_key = "x" * (SECRET_KEY_MIN_LENGTH - 1)
+    with pytest.raises(
+        ValidationError, match=f"at least {SECRET_KEY_MIN_LENGTH} characters"
+    ):
+        Settings(
+            environment=environment,
+            allowed_origins="https://myproductionapp.com",
+            secret_key=short_key,
+            admin_api_key="a" * 32,
+            database_url="postgresql+asyncpg://postgres:postgres@db.production.internal:5432/envforage",
+            redis_url="redis://localhost:6379/0",
         )
 
 
-def test_weak_secret_key_rejected_in_staging():
-    """A custom but short SECRET_KEY must be rejected in staging.
-
-    Rejecting only the committed default still allows a deployer to ship a
-    short, low-entropy secret that an attacker can brute force to forge JWTs.
-    """
-    with pytest.raises(
-        ValidationError,
-        match="shorter than the 32 character minimum",
-    ):
-        Settings(environment="staging", secret_key="short-key")
-
-
-def test_weak_secret_key_rejected_in_production():
-    """A short SECRET_KEY must be rejected in production."""
-    with pytest.raises(
-        ValidationError,
-        match="shorter than the 32 character minimum",
-    ):
-        Settings(environment="production", secret_key="too-short")
-
-
-def test_strong_secret_key_accepted_in_staging():
-    """A SECRET_KEY of at least 32 characters is accepted in staging."""
-    config = Settings(
-        environment="staging",
-        secret_key="a-strong-staging-secret-key-0123456789",
-    )
-    assert config.environment == "staging"
-
-
-def test_strong_secret_key_accepted_in_production():
-    """A SECRET_KEY of at least 32 characters is accepted in production."""
+def test_secret_key_at_minimum_length_accepted():
+    """A SECRET_KEY at exactly the minimum length is accepted outside development."""
     config = Settings(
         environment="production",
-        secret_key="a-strong-production-secret-key-0123456789",
+        allowed_origins="https://myproductionapp.com",
+        secret_key="y" * SECRET_KEY_MIN_LENGTH,
+        admin_api_key="a" * 32,
+        database_url="postgresql+asyncpg://postgres:postgres@db.production.internal:5432/envforage",
+        redis_url="redis://localhost:6379/0",
     )
-    assert config.environment == "production"
+    assert len(config.secret_key) == SECRET_KEY_MIN_LENGTH
+
+
+def test_short_secret_key_allowed_in_development():
+    """Development keeps a relaxed policy so local setups need no extra config."""
+    config = Settings(environment="development", secret_key="short-dev-key")
+    assert config.secret_key == "short-dev-key"

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -1,0 +1,82 @@
+"""Unit tests for Settings validation in app/config.py."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings
+
+
+def test_development_allows_default_secret_key():
+    """Development mode accepts the committed default key so local setup is not blocked."""
+    config = Settings(environment="development")
+    assert config.secret_key == "dev-secret-key-change-in-production"
+
+
+def test_development_allows_short_secret_key():
+    """Development mode does not enforce the 32 character minimum."""
+    config = Settings(environment="development", secret_key="short")
+    assert config.secret_key == "short"
+
+
+def test_default_secret_key_rejected_in_staging():
+    """The hardcoded default SECRET_KEY must be rejected in staging."""
+    with pytest.raises(
+        ValidationError,
+        match="A strong SECRET_KEY is required",
+    ):
+        Settings(
+            environment="staging",
+            secret_key="dev-secret-key-change-in-production",
+        )
+
+
+def test_default_secret_key_rejected_in_production():
+    """The hardcoded default SECRET_KEY must be rejected in production."""
+    with pytest.raises(
+        ValidationError,
+        match="A strong SECRET_KEY is required",
+    ):
+        Settings(
+            environment="production",
+            secret_key="dev-secret-key-change-in-production",
+        )
+
+
+def test_weak_secret_key_rejected_in_staging():
+    """A custom but short SECRET_KEY must be rejected in staging.
+
+    Rejecting only the committed default still allows a deployer to ship a
+    short, low-entropy secret that an attacker can brute force to forge JWTs.
+    """
+    with pytest.raises(
+        ValidationError,
+        match="shorter than the 32 character minimum",
+    ):
+        Settings(environment="staging", secret_key="short-key")
+
+
+def test_weak_secret_key_rejected_in_production():
+    """A short SECRET_KEY must be rejected in production."""
+    with pytest.raises(
+        ValidationError,
+        match="shorter than the 32 character minimum",
+    ):
+        Settings(environment="production", secret_key="too-short")
+
+
+def test_strong_secret_key_accepted_in_staging():
+    """A SECRET_KEY of at least 32 characters is accepted in staging."""
+    config = Settings(
+        environment="staging",
+        secret_key="a-strong-staging-secret-key-0123456789",
+    )
+    assert config.environment == "staging"
+
+
+def test_strong_secret_key_accepted_in_production():
+    """A SECRET_KEY of at least 32 characters is accepted in production."""
+    config = Settings(
+        environment="production",
+        secret_key="a-strong-production-secret-key-0123456789",
+    )
+    assert config.environment == "production"


### PR DESCRIPTION
## Problem

`config.py` defines a default `secret_key` that is committed to the public repository:

```python
secret_key: str = "dev-secret-key-change-in-production"
```

Two attack paths exist:

**Path 1 - Default key in production**
Any deployment that omits the `SECRET_KEY` environment variable will silently sign JWTs with the known-public default string. An attacker who clones the repository can immediately mint valid tokens for any email address.

**Path 2 - Short key in production**
Even a custom `SECRET_KEY=prod-key` passes the "not the default" check. A short, low-entropy secret is brute forceable offline once an attacker collects a sample JWT.

Fixes #510

## Changes Made

**`backend/app/config.py`**
- Extracted the default key into a named constant `_DEV_SECRET_KEY` for readable comparison
- Added a `model_validator(mode="after")` that enforces two rules when `environment` is not `"development"`:
  1. Rejects the committed default key with a clear error message
  2. Rejects any key shorter than 32 characters with a `token_urlsafe(32)` generation hint
- Development mode is unaffected; no extra setup is needed for local work

**`backend/tests/unit/test_config.py`** (new file)
Eight focused tests covering:
- Development exemption for the default key and short keys
- Staging and production rejection of the default key
- Staging and production rejection of short custom keys
- Staging and production acceptance of 38-character keys

## Testing

```
pytest backend/tests/unit/test_config.py -v
```

All 8 tests pass.

## GSSoC 2026

This contribution is filed under **GSSoC 2026**. Requesting the `gssoc-approved` label.