### PR TITLE
feat: add HorizontalPodAutoscaler to Helm chart (#1068)

### DIFF
--- a/helm/envforage/templates/hpa.yaml
+++ b/helm/envforage/templates/hpa.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.autoscaling.enabled }}
+{{- if and (not .Values.autoscaling.targetCPUUtilizationPercentage) (not .Values.autoscaling.targetMemoryUtilizationPercentage) }}
+{{- fail "autoscaling.enabled is true but neither targetCPUUtilizationPercentage nor targetMemoryUtilizationPercentage is set; at least one is required for a valid HPA" }}
+{{- end }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/envforage/templates/hpa.yaml
+++ b/helm/envforage/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "envforage.fullname" . }}-backend
+  labels:
+    app: {{ include "envforage.fullname" . }}-backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "envforage.fullname" . }}-backend
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/envforage/values.yaml
+++ b/helm/envforage/values.yaml
@@ -23,6 +23,13 @@ resources:
     cpu: 500m
     memory: 512Mi
 
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
 env:
   DATABASE_URL: "postgresql+asyncpg://envforage:changeme@envforage-postgres:5432/envforage"
   REDIS_URL: "redis://envforage-redis:6379/0"


### PR DESCRIPTION
## Description
 
The Helm chart had no way to autoscale the backend, so this adds a HorizontalPodAutoscaler template plus the values to drive it.
 
`templates/hpa.yaml` creates an HPA targeting the backend Deployment (`<release>-backend`), using `autoscaling/v2` with CPU and memory utilization metrics. Each metric is rendered only if its target percentage is set, so the chart can run CPU-only or memory-only by leaving the other unset.
 
It defaults to `enabled: false`, so existing installs render no HPA and are unaffected. Autoscaling is opt-in via `--set autoscaling.enabled=true`.
 
## Related Issues
 
Fixes #1068
 
## Changes Made
 
- Added `helm/envforage/templates/hpa.yaml`, a HorizontalPodAutoscaler (`autoscaling/v2`) targeting the `<release>-backend` Deployment, with optional CPU and memory utilization metrics.
- Added an `autoscaling` block to `helm/envforage/values.yaml` (disabled by default):
```yaml
autoscaling:
  enabled: false
  minReplicas: 1
  maxReplicas: 5
  targetCPUUtilizationPercentage: 80
  targetMemoryUtilizationPercentage: 80
```
 
- Utilization-based autoscaling needs resource requests on the pods; the backend container already sets `resources.requests.cpu/memory`, so the HPA has a baseline to measure against. The Deployment doesn't hardcode a `replicas:` field, so there's no conflict with the HPA managing replica count when enabled.
## Verification
- [ ] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`
Rendered the template both ways: with `autoscaling.enabled=true` it produces a valid HPA with both CPU and memory metrics and a `scaleTargetRef` matching the backend Deployment; with `enabled=false` (the default) it renders nothing. This is a Helm-template-only change, so the Python test suite doesn't cover it.
 
## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional autoscaling support for the backend deployment.
  * You can now configure minimum and maximum replica counts, plus CPU and memory scaling targets through Helm values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->