### PR TITLE
fix: add aria-label to icon-only buttons for screen reader support

### DIFF
--- a/frontend/src/app/docs/api/page.tsx
+++ b/frontend/src/app/docs/api/page.tsx
@@ -338,6 +338,7 @@ print(f"Packages: {data['packages']}")`,
 								<code style={{ color: "inherit" }}>{codeSnippets[activeTab]}</code>
 							</pre>
 							<button
+							    aria-label="Copy request code" 
 								onClick={() => copyCode(codeSnippets[activeTab], "request")}
 								style={{
 									position: "absolute",
@@ -381,6 +382,7 @@ print(f"Packages: {data['packages']}")`,
 								<code style={{ color: "inherit" }}>{getSimulatedResponse()}</code>
 							</pre>
 							<button
+							    aria-label="Copy response code" 
 								onClick={() => copyCode(getSimulatedResponse(), "response")}
 								style={{
 									position: "absolute",
@@ -399,7 +401,7 @@ print(f"Packages: {data['packages']}")`,
 						</div>
 					</div>
 				</div>
-			</div>
+			</div> 
 
 			{/* Request Payload Definition */}
 			<h2

--- a/frontend/src/app/docs/layout.tsx
+++ b/frontend/src/app/docs/layout.tsx
@@ -170,6 +170,8 @@ export default function DocsLayout({
 				{/* Version Selector */}
 				<div style={{ position: "relative", marginBottom: "2rem" }}>
 					<button
+					    aria-label="Toggle version selector"
+                        aria-expanded={isVersionDropdownOpen}
 						onClick={() => setIsVersionDropdownOpen(!isVersionDropdownOpen)}
 						style={{
 							width: "100%",
@@ -413,6 +415,7 @@ export default function DocsLayout({
 								Navigation
 							</span>
 							<button
+							    aria-label="Close navigation menu"
 								onClick={() => setIsMobileMenuOpen(false)}
 								style={{ background: "none", border: "none", color: "var(--text-primary)", cursor: "pointer", padding: "0.25rem" }}
 							>

--- a/frontend/src/app/docs/layout.tsx
+++ b/frontend/src/app/docs/layout.tsx
@@ -170,7 +170,7 @@ export default function DocsLayout({
 				{/* Version Selector */}
 				<div style={{ position: "relative", marginBottom: "2rem" }}>
 					<button
-					    aria-label="Toggle version selector"
+					    aria-label={`Toggle version selector, current version: ${selectedVersion}`} 
                         aria-expanded={isVersionDropdownOpen}
 						onClick={() => setIsVersionDropdownOpen(!isVersionDropdownOpen)}
 						style={{

--- a/frontend/src/app/download/page.tsx
+++ b/frontend/src/app/download/page.tsx
@@ -217,9 +217,9 @@ export default function InstallPage() {
 							{installCommand}
 						</code>
 						<button
-						    aria-label="Copy install command"
+						    aria-label={copied ? "Copied to clipboard" : "Copy install command"}
 							onClick={handleCopy}
-							style={{ 
+							style={{  
 								background: "none",
 								border: "none",
 								cursor: "pointer",

--- a/frontend/src/app/download/page.tsx
+++ b/frontend/src/app/download/page.tsx
@@ -217,8 +217,9 @@ export default function InstallPage() {
 							{installCommand}
 						</code>
 						<button
+						    aria-label="Copy install command"
 							onClick={handleCopy}
-							style={{
+							style={{ 
 								background: "none",
 								border: "none",
 								cursor: "pointer",

--- a/frontend/src/app/troubleshoot/Client.tsx
+++ b/frontend/src/app/troubleshoot/Client.tsx
@@ -864,6 +864,7 @@ width: "100%",
 																				$ {cmd}
 																			</code>
 																			<button
+																			    aria-label="Copy command" 
 																				onClick={() =>
 																					handleCopy(cmd, `cmd-${idx}-${ci}`)
 																				}
@@ -873,7 +874,7 @@ width: "100%",
 																					cursor: "pointer",
 																					padding: "0.25rem",
 																					color: "var(--text-muted)",
-																				}}
+																				}} 
 																			>
 																				{copiedId === `cmd-${idx}-${ci}` ? (
 																					<Check


### PR DESCRIPTION
Closes #1060

- Audited the entire frontend and found 6 actual icon-only buttons missing aria-label.

## Changes
Added descriptive `aria-label` to 6 icon-only buttons.

- `app/troubleshoot/Client.tsx` — copy command button
- `app/download/page.tsx` — copy install command button  
- `app/docs/layout.tsx` — version selector dropdown toggle (also added `aria-expanded`)
- `app/docs/layout.tsx` — mobile nav close button
- `app/docs/api/page.tsx` — copy request code button
- `app/docs/api/page.tsx` — copy response code button

## Testing
- `npm run lint` passes with 0 errors

## Labels
enhancement, frontend, a11y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for several copy and navigation buttons across the docs, download, and troubleshooting pages.
  * Added clearer labels for screen readers and better state feedback for the version selector.
  * Updated the mobile navigation menu close control to be more descriptive.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->