### PR TITLE
feat: implement dark mode toggle (#1058)

### DIFF
--- a/frontend/src/app/components/Navbar.tsx
+++ b/frontend/src/app/components/Navbar.tsx
@@ -6,8 +6,8 @@ import { usePathname } from "next/navigation";
 
 import { Menu, X } from "lucide-react";
 import packageJson from "../../../package.json";
-import { ThemeToggle } from "../providers";
-
+import { ThemeToggle } from "../../components/ThemeToggle";  
+ 
 export default function Navbar() {
 	const pathname = usePathname();
 	const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { createContext, useContext, useEffect, useState } from "react";
-import { Moon, Sun } from "lucide-react";
 
 // Create a context to share theme state across components
 const ThemeContext = createContext<{
@@ -16,11 +15,10 @@ export function useTheme() {
 		throw new Error("useTheme must be used within ThemeProvider");
 	}
 	return context;
-}
-
+} 
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-	const [theme, setTheme] = useState<"dark" | "light" | "system">("light");
+	const [theme, setTheme] = useState<"dark" | "light" | "system">("light");   
 	const [mounted, setMounted] = useState(false);
 
 	const applyTheme = (newTheme: "dark" | "light" | "system") => {
@@ -59,10 +57,10 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 	}, []);
 
 	const toggleTheme = () => {
-		const newTheme = theme === "dark" ? "light" : "dark";
-		setTheme(newTheme);
+	const newTheme = theme === "dark" ? "light" : theme === "light" ? "system" : "dark"; 
+		setTheme(newTheme); 
 		localStorage.setItem("theme", newTheme);
-		applyTheme(newTheme);
+		applyTheme(newTheme); 
 	};
 
 	return (
@@ -71,27 +69,6 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 		</ThemeContext.Provider>
 	);
 }
-
-export function ThemeToggle() {
-	const { theme, toggleTheme, mounted } = useTheme();
-
-	// Prevent hydration mismatch by not rendering until mounted
-	if (!mounted) {
-		return null;
-	}
-
-	return (
-		<button
-			onClick={toggleTheme}
-			className="theme-toggle-navbar"
-			title={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
-			aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
-		>
-			{theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
-		</button>
-	);
-}
-
 
 // --- Advanced System Preference Media Listener ---
 export function useSystemThemePreference() {

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react"; 
+import { useTheme } from "../app/providers"; 
+
+export function ThemeToggle() {
+	const { theme, toggleTheme, mounted } = useTheme();
+
+	// Prevent hydration mismatch by not rendering until mounted
+	if (!mounted) {
+		return null;
+	}
+
+	return (
+		<button
+			onClick={toggleTheme}
+			className="theme-toggle-navbar"
+			title={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+			aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+		>
+			{theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
+		</button>
+	);
+}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Moon, Sun } from "lucide-react"; 
+import { Moon, Sun, Monitor } from "lucide-react"; 
 import { useTheme } from "../app/providers"; 
 
 export function ThemeToggle() {
@@ -11,14 +11,23 @@ export function ThemeToggle() {
 		return null;
 	}
 
+	const nextTheme =
+		theme === "dark" ? "light" : theme === "light" ? "system" : "dark";
+
 	return (
 		<button
 			onClick={toggleTheme}
 			className="theme-toggle-navbar"
-			title={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
-			aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+			title={`Switch to ${nextTheme} mode`}
+			aria-label={`Switch to ${nextTheme} mode`}
 		>
-			{theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
+			{theme === "dark" ? (
+				<Sun size={18} />
+			) : theme === "light" ? (
+				<Moon size={18} />
+			) : (
+				<Monitor size={18} />
+			)}
 		</button>
 	);
-}
+} 


### PR DESCRIPTION
Closes #1058

## Changes
- Created `frontend/src/components/ThemeToggle.tsx` as standalone component
- Removed `ThemeToggle` from `providers.tsx` and cleaned up unused imports
- Updated `Navbar.tsx` import to use new component
- Extended `toggleTheme()` to cycle `dark ->light -> system -> dark`

## Testing
- Toggle works.
- Theme persists on page refresh via localStorage.
- No hydration mismatch (mounted check in place).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated theme toggle to the app navigation.
  * Theme switching now cycles through three modes: dark, light, and system.
  * Theme choice is saved so it persists across refreshes and future visits.

* **Bug Fixes**
  * Improved initial theme rendering to reduce flicker and hydration mismatches during page load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->