### PR TITLE
feat(docker): add Redis container to local Docker Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,11 @@ SECRET_KEY=dev-secret-key-change-in-production
 # For local postgres: postgresql+asyncpg://postgres:postgres@localhost:5432/envforage
 DATABASE_URL=sqlite+aiosqlite:///local.db
 
-# ── Redis (optional locally, required in production) ──────────
+# ── Redis ──────────────────────────────────────────────────────
 # Format: redis://[:password@]host:port[/db]
-# REDIS_URL=redis://localhost:6379/0
+# For local Docker: redis://:devredis123@redis:6379/0
+# For local non-Docker: REDIS_URL=redis://localhost:6379/0
+REDIS_URL=redis://:devredis123@localhost:6379/0
 
 # ── CORS ─────────────────────────────────────────────────────
 ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -35,7 +35,7 @@ services:
     volumes:
       - redisdata:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD-SHELL", "REDISCLI_AUTH=${REDIS_PASSWORD:-devredis123} redis-cli ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -56,6 +56,76 @@ services:
         condition: service_healthy
     volumes:
       - pgadmindata:/var/lib/pgadmin
+    networks:
+      - envforage-network
+
+  migrate:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: envforage-migrate-local
+    restart: "no"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-envforage_admin}:${POSTGRES_PASSWORD:-devpassword123}@db:5432/${POSTGRES_DB:-envforage_dev}
+      REDIS_URL: redis://:${REDIS_PASSWORD:-devredis123}@redis:6379/0
+      ENVIRONMENT: development
+      DEBUG: "true"
+      SECRET_KEY: dev-secret-key-change-in-production
+    command: alembic upgrade head
+
+  api:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: envforage-api-local
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    ports:
+      - "8000:8000"
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-envforage_admin}:${POSTGRES_PASSWORD:-devpassword123}@db:5432/${POSTGRES_DB:-envforage_dev}
+      REDIS_URL: redis://:${REDIS_PASSWORD:-devredis123}@redis:6379/0
+      ENVIRONMENT: development
+      DEBUG: "true"
+      SECRET_KEY: dev-secret-key-change-in-production
+      ALLOWED_ORIGINS: http://localhost:3000,http://127.0.0.1:3000
+      ENVFORAGE_LLM_PROVIDER: mock
+    volumes:
+      - ./backend:/app
+    command: >
+      sh -c "
+        python -m app.services.seed_service &&
+        uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+      "
+    networks:
+      - envforage-network
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        - NEXT_PUBLIC_API_URL=http://localhost:8000/api/v1
+        - BACKEND_API_URL=http://api:8000
+    container_name: envforage-frontend-local
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - PORT=3000
+    depends_on:
+      - api
     networks:
       - envforage-network
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -77,6 +77,8 @@ services:
       DEBUG: "true"
       SECRET_KEY: dev-secret-key-change-in-production
     command: alembic upgrade head
+    networks:
+      - envforage-network
 
   api:
     build:


### PR DESCRIPTION
Closes #1070

## Description
Adds a complete Redis-backed local Docker Compose stack so that local development mirrors production caching behavior. Previously, `docker-compose.local.yml` only contained infrastructure services (PostgreSQL, Redis, pgAdmin) but lacked the application services that actually consume Redis — meaning local dev fell back to in-memory caching.

## Related Issues
- Fixes #1070

## Changes Made
- **Fixed Redis healthcheck** — Added `REDISCLI_AUTH` authentication so healthcheck passes with `--requirepass` enabled (previously always failed with `NOAUTH`)
- **Added `migrate` service** — One-shot Alembic migration container (matches prod pattern) to prevent race conditions when multiple API workers start
- **Added `api` service** — Backend API with `REDIS_URL` configured to connect to local Redis, depends on db/redis/migrate health, includes hot-reload via source mount
- **Added `frontend` service** — Next.js frontend connected to API
- **Updated `.env.example`** — Uncommented `REDIS_URL` with Docker and non-Docker examples

## Verification
- [x] YAML syntax validated via `yamllint` (no errors)
- [x] Tested via `docker compose -f docker-compose.local.yml up`
- [x] Verified Redis connection from API container (`curl localhost:8000/api/v1/health`)
- [x] Confirmed Redis healthcheck passes with authentication

## Documentation
- [x] Updated `.env.example` with `REDIS_URL` documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer local environment setup guidance, including a ready-to-use Redis connection example.
  * Expanded the local development stack to start the database, backend, and frontend together more reliably.

* **Bug Fixes**
  * Improved Redis health checks so local services wait for authentication to be available before starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->