### PR TITLE
feat: add clean target and cross-platform clean.py to remove build artifacts (#1072)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint run-dev db-upgrade
+.PHONY: test lint run-dev db-upgrade clean
 
 # Run backend tests
 test:
@@ -15,3 +15,7 @@ run-dev:
 # Run database migrations and seed development data
 db-upgrade:
 		cd backend && alembic upgrade head && python -m app.services.seed_service
+
+# Remove locally generated artifacts (caches, test outputs, build dirs)
+clean:
+		python scripts/clean.py

--- a/scripts/clean.py
+++ b/scripts/clean.py
@@ -2,9 +2,9 @@
 """Remove locally generated build/test/cache artifacts.
 
 Mirrors the generated paths in .gitignore so a developer can clean a working
-tree without deleting environment or state. Virtualenvs, .env files, databases,
-and Docker volumes are intentionally left alone, since those are environment or
-state rather than build artifacts.
+tree without deleting environment or state. Virtualenvs, node_modules, .env
+files, databases, and Docker volumes are intentionally left alone, since those
+are environment or state rather than build artifacts.
 
 Usage:
     python scripts/clean.py
@@ -12,12 +12,27 @@ Usage:
 
 from __future__ import annotations
 
+import fnmatch
+import os
 import shutil
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 
-# Directory names removed wherever they occur in the tree.
+# Directories we never descend into: virtualenvs, dependencies, VCS, and state.
+# Pruned in-place during the walk so installed packages (e.g. compiled .pyd
+# files inside a venv) are never touched and the tree is traversed only once.
+PRUNE_DIRS = {
+    ".venv",
+    "venv",
+    "env",
+    "ENV",
+    "node_modules",
+    ".git",
+    "postgres_data",
+}
+
+# Directory names removed wherever they occur (outside pruned dirs).
 DIR_NAMES = {
     "__pycache__",
     ".pytest_cache",
@@ -27,7 +42,7 @@ DIR_NAMES = {
     ".eggs",
 }
 
-# Directory-name glob patterns removed wherever they occur (e.g. foo.egg-info).
+# Directory-name glob patterns removed wherever they occur.
 DIR_PATTERNS = ("*.egg-info",)
 
 # File glob patterns removed wherever they occur.
@@ -62,20 +77,19 @@ def _rm(path: Path) -> None:
 
 
 def main() -> None:
-    for name in DIR_NAMES:
-        for path in ROOT.rglob(name):
-            if path.is_dir():
-                _rm(path)
+    # Single top-down walk: prune ignored directories in place so we never
+    # descend into them, and remove matching artifact dirs/files as we go.
+    for dirpath, dirnames, filenames in os.walk(ROOT, topdown=True):
+        dirnames[:] = [d for d in dirnames if d not in PRUNE_DIRS]
 
-    for pattern in DIR_PATTERNS:
-        for path in ROOT.rglob(pattern):
-            if path.is_dir():
-                _rm(path)
+        for d in list(dirnames):
+            if d in DIR_NAMES or any(fnmatch.fnmatch(d, p) for p in DIR_PATTERNS):
+                _rm(Path(dirpath) / d)
+                dirnames.remove(d)  # don't descend into a dir we just removed
 
-    for pattern in FILE_PATTERNS:
-        for path in ROOT.rglob(pattern):
-            if path.is_file():
-                _rm(path)
+        for f in filenames:
+            if any(fnmatch.fnmatch(f, p) for p in FILE_PATTERNS):
+                _rm(Path(dirpath) / f)
 
     for rel in EXACT_PATHS:
         _rm(ROOT / rel)

--- a/scripts/clean.py
+++ b/scripts/clean.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Remove locally generated build/test/cache artifacts.
+
+Mirrors the generated paths in .gitignore so a developer can clean a working
+tree without deleting environment or state. Virtualenvs, .env files, databases,
+and Docker volumes are intentionally left alone, since those are environment or
+state rather than build artifacts.
+
+Usage:
+    python scripts/clean.py
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Directory names removed wherever they occur in the tree.
+DIR_NAMES = {
+    "__pycache__",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".mypy_cache",
+    "htmlcov",
+    ".eggs",
+}
+
+# Directory-name glob patterns removed wherever they occur (e.g. foo.egg-info).
+DIR_PATTERNS = ("*.egg-info",)
+
+# File glob patterns removed wherever they occur.
+FILE_PATTERNS = ("*.pyc", "*.pyo", "*.pyd", "*.egg", "*.log")
+
+# Specific paths (relative to repo root) removed if present.
+EXACT_PATHS = (
+    "build",
+    "dist",
+    "generated",
+    "logs",
+    ".coverage",
+    "coverage.xml",
+    "backend/.coverage",
+    "backend/coverage.xml",
+    "frontend/.next",
+    "frontend/out",
+)
+
+
+def _rm(path: Path) -> None:
+    try:
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path, ignore_errors=True)
+        elif path.exists() or path.is_symlink():
+            path.unlink(missing_ok=True)
+        else:
+            return
+        print(f"removed {path.relative_to(ROOT)}")
+    except Exception as exc:  # best-effort cleanup
+        print(f"skip {path}: {exc}")
+
+
+def main() -> None:
+    for name in DIR_NAMES:
+        for path in ROOT.rglob(name):
+            if path.is_dir():
+                _rm(path)
+
+    for pattern in DIR_PATTERNS:
+        for path in ROOT.rglob(pattern):
+            if path.is_dir():
+                _rm(path)
+
+    for pattern in FILE_PATTERNS:
+        for path in ROOT.rglob(pattern):
+            if path.is_file():
+                _rm(path)
+
+    for rel in EXACT_PATHS:
+        _rm(ROOT / rel)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Addresses #1072. The Makefile had no `clean` target, so locally generated artifacts (caches, test outputs, build dirs) had to be removed by hand.

This adds a cross-platform `scripts/clean.py` and a Makefile `clean` target that calls it. The script does the removals with `pathlib`/`shutil`, so it runs identically on Windows, macOS, and Linux (`python scripts/clean.py`), including for contributors on plain PowerShell without `make` + GNU `find`. The Makefile target is just a thin wrapper (`python scripts/clean.py`).

## Related Issues

Fixes #1072

## Changes Made

- Added `scripts/clean.py`, which removes generated artifacts that mirror the entries in `.gitignore`:
  - Directories: `__pycache__`, `.pytest_cache`, `.ruff_cache`, `.mypy_cache`, `htmlcov`, `.eggs`, `*.egg-info`
  - Files: `*.pyc`, `*.pyo`, `*.pyd`, `*.egg`, `*.log`
  - Paths: `build/`, `dist/`, `generated/`, `logs/`, `.coverage`, `coverage.xml`, `backend/.coverage`, `backend/coverage.xml`, `frontend/.next`, `frontend/out`
- Added a `clean` target to the `Makefile` (and to `.PHONY`) that runs `python scripts/clean.py`.

## Notes for reviewers

The script deliberately does not touch environment or state, matching the discussion on the issue. It prunes and never descends into `.venv/`, `venv/`, `env/`, `ENV/`, `node_modules/`, `.git/`, and `postgres_data/`, so installed packages and virtualenvs are left completely alone. `.env*` files and `*.db`/`*.sqlite3` databases are also never removed, since those are state, not build artifacts.

The removal list mirrors the Python, Test artifacts, and Generated scripts sections of `.gitignore`, so the two stay in sync.

## Verification
- [ ] Added unit tests
- [ ] Ran `pytest tests/` successfully
- [x] Manually tested via the CLI

Ran `python scripts/clean.py` locally: it removes the project's build/test/cache artifacts and leaves `.venv/`, `node_modules/`, `.env`, and databases untouched. Also confirmed `make clean` invokes the script.

## Documentation
- [ ] Updated `docs/FEATURES.md`
- [ ] Updated `CHANGELOG.md`
- [x] Code is documented

Happy to also mention `make clean` / `python scripts/clean.py` in the contributing docs if you'd like.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `clean` command to remove locally generated build, test, and cache artifacts.
  * Completed the database upgrade workflow so it now runs migrations and then applies seed data.

* **Chores**
  * Marked cleanup as a phony build target for more reliable command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->