### PR TITLE
test(cli): add unit tests for envforge verify PyTorch/CUDA output parsing

### DIFF
--- a/cli/tests/test_verify.py
+++ b/cli/tests/test_verify.py
@@ -1,0 +1,196 @@
+"""
+Unit tests for `envforge verify` CLI command.
+
+Tests mock subprocess.run to simulate PyTorch/CUDA inspection script
+output, covering all key code paths in the verify command.
+"""
+from __future__ import annotations
+
+import json
+from subprocess import TimeoutExpired
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from envforage.cli import cli
+
+
+def _make_proc(stdout: dict, returncode: int = 0, stderr: str = "") -> MagicMock:
+    """Build a mock subprocess.CompletedProcess result."""
+    mock = MagicMock()
+    mock.returncode = returncode
+    mock.stdout = json.dumps(stdout)
+    mock.stderr = stderr
+    return mock
+
+
+def _make_report():
+    """Stub ReportBuilder so no real hardware detection runs."""
+    mock_report = MagicMock()
+    mock_report.active_python = MagicMock()
+    mock_report.active_python.path = "python"
+    mock_report.gpus = []
+    mock_builder = MagicMock()
+    mock_builder.return_value.build.return_value = mock_report
+    return mock_builder
+
+
+# ── Successful scenarios ──────────────────────────────────────────────────────
+
+
+def test_verify_pytorch_cpu_success():
+    """PyTorch import OK, no CUDA — should PASS with CPU only message."""
+    proc = _make_proc({
+        "framework": "PyTorch",
+        "import_ok": True,
+        "version": "2.3.0",
+        "cuda_ok": False,
+        "cuda_version": None,
+        "error": None,
+    })
+    with patch("envforage.cli.ReportBuilder", _make_report()):
+        with patch("subprocess.run", return_value=proc):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["verify", "--quiet"])
+
+    output = json.loads(result.output)
+    assert output["status"] == "PASS"
+    assert "CPU only" in output["message"]
+    assert result.exit_code == 0
+
+
+def test_verify_pytorch_cuda_success():
+    """PyTorch + CUDA both available — should PASS with CUDA message."""
+    proc = _make_proc({
+        "framework": "PyTorch",
+        "import_ok": True,
+        "version": "2.3.0",
+        "cuda_ok": True,
+        "cuda_version": "12.1",
+        "error": None,
+    })
+    with patch("envforage.cli.ReportBuilder", _make_report()):
+        with patch("subprocess.run", return_value=proc):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["verify", "--profile", "pytorch-cuda", "--quiet"]
+            )
+
+    output = json.loads(result.output)
+    assert output["status"] == "PASS"
+    assert "CUDA" in output["message"]
+    assert result.exit_code == 0
+
+
+# ── Import failure ────────────────────────────────────────────────────────────
+
+
+def test_verify_import_failure_exits_nonzero():
+    """PyTorch import failed — should FAIL with friendly error message."""
+    proc = _make_proc({
+        "framework": "PyTorch",
+        "import_ok": False,
+        "version": None,
+        "cuda_ok": False,
+        "cuda_version": None,
+        "error": "ModuleNotFoundError: No module named 'torch'",
+    })
+    with patch("envforage.cli.ReportBuilder", _make_report()):
+        with patch("subprocess.run", return_value=proc):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["verify", "--quiet"])
+
+    output = json.loads(result.output)
+    assert output["status"] == "FAIL"
+    assert "import failed" in output["message"]
+    assert result.exit_code != 0
+    assert "Traceback" not in result.output
+
+
+# ── CUDA unavailable on GPU profile ──────────────────────────────────────────
+
+
+def test_verify_cuda_unavailable_on_gpu_profile():
+    """Import OK but CUDA not available on a CUDA profile — should FAIL."""
+    proc = _make_proc({
+        "framework": "PyTorch",
+        "import_ok": True,
+        "version": "2.3.0",
+        "cuda_ok": False,
+        "cuda_version": None,
+        "error": None,
+    })
+    with patch("envforage.cli.ReportBuilder", _make_report()):
+        with patch("subprocess.run", return_value=proc):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["verify", "--profile", "pytorch-cuda", "--quiet"]
+            )
+
+    output = json.loads(result.output)
+    assert output["status"] == "FAIL"
+    assert "CUDA" in output["message"] or "GPU" in output["message"]
+    assert result.exit_code != 0
+
+
+# ── Subprocess error cases ────────────────────────────────────────────────────
+
+
+def test_verify_subprocess_nonzero_returncode():
+    """Non-zero returncode from subprocess — should FAIL gracefully."""
+    proc = MagicMock()
+    proc.returncode = 1
+    proc.stdout = ""
+    proc.stderr = "Segmentation fault"
+
+    with patch("envforage.cli.ReportBuilder", _make_report()):
+        with patch("subprocess.run", return_value=proc):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["verify", "--quiet"])
+
+    output = json.loads(result.output)
+    assert output["status"] == "FAIL"
+    assert result.exit_code != 0
+    assert "Traceback" not in result.output
+
+
+def test_verify_timeout_shows_friendly_message():
+    """Subprocess timeout — should show 'timed out' message, no raw exception."""
+    with patch("envforage.cli.ReportBuilder", _make_report()):
+        with patch("subprocess.run", side_effect=TimeoutExpired(cmd="python", timeout=15)):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["verify", "--quiet"])
+
+    output = json.loads(result.output)
+    assert output["status"] == "FAIL"
+    assert "timed out" in output["message"].lower()
+    assert result.exit_code != 0
+    assert "Traceback" not in result.output
+
+
+def test_verify_malformed_output_no_traceback():
+    """Malformed subprocess JSON output — should fail gracefully, no traceback."""
+    proc = MagicMock()
+    proc.returncode = 0
+    proc.stdout = "NOT_VALID_JSON!!!"
+    proc.stderr = ""
+
+    with patch("envforage.cli.ReportBuilder", _make_report()):
+        with patch("subprocess.run", return_value=proc):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["verify", "--quiet"])
+
+    assert result.exit_code != 0
+    assert "Traceback" not in result.output
+
+
+def test_verify_unexpected_exception_no_traceback():
+    """Unexpected exception in subprocess — should fail gracefully, no traceback."""
+    with patch("envforage.cli.ReportBuilder", _make_report()):
+        with patch("subprocess.run", side_effect=OSError("Unexpected OS error")):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["verify", "--quiet"])
+
+    assert result.exit_code != 0
+    assert "Traceback" not in result.output

--- a/cli/tests/test_verify.py
+++ b/cli/tests/test_verify.py
@@ -145,20 +145,24 @@ def test_verify_subprocess_nonzero_returncode():
     proc.stderr = "Segmentation fault"
 
     with patch("envforage.cli.ReportBuilder", _make_report()):
-        with patch("subprocess.run", return_value=proc):
+        with patch("subprocess.run", return_value=proc) as mock_run:
             runner = CliRunner()
             result = runner.invoke(cli, ["verify", "--quiet"])
 
-    output = json.loads(result.output)
-    assert output["status"] == "FAIL"
     assert result.exit_code != 0
     assert "Traceback" not in result.output
+    output = json.loads(result.output)
+    assert output["status"] == "FAIL"
+    assert "Segmentation fault" in output.get("error", "")
 
 
 def test_verify_timeout_shows_friendly_message():
-    """Subprocess timeout — should show 'timed out' message, no raw exception."""
+    """Subprocess timeout — should show 'timed out' message and use 15s timeout."""
     with patch("envforage.cli.ReportBuilder", _make_report()):
-        with patch("subprocess.run", side_effect=TimeoutExpired(cmd="python", timeout=15)):
+        with patch(
+            "subprocess.run",
+            side_effect=TimeoutExpired(cmd="python", timeout=15),
+        ) as mock_run:
             runner = CliRunner()
             result = runner.invoke(cli, ["verify", "--quiet"])
 
@@ -167,6 +171,13 @@ def test_verify_timeout_shows_friendly_message():
     assert "timed out" in output["message"].lower()
     assert result.exit_code != 0
     assert "Traceback" not in result.output
+    # Verify the 15-second timeout is configured
+    call_kwargs = mock_run.call_args[1] if mock_run.call_args[1] else {}
+    call_args = mock_run.call_args[0] if mock_run.call_args[0] else []
+    timeout_used = call_kwargs.get("timeout") or (
+        mock_run.call_args.kwargs.get("timeout") if hasattr(mock_run.call_args, "kwargs") else None
+    )
+    assert timeout_used == 15
 
 
 def test_verify_malformed_output_no_traceback():


### PR DESCRIPTION
## Description
The `envforge verify` command runs an inline Python subprocess to test
PyTorch/TensorFlow/JAX import and CUDA availability, then parses the JSON
output. This parsing logic had zero unit test coverage — any regression
would silently break the verify command without any test catching it.

## Related Issues
Closes #1145

## Changes Made
- `cli/tests/test_verify.py` (new file, 196 lines, 8 tests)
- No production code changes

## Test Coverage

| Test | What it verifies |
|------|-----------------|
| `test_verify_pytorch_cpu_success` | Import OK, no CUDA → PASS + "CPU only" message |
| `test_verify_pytorch_cuda_success` | Import OK + CUDA available → PASS + "CUDA" message |
| `test_verify_import_failure_exits_nonzero` | Import failed → FAIL + friendly error, no traceback |
| `test_verify_cuda_unavailable_on_gpu_profile` | CUDA missing on GPU profile → FAIL |
| `test_verify_subprocess_nonzero_returncode` | Non-zero returncode → FAIL gracefully |
| `test_verify_timeout_shows_friendly_message` | `TimeoutExpired` → FAIL + "timed out" message, no traceback |
| `test_verify_malformed_output_no_traceback` | Invalid JSON stdout → FAIL gracefully, no traceback |
| `test_verify_unexpected_exception_no_traceback` | `OSError` → FAIL gracefully, no traceback |

All tests mock `subprocess.run` and `ReportBuilder` so no real hardware
detection or subprocess execution runs during testing, following the same
pattern established in `test_fix.py` and `test_troubleshoot_and_list.py`.

## Verification
- [x] Added unit tests
- [x] Ran `pytest tests/` successfully
- [ ] Manually tested via the API / CLI
- [ ] (If applicable) Generated scripts pass `SafetyFilter`

All 8 tests pass:
8 passed in 12.32s

## Documentation
- [ ] Updated `docs/FEATURES.md`
- [ ] Updated `CHANGELOG.md`
- [ ] Code is fully documented and type-hinted

## Screenshots 
<img width="1460" height="333" alt="image" src="https://github.com/user-attachments/assets/7ab20cb4-f86e-4915-9d1d-8b6481192de8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for the `envforge verify` command across CPU-only, CUDA, import failure, CUDA-unavailable under GPU profile, non-zero subprocess exit, timeout handling (including a 15s timeout), malformed output, and unexpected error scenarios.
  * Verified structured JSON status reporting, user-friendly failure messages, correct non-zero exit codes on failure, and traceback-free error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->