### PR TITLE
ci: sign Windows executable and installer on release (#1065)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,10 +111,36 @@ jobs:
           cd cli
           pyinstaller --onefile --name envforage envforage/__main__.py
 
+      - name: Sign executable
+        if: ${{ env.WINDOWS_CERT_BASE64 != '' }}
+        env:
+          WINDOWS_CERT_BASE64: ${{ secrets.WINDOWS_CERT_BASE64 }}
+          WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+        run: |
+          $certBytes = [System.Convert]::FromBase64String($env:WINDOWS_CERT_BASE64)
+          $certPath = Join-Path $env:RUNNER_TEMP "codesign.pfx"
+          [System.IO.File]::WriteAllBytes($certPath, $certBytes)
+          & signtool sign /f $certPath /p $env:WINDOWS_CERT_PASSWORD /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 cli\dist\envforage.exe
+          Remove-Item $certPath
+
       - name: Compile Windows Installer (Inno Setup)
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.8
         with:
           path: cli/installer/setup.iss
+
+      - name: Sign installer
+        if: ${{ env.WINDOWS_CERT_BASE64 != '' }}
+        env:
+          WINDOWS_CERT_BASE64: ${{ secrets.WINDOWS_CERT_BASE64 }}
+          WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+        run: |
+          $certBytes = [System.Convert]::FromBase64String($env:WINDOWS_CERT_BASE64)
+          $certPath = Join-Path $env:RUNNER_TEMP "codesign.pfx"
+          [System.IO.File]::WriteAllBytes($certPath, $certBytes)
+          Get-ChildItem cli\installer\Output\envforage-v*-setup.exe | ForEach-Object {
+            & signtool sign /f $certPath /p $env:WINDOWS_CERT_PASSWORD /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 $_.FullName
+          }
+          Remove-Item $certPath
 
       - name: Rename binaries for release
         run: |


### PR DESCRIPTION
## Description
 
Addresses #1065. The Windows installer and the bundled executable were unsigned, which triggers SmartScreen warnings.
 
This adds two signing steps to the `build-windows-exe` job in `release.yml`: one signs the PyInstaller `envforage.exe` before Inno Setup bundles it, and one signs the compiled installer. Both use `signtool` (preinstalled on the `windows-latest` runner) with SHA256 and an RFC 3161 timestamp, so signatures stay valid after the certificate expires.
 
Both steps are gated on `WINDOWS_CERT_BASE64` being set, so they skip silently when the secret isn't configured. Releases keep working as-is today, and signing turns on automatically once the certificate secrets are added. Nothing runs on forks or PRs, since this workflow only triggers on `v*` tag pushes.
 
## Related Issues
 
Fixes #1065
 
## Changes Made
 
- Added a "Sign executable" step to `build-windows-exe` in `release.yml`, signing `cli/dist/envforage.exe` after PyInstaller compiles it and before Inno Setup bundles it.
- Added a "Sign installer" step signing the compiled installer (`cli/installer/Output/envforage-v*-setup.exe`).
- Both use `signtool` with SHA256 and an RFC 3161 timestamp, gated on `WINDOWS_CERT_BASE64` so they skip when no certificate secret is configured.
To activate, two repository secrets are needed:
- `WINDOWS_CERT_BASE64` — the code-signing certificate (.pfx), base64-encoded
- `WINDOWS_CERT_PASSWORD` — its password
## Notes for reviewers
 
Worth being clear: this wires up the signing mechanism, but SmartScreen warnings only go away once a real code-signing certificate is in place (an EV or OV cert for immediate SmartScreen reputation), since the certificate has to be yours. This PR makes the pipeline ready for that.
 
I kept the signing in the workflow rather than adding a `SignTool` directive to `setup.iss`, since the build uses the Inno Setup Action which doesn't cleanly expose sign-tool registration. Signing the installer output as a separate step achieves the same result without changing `setup.iss`.
 
Happy to switch to different secret names or a different timestamp authority if you'd prefer.
 
## Verification
- [ ] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`
This is a release-workflow change that only runs on `v*` tag pushes, so it isn't exercised by the PR CI or the Python test suite. I validated the workflow YAML parses and that the signing steps are correctly ordered (sign exe before installer compile, sign installer after) and gated on the certificate secret.
 
## Documentation
- [ ] Updated `docs/FEATURES.md` (if adding a feature/profile)
- [ ] Updated `CHANGELOG.md`
- [x] Code is fully documented and type-hinted