### PR TITLE
Add issue and PR stale github action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+name: Close Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs everyday at midnight UTC
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v11
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed in 7 days if no further activity occurs.'
+          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed in 14 days if no further activity occurs.'
+          
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          
+          days-before-issue-stale: 30
+          days-before-issue-close: 7
+          
+          days-before-pr-stale: 45       
+          days-before-pr-close: 14

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v11
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed in 7 days if no further activity occurs.'


### PR DESCRIPTION
## Description
This PR introduces an automated stale issue and PR management workflow using the official GitHub Stale Action. 

## Related Issues
Resolves #1071

## Changes Made
- Created a new GitHub Actions workflow configuration file at `.github/workflows/stale.yml`.
- Configured a daily cron schedule to scan for inactive items.
- Implemented specific lifecycle rules based on maintainer guidance:
  - **Issues**: Marked stale after 30 days of inactivity, automatically closed after an additional 7 days of no response.
  - **Pull Requests**: Marked stale after 45 days of inactivity, automatically closed after an additional 14 days of no response.

## Verification
- [ ] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [x] Manually tested via the API / CLI (Verified YAML syntax against the documentation)
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted (Inline comment added to explain the cron schedule)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated daily workflow to mark inactive issues and pull requests as stale and close them after a set period of inactivity.
  * Updated the repository’s maintenance automation with custom stale messaging and automatic follow-up actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->