### PR TITLE
fix: guard against undefined error.config in axios retry interceptor

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -235,9 +235,18 @@ export const apiClient = axios.create({
 apiClient.interceptors.response.use(
     (response) => response,
     async (error: AxiosError) => {
-        const config = error.config as typeof error.config & { retryCount?: number };
-        
-        if (!config || !config.retryCount) {
+        const config = error.config as
+            | (typeof error.config & { retryCount?: number })
+            | undefined;
+
+        // error.config can be undefined (e.g. errors raised before the
+        // request config is attached, or by a request interceptor). Bail
+        // out instead of crashing on `config.retryCount = 0` below.
+        if (!config) {
+            return Promise.reject(error);
+        }
+
+        if (!config.retryCount) {
             config.retryCount = 0;
         }
 


### PR DESCRIPTION
## Bug

In `frontend/src/services/api.ts`, the response interceptor on `apiClient` (the exponential-backoff retry client added for #299) assumed `error.config` is always defined. `AxiosError.config` is typed as optional (`config?: InternalAxiosRequestConfig`) and can genuinely be `undefined` — e.g. for errors raised before the request config is attached, or thrown from a request interceptor. The interceptor cast `error.config` to a non-optional type and then executed `config.retryCount = 0` inside the `!config` branch, which throws `TypeError: Cannot set properties of undefined` at runtime for any such error.

The `as` type assertion masked this from `tsc` even with `strict: true` (verified in isolation — the same code without the cast is correctly flagged as `'config' is possibly 'undefined'`).

## Fix

Add an explicit `if (!config) return Promise.reject(error);` guard before touching `config.retryCount`, instead of relying on the cast to make the value non-optional.

## Testing

- `npx tsc --noEmit` passes clean on the changed file.
- `npx eslint src/services/api.ts` passes clean.
- `next build` compiles successfully (TypeScript pass included).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request retry handling to avoid errors when a network response has no request configuration attached.
  * Early error cases now fail safely instead of attempting to read retry settings from missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->