### PR TITLE
test(cli): add mocked network tests for troubleshoot and list commands

### DIFF
--- a/cli/envforage/cli.py
+++ b/cli/envforage/cli.py
@@ -1334,7 +1334,7 @@ def rollback(quiet: bool) -> None:
 def troubleshoot(api_url: str | None, quiet: bool, timeout: int | None) -> None:
     config = load_config()
     final_api_url = api_url or config.api_url
-    final_timeout = timeout or config.timeout
+    final_timeout = timeout if timeout is not None else config.timeout
     asyncio.run(_troubleshoot(final_api_url, quiet, final_timeout))
 
 

--- a/cli/envforage/cli.py
+++ b/cli/envforage/cli.py
@@ -1324,13 +1324,21 @@ def rollback(quiet: bool) -> None:
     default=False,
     help="Suppress all logging output and print only the analysis results.",
 )
-def troubleshoot(api_url: str | None, quiet: bool) -> None:
+@click.option(
+    "--timeout",
+    "-t",
+    type=int,
+    default=None,
+    help="Timeout in seconds for each detector subprocess call.",
+)
+def troubleshoot(api_url: str | None, quiet: bool, timeout: int | None) -> None:
     config = load_config()
     final_api_url = api_url or config.api_url
-    asyncio.run(_troubleshoot(final_api_url, quiet))
+    final_timeout = timeout or config.timeout
+    asyncio.run(_troubleshoot(final_api_url, quiet, final_timeout))
 
 
-async def _troubleshoot(api_url: str, quiet: bool) -> None:
+async def _troubleshoot(api_url: str, quiet: bool, timeout: int) -> None:
     """
     Send diagnostic report to AI troubleshoot endpoint
     and stream analysis results live to terminal.
@@ -1344,7 +1352,7 @@ async def _troubleshoot(api_url: str, quiet: bool) -> None:
         )
 
     # Build diagnostic report
-    if quiet or output_format in ("json", "minimal"):
+    if quiet:
         report = ReportBuilder(timeout=timeout).build()
     else:
         with Progress(
@@ -1356,7 +1364,7 @@ async def _troubleshoot(api_url: str, quiet: bool) -> None:
             task = progress.add_task("Building diagnostic report...", total=None)
             def _update_progress(msg: str) -> None:
                 progress.update(task, description=msg)
-            report = ReportBuilder().build(progress_callback=_update_progress)
+            report = ReportBuilder(timeout=timeout).build(progress_callback=_update_progress)
             progress.update(task, description="[green]Report ready[/]")
     url = f"{api_url.rstrip('/')}/api/v1/troubleshoot"
 

--- a/cli/tests/test_troubleshoot_and_list.py
+++ b/cli/tests/test_troubleshoot_and_list.py
@@ -125,7 +125,7 @@ class TestTroubleshootCommand:
                           "--api-url", "http://localhost:8000"]
                 )
 
-        assert "EnvForge AI Troubleshooter" not in result.output
+        assert "EnvForage AI Troubleshooter" not in result.output
         assert "Traceback" not in result.output
 
 

--- a/cli/tests/test_troubleshoot_and_list.py
+++ b/cli/tests/test_troubleshoot_and_list.py
@@ -29,10 +29,8 @@ def _make_report_builder():
     return mock_builder, mock_report
 
 
-def _make_sync_response(status_code=200, json_data=None, connect_error=False):
+def _make_sync_response(status_code=200, json_data=None):
     """Build a mock synchronous httpx response."""
-    if connect_error:
-        return None  # signal to raise ConnectError
     mock_resp = MagicMock()
     mock_resp.status_code = status_code
     mock_resp.raise_for_status = MagicMock()
@@ -52,10 +50,15 @@ class TestTroubleshootCommand:
         mock_response.raise_for_status = MagicMock()
 
         if stream_lines is not None:
-            async def _aiter_lines():
-                for line in (stream_lines or []):
-                    yield line
-            mock_response.aiter_lines = _aiter_lines
+            class _AsyncIter:
+                def __init__(self, lines):
+                    self._lines = lines
+                def __aiter__(self):
+                    return self._async_gen()
+                async def _async_gen(self):
+                    for line in self._lines:
+                        yield line
+            mock_response.aiter_lines = MagicMock(return_value=_AsyncIter(stream_lines or []))
 
         mock_stream_ctx = MagicMock()
         if connect_error:
@@ -90,13 +93,13 @@ class TestTroubleshootCommand:
                 )
 
         assert "Traceback" not in result.output
-        assert "Cannot connect" in result.output or result.exit_code != 0
+        assert "Cannot connect" in result.output
 
-    def test_successful_stream_prints_no_traceback(self):
-        """A successful stream should exit cleanly."""
+    def test_successful_stream_parses_and_exits_cleanly(self):
+        """A successful SSE stream should be parsed and exit with code 0."""
+        valid_response = '{"root_cause": "CUDA not found", "suggested_fixes": [], "confidence": 0.9}'
         stream_lines = [
-            'data: {"chunk": "Checking CUDA..."}',
-            "data: [DONE]",
+            f"data: {valid_response}",
         ]
         mock_builder, _ = _make_report_builder()
         mock_class = self._make_stream_client(stream_lines=stream_lines)
@@ -110,6 +113,7 @@ class TestTroubleshootCommand:
                 )
 
         assert "Traceback" not in result.output
+        assert result.exit_code == 0
 
     def test_quiet_suppresses_panel_output(self):
         """--quiet should suppress the EnvForge AI Troubleshooter panel."""

--- a/cli/tests/test_troubleshoot_and_list.py
+++ b/cli/tests/test_troubleshoot_and_list.py
@@ -1,0 +1,219 @@
+"""
+Tests for `envforage troubleshoot` and `envforage list` CLI commands.
+
+Both commands make live HTTP requests to the backend API. These tests
+mock the relevant httpx functions to intercept network calls:
+- troubleshoot: uses httpx.AsyncClient + client.stream() (async)
+- list: uses synchronous httpx.get() directly
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from envforage.cli import cli
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+def _make_report_builder():
+    """Stub out ReportBuilder so no real hardware detection runs."""
+    mock_report = MagicMock()
+    mock_report.to_json.return_value = '{"agent_version": "1.0.0"}'
+    mock_report.model_dump.return_value = {"agent_version": "1.0.0"}
+    mock_builder = MagicMock()
+    mock_builder.return_value.build.return_value = mock_report
+    return mock_builder, mock_report
+
+
+def _make_sync_response(status_code=200, json_data=None, connect_error=False):
+    """Build a mock synchronous httpx response."""
+    if connect_error:
+        return None  # signal to raise ConnectError
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = json_data or {}
+    return mock_resp
+
+
+# ── envforage troubleshoot ────────────────────────────────────────────────────
+
+
+class TestTroubleshootCommand:
+    """Tests for `envforage troubleshoot`."""
+
+    def _make_stream_client(self, stream_lines=None, connect_error=False):
+        """Build a mock httpx.AsyncClient for streaming."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        if stream_lines is not None:
+            async def _aiter_lines():
+                for line in (stream_lines or []):
+                    yield line
+            mock_response.aiter_lines = _aiter_lines
+
+        mock_stream_ctx = MagicMock()
+        if connect_error:
+            mock_stream_ctx.__aenter__ = AsyncMock(
+                side_effect=httpx.ConnectError("refused")
+            )
+        else:
+            mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        mock_client = MagicMock()
+        mock_client.stream = MagicMock(return_value=mock_stream_ctx)
+
+        mock_client_ctx = MagicMock()
+        mock_client_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        mock_class = MagicMock(return_value=mock_client_ctx)
+        return mock_class
+
+    def test_connect_error_shows_friendly_message(self):
+        """A ConnectError should print a friendly error, not a traceback."""
+        mock_builder, _ = _make_report_builder()
+        mock_class = self._make_stream_client(connect_error=True)
+
+        with patch("envforage.cli.ReportBuilder", mock_builder):
+            with patch("httpx.AsyncClient", mock_class):
+                runner = CliRunner()
+                result = runner.invoke(
+                    cli, ["troubleshoot", "--quiet",
+                          "--api-url", "http://localhost:9999"]
+                )
+
+        assert "Traceback" not in result.output
+        assert "Cannot connect" in result.output or result.exit_code != 0
+
+    def test_successful_stream_prints_no_traceback(self):
+        """A successful stream should exit cleanly."""
+        stream_lines = [
+            'data: {"chunk": "Checking CUDA..."}',
+            "data: [DONE]",
+        ]
+        mock_builder, _ = _make_report_builder()
+        mock_class = self._make_stream_client(stream_lines=stream_lines)
+
+        with patch("envforage.cli.ReportBuilder", mock_builder):
+            with patch("httpx.AsyncClient", mock_class):
+                runner = CliRunner()
+                result = runner.invoke(
+                    cli, ["troubleshoot", "--quiet",
+                          "--api-url", "http://localhost:8000"]
+                )
+
+        assert "Traceback" not in result.output
+
+    def test_quiet_suppresses_panel_output(self):
+        """--quiet should suppress the EnvForge AI Troubleshooter panel."""
+        stream_lines = ["data: [DONE]"]
+        mock_builder, _ = _make_report_builder()
+        mock_class = self._make_stream_client(stream_lines=stream_lines)
+
+        with patch("envforage.cli.ReportBuilder", mock_builder):
+            with patch("httpx.AsyncClient", mock_class):
+                runner = CliRunner()
+                result = runner.invoke(
+                    cli, ["troubleshoot", "--quiet",
+                          "--api-url", "http://localhost:8000"]
+                )
+
+        assert "EnvForge AI Troubleshooter" not in result.output
+        assert "Traceback" not in result.output
+
+
+# ── envforage list ────────────────────────────────────────────────────────────
+
+
+class TestListCommand:
+    """Tests for `envforage list`."""
+
+    def _profiles_data(self, profiles=None):
+        return {
+            "profiles": profiles or [
+                {"slug": "pytorch-cuda", "name": "PyTorch + CUDA",
+                 "description": "GPU-accelerated PyTorch", "tags": ["gpu", "cuda"]},
+                {"slug": "cpu-only", "name": "CPU Only",
+                 "description": "CPU-only PyTorch", "tags": ["cpu"]},
+            ],
+            "total": 2,
+            "page": 1,
+            "page_size": 100,
+        }
+
+    def test_list_quiet_outputs_json(self):
+        """--quiet should print a JSON list to stdout and exit 0."""
+        mock_resp = _make_sync_response(json_data=self._profiles_data())
+
+        with patch("httpx.get", return_value=mock_resp):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["list", "--quiet", "--api-url", "http://localhost:8000"]
+            )
+
+        assert result.exit_code == 0
+        assert "pytorch-cuda" in result.output
+
+    def test_list_connect_error_shows_friendly_message(self):
+        """A ConnectError should print a friendly error, not a traceback."""
+        with patch("httpx.get", side_effect=httpx.ConnectError("refused")):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["list", "--api-url", "http://localhost:9999"]
+            )
+
+        assert "Traceback" not in result.output
+        assert "Cannot connect" in result.output
+
+    def test_list_empty_profiles(self):
+        """Empty profile list should exit 0 without crashing."""
+        mock_resp = _make_sync_response(
+            json_data={"profiles": [], "total": 0, "page": 1, "page_size": 100}
+        )
+
+        with patch("httpx.get", return_value=mock_resp):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["list", "--quiet", "--api-url", "http://localhost:8000"]
+            )
+
+        assert result.exit_code == 0
+        assert "[]" in result.output
+
+    def test_list_filter_by_tag(self):
+        """--filter should restrict output to matching profiles."""
+        mock_resp = _make_sync_response(json_data=self._profiles_data())
+
+        with patch("httpx.get", return_value=mock_resp):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["list", "--filter", "cpu",
+                      "--quiet", "--api-url", "http://localhost:8000"]
+            )
+
+        assert result.exit_code == 0
+        assert "cpu-only" in result.output
+
+    def test_list_http_error_shows_status_code(self):
+        """Non-2xx response should show the status code in output."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+        mock_resp.text = "Service Unavailable"
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "503", request=MagicMock(), response=mock_resp
+        )
+
+        with patch("httpx.get", return_value=mock_resp):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["list", "--api-url", "http://localhost:8000"]
+            )
+
+        assert "503" in result.output


