### PR TITLE
fix(config): enforce ADMIN_API_KEY validation outside development

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -293,13 +293,20 @@ class Settings(BaseSettings):
 
             # Validate ADMIN_API_KEY is configured
             if not self.admin_api_key or self.admin_api_key.strip() == "":
-                # For dummy deployments, just skip this error
-                pass
+                raise ValueError(
+                    f"ADMIN_API_KEY is required when environment='{self.environment}'. "
+                    "The admin API endpoints would otherwise be reachable without "
+                    "authentication. Generate a strong value with: "
+                    'python -c "from secrets import token_urlsafe; print(token_urlsafe(32))"'
+                )
 
             # Validate ADMIN_API_KEY has minimum length (32 characters for security)
-            if len(self.admin_api_key) > 0 and len(self.admin_api_key) < 32:
-                # For dummy deployments, just skip this error
-                pass
+            if len(self.admin_api_key) < 32:
+                raise ValueError(
+                    f"ADMIN_API_KEY must be at least 32 characters when "
+                    f"environment='{self.environment}'. Generate a strong value with: "
+                    'python -c "from secrets import token_urlsafe; print(token_urlsafe(32))"'
+                )
 
         return self
 

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -151,3 +151,50 @@ def test_short_secret_key_allowed_in_development():
     """Development keeps a relaxed policy so local setups need no extra config."""
     config = Settings(environment="development", secret_key="short-dev-key")
     assert config.secret_key == "short-dev-key"
+
+@pytest.mark.parametrize("environment", ["staging", "production"])
+def test_missing_admin_api_key_rejected_outside_development(environment):
+    """ADMIN_API_KEY is required outside development to protect admin endpoints."""
+    with pytest.raises(ValidationError, match="ADMIN_API_KEY is required"):
+        Settings(
+            environment=environment,
+            allowed_origins="https://myproductionapp.com",
+            secret_key="s" * SECRET_KEY_MIN_LENGTH,
+            admin_api_key="",
+            database_url="postgresql+asyncpg://postgres:postgres@db.production.internal:5432/envforage",
+            redis_url="redis://localhost:6379/0",
+        )
+
+
+@pytest.mark.parametrize("environment", ["staging", "production"])
+def test_short_admin_api_key_rejected_outside_development(environment):
+    """A custom but weak ADMIN_API_KEY must be rejected in non-development environments."""
+    short_key = "a" * 31
+    with pytest.raises(ValidationError, match="at least 32 characters"):
+        Settings(
+            environment=environment,
+            allowed_origins="https://myproductionapp.com",
+            secret_key="s" * SECRET_KEY_MIN_LENGTH,
+            admin_api_key=short_key,
+            database_url="postgresql+asyncpg://postgres:postgres@db.production.internal:5432/envforage",
+            redis_url="redis://localhost:6379/0",
+        )
+
+
+def test_admin_api_key_at_minimum_length_accepted():
+    """An ADMIN_API_KEY at exactly the minimum length is accepted outside development."""
+    config = Settings(
+        environment="production",
+        allowed_origins="https://myproductionapp.com",
+        secret_key="s" * SECRET_KEY_MIN_LENGTH,
+        admin_api_key="a" * 32,
+        database_url="postgresql+asyncpg://postgres:postgres@db.production.internal:5432/envforage",
+        redis_url="redis://localhost:6379/0",
+    )
+    assert len(config.admin_api_key) == 32
+
+
+def test_missing_admin_api_key_allowed_in_development():
+    """Development keeps a relaxed policy so local setups need no extra config."""
+    config = Settings(environment="development", admin_api_key="")
+    assert config.admin_api_key == ""


### PR DESCRIPTION
## Description
`backend/app/config.py`'s `validate_settings()` model validator already 
contained the logic to check for a missing or weak `ADMIN_API_KEY` in 
non-development environments — but both checks ended in `pass` instead 
of raising an error. This meant a deployed staging or production instance 
with no `ADMIN_API_KEY` set would silently start up with completely 
unprotected admin endpoints, defeating the purpose of the check entirely.

## Related Issues
Closes #1055

## Changes Made
- `backend/app/config.py` — replaced both disabled `pass` statements with 
  real `ValueError` raises:
  - Missing/empty `ADMIN_API_KEY` outside development → fails startup
  - `ADMIN_API_KEY` shorter than 32 characters outside development → fails startup
  - Both error messages suggest generating a strong key via 
    `python -c "from secrets import token_urlsafe; print(token_urlsafe(32))"`
- `backend/tests/unit/test_config.py` — added 5 new tests:
  - Missing key rejected in staging/production
  - Short key rejected in staging/production
  - Key at exactly 32 chars accepted
  - Missing key still allowed in development (relaxed local policy)

## Before vs After

**Before:** A staging/production deployment with `ADMIN_API_KEY=""` starts 
successfully — admin endpoints are reachable with no authentication.

**After:** Same deployment fails fast at startup with a clear error 
message telling the operator exactly what to fix.

## Verification
- [x] Added unit tests
- [x] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

All 13 config tests pass, and the full backend suite (801 tests) passes 
clean with no regressions:
801 passed, 671 warnings in 147.35s

## Documentation
- [ ] Updated `docs/FEATURES.md`
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted

## Screenshots
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/7648a3ca-a823-4b75-a435-93f82429f2b8" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/8411a3f4-9d57-4cd1-9edf-c560a8b4e60e" />
