### PR TITLE
feat(helm): implement NetworkPolicies to restrict lateral pod movement

### DIFF
--- a/helm/envforage/templates/networkpolicy.yaml
+++ b/helm/envforage/templates/networkpolicy.yaml
@@ -14,6 +14,17 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  name: {{ include "envforage.fullname" . }}-default-deny-egress
+  labels:
+    app: {{ include "envforage.fullname" . }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
   name: {{ include "envforage.fullname" . }}-frontend
   labels:
     app: {{ include "envforage.fullname" . }}-frontend
@@ -36,7 +47,11 @@ spec:
       ports:
         - port: 8000
           protocol: TCP
-    - ports:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.dnsNamespace }}
+      ports:
         - port: 53
           protocol: UDP
         - port: 53
@@ -85,7 +100,11 @@ spec:
       ports:
         - port: 11434
           protocol: TCP
-    - ports:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.dnsNamespace }}
+      ports:
         - port: 53
           protocol: UDP
         - port: 53
@@ -113,7 +132,11 @@ spec:
         - port: 5432
           protocol: TCP
   egress:
-    - ports:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.dnsNamespace }}
+      ports:
         - port: 53
           protocol: UDP
         - port: 53
@@ -141,7 +164,11 @@ spec:
         - port: 6379
           protocol: TCP
   egress:
-    - ports:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.dnsNamespace }}
+      ports:
         - port: 53
           protocol: UDP
         - port: 53
@@ -169,7 +196,11 @@ spec:
         - port: 11434
           protocol: TCP
   egress:
-    - ports:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.dnsNamespace }}
+      ports:
         - port: 53
           protocol: UDP
         - port: 53

--- a/helm/envforage/templates/networkpolicy.yaml
+++ b/helm/envforage/templates/networkpolicy.yaml
@@ -1,0 +1,177 @@
+{{- if .Values.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "envforage.fullname" . }}-default-deny-ingress
+  labels:
+    app: {{ include "envforage.fullname" . }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "envforage.fullname" . }}-frontend
+  labels:
+    app: {{ include "envforage.fullname" . }}-frontend
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "envforage.fullname" . }}-frontend
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: 3000
+          protocol: TCP
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: {{ include "envforage.fullname" . }}-backend
+      ports:
+        - port: 8000
+          protocol: TCP
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "envforage.fullname" . }}-backend
+  labels:
+    app: {{ include "envforage.fullname" . }}-backend
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "envforage.fullname" . }}-backend
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: {{ include "envforage.fullname" . }}-frontend
+      ports:
+        - port: 8000
+          protocol: TCP
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: {{ include "envforage.fullname" . }}-postgres
+      ports:
+        - port: 5432
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: {{ include "envforage.fullname" . }}-redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: {{ include "envforage.fullname" . }}-ollama
+      ports:
+        - port: 11434
+          protocol: TCP
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "envforage.fullname" . }}-postgres
+  labels:
+    app: {{ include "envforage.fullname" . }}-postgres
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "envforage.fullname" . }}-postgres
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: {{ include "envforage.fullname" . }}-backend
+      ports:
+        - port: 5432
+          protocol: TCP
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "envforage.fullname" . }}-redis
+  labels:
+    app: {{ include "envforage.fullname" . }}-redis
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "envforage.fullname" . }}-redis
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: {{ include "envforage.fullname" . }}-backend
+      ports:
+        - port: 6379
+          protocol: TCP
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "envforage.fullname" . }}-ollama
+  labels:
+    app: {{ include "envforage.fullname" . }}-ollama
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "envforage.fullname" . }}-ollama
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: {{ include "envforage.fullname" . }}-backend
+      ports:
+        - port: 11434
+          protocol: TCP
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+{{- end }}

--- a/helm/envforage/values.yaml
+++ b/helm/envforage/values.yaml
@@ -50,3 +50,4 @@ frontend:
 
 networkPolicy:
   enabled: true
+  dnsNamespace: kube-system

--- a/helm/envforage/values.yaml
+++ b/helm/envforage/values.yaml
@@ -47,3 +47,6 @@ frontend:
   tag: latest
   pullPolicy: IfNotPresent
   apiUrl: "/api/v1"
+
+networkPolicy:
+  enabled: true


### PR DESCRIPTION
Closes #1069

## Description
Implement Kubernetes NetworkPolicies in the Helm chart to restrict lateral movement between pods. This adds proper network segmentation so each service only communicates with its authorized dependencies, reducing the attack surface if any single pod is compromised.

## Related Issues
- Closes #1069

## Changes Made
- Added `networkPolicy.enabled: true` toggle in `helm/envforage/values.yaml`
- Created `helm/envforage/templates/networkpolicy.yaml` with 6 NetworkPolicies:
  - Default deny ingress (namespace-wide)
  - Frontend: ingress from any on port 3000, egress to backend + DNS
  - Backend: ingress from frontend only, egress to postgres/redis/ollama + DNS
  - PostgreSQL: ingress from backend only on port 5432, egress to DNS
  - Redis: ingress from backend only on port 6379, egress to DNS
  - Ollama: ingress from backend only on port 11434, egress to DNS

## Verification
- [x] Ran `helm template` to verify YAML renders correctly
- [x] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

## Documentation
- [x] Updated `CHANGELOG.md`
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [x] Code is fully documented and type-hinted

## Screenshots (if applicable)
N/A - Infrastructure/helm chart change only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Kubernetes network policies to improve service isolation and control pod traffic.
  * By default, network policies are enabled for the deployment configuration.
  * Traffic is now restricted so only the expected app-to-app and DNS connections are allowed between frontend, backend, database, cache, and AI service components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->