### PR DESCRIPTION
## Description
`envforage troubleshoot` and `envforage list` were the only CLI commands
making live HTTP requests with zero test coverage. Any network call in
these commands would hit a real server during tests, causing hangs or
failures in CI. This PR adds 8 mocked tests covering both commands.

Additionally, discovered and fixed a latent bug in `_troubleshoot()`:
`output_format` and `timeout` were referenced as variables but never
defined as parameters, causing a `NameError` crash on every invocation.
Added `--timeout` to the `troubleshoot` command (matching the existing
pattern in `diagnose`) to fix this.

## Related Issues
Closes #1064

## Changes Made
- `cli/envforage/cli.py` — fixed latent `NameError` bug in `_troubleshoot()`:
  added `--timeout` Click option and updated `_troubleshoot()` to accept
  and use `timeout` parameter
- `cli/tests/test_troubleshoot_and_list.py` (new) — 8 tests covering both
  commands with fully mocked HTTP layers

## Key Implementation Detail
The two commands use different HTTP patterns requiring different mock strategies:
- `troubleshoot` → `httpx.AsyncClient` + `client.stream()` (async SSE)
- `list` → synchronous `httpx.get()` directly

## Test Coverage

**`TestTroubleshootCommand` (3 tests)**
| Test | What it verifies |
|------|-----------------|
| `test_connect_error_shows_friendly_message` | `ConnectError` shows clean error, no traceback |
| `test_successful_stream_prints_no_traceback` | SSE stream exits cleanly |
| `test_quiet_suppresses_panel_output` | `--quiet` suppresses the Rich panel |

**`TestListCommand` (5 tests)**
| Test | What it verifies |
|------|-----------------|
| `test_list_quiet_outputs_json` | `--quiet` prints JSON and exits 0 |
| `test_list_connect_error_shows_friendly_message` | `ConnectError` shows clean error |
| `test_list_empty_profiles` | Empty list exits 0, prints `[]` |
| `test_list_filter_by_tag` | `--filter` narrows to matching profiles |
| `test_list_http_error_shows_status_code` | 503 response shows status code |

## Verification
- [x] Added unit tests
- [x] Ran `pytest tests/` successfully
- [x] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

All 8 tests pass:
8 passed in 13.73s

## Documentation
- [ ] Updated `docs/FEATURES.md`
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted

## Screenshots
<img width="1918" height="515" alt="image" src="https://github.com/user-attachments/assets/ef7b52b5-03c1-45e8-87d2-c13dcf654cd9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--timeout` (`-t`) option to the `troubleshoot` command to control diagnostic runtime.
  * `troubleshoot` now uses the selected timeout when generating the diagnostic report.

* **Bug Fixes**
  * Quiet mode no longer shows the progress UI, while still producing the full diagnostic output.
  * Removed prior conditional report-building behavior to ensure consistent output formatting.

* **Tests**
  * Added CLI tests covering connection failures, quiet output, empty results, filtering, and HTTP error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->