### PR TITLE
because installing nothing is hard

### DIFF
--- a/backend/app/templates/jinja/setup/setup_linux.sh.j2
+++ b/backend/app/templates/jinja/setup/setup_linux.sh.j2
@@ -113,7 +113,7 @@ fi
 # ── Package installation ──────────────────────────────────────────────────────
 info "Installing packages..."
 
-{% if cuda_version %}
+{% if cuda_version and has_cuda_packages %}
 # PyTorch CUDA index (required for CUDA-specific builds)
 TORCH_INDEX="https://download.pytorch.org/whl/cu{{ cuda_version | replace('.', '') }}"
 
@@ -128,7 +128,10 @@ ${RUN_CMD}pip install \
 {% endif %}
 {% endfor %}
     --index-url "$TORCH_INDEX"
+{% endif %}
 
+{% if cuda_version %}
+{% if has_standard_packages %}
 # Install remaining packages from PyPI
 {% if use_uv %}
 ${RUN_CMD}uv pip install \
@@ -141,6 +144,7 @@ ${RUN_CMD}pip install \
 {% endif %}
 {% endfor %}
     --quiet
+{% endif %}
 {% else %}
 # CPU-only installation
 {% if use_uv %}

--- a/backend/app/templates/jinja/setup/setup_windows.ps1.j2
+++ b/backend/app/templates/jinja/setup/setup_windows.ps1.j2
@@ -57,27 +57,40 @@ Write-Info "Starting pre-flight checks..."
 
 $RequiredPython = "{{ python_version }}"
 $PythonBin = $null
+$PythonArgs = @()
 
-foreach ($py in @("py -{{ python_version }}", "python{{ python_version }}", "python", "python3")) {
-    try {
-        $ver = & $py --version 2>$null
-        if ($ver -match "Python $($RequiredPython)") {
-            $PythonBin = $py
-            break
-        }
-    } catch { }
+# First check Windows Python Launcher with specific version argument
+try {
+    $ver = & py "-$RequiredPython" --version 2>$null
+    if ($ver -match "Python $($RequiredPython)") {
+        $PythonBin = "py"
+        $PythonArgs = @("-$RequiredPython")
+    }
+} catch { }
+
+if (-not $PythonBin) {
+    foreach ($cmd in @("python{{ python_version }}", "python", "python3")) {
+        try {
+            $ver = & $cmd --version 2>$null
+            if ($ver -match "Python $($RequiredPython)") {
+                $PythonBin = $cmd
+                $PythonArgs = @()
+                break
+            }
+        } catch { }
+    }
 }
 
 if (-not $PythonBin) {
     Write-Err "Python {{ python_version }} not found. Download from: https://www.python.org/downloads/"
 }
-Write-Info "Python found: $(& $PythonBin --version)"
+Write-Info "Python found: $(& $PythonBin @PythonArgs --version)"
 
 # ── Virtual environment ───────────────────────────────────────────────────────
 $VenvDir = ".venv"
 if (-not (Test-Path $VenvDir)) {
     Write-Info "Creating virtual environment in $VenvDir..."
-    & $PythonBin -m venv $VenvDir
+    & $PythonBin @PythonArgs -m venv $VenvDir
 }
 
 # Activate

--- a/backend/app/templates/models.py
+++ b/backend/app/templates/models.py
@@ -49,6 +49,8 @@ class TemplateContext:
                 }
                 for p in self.resolved.packages
             ],
+            "has_cuda_packages": any(bool(p.cuda_variant) for p in self.resolved.packages),
+            "has_standard_packages": any(not p.cuda_variant for p in self.resolved.packages),
             "warnings": self.warnings,
             "generated_at": self.generated_at.strftime("%Y-%m-%d %H:%M UTC"),
             "envforage_version": self.envforage_version,

--- a/backend/tests/unit/templates/test_setup_templates.py
+++ b/backend/tests/unit/templates/test_setup_templates.py
@@ -1,0 +1,112 @@
+import pytest
+
+from app.compatibility.models import ResolvedEnvironment, ResolvedPackage
+from app.templates.engine import TemplateRenderer
+from app.templates.models import TemplateContext
+
+
+def make_context(
+    profile_name="pytorch-env",
+    python_version="3.11",
+    cuda_version=None,
+    target_os="LINUX",
+    packages=None,
+):
+    if packages is None:
+        packages = []
+    resolved = ResolvedEnvironment(
+        python_version=python_version,
+        cuda_version=cuda_version,
+        target_os=target_os,
+        packages=packages,
+    )
+    return TemplateContext(
+        profile_id="test-profile",
+        profile_name=profile_name,
+        resolved=resolved,
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_linux_cuda_with_torch_packages():
+    """Verify setup.sh renders both TORCH_INDEX and PyPI blocks when cuda_variant packages exist."""
+    context = make_context(
+        profile_name="PyTorch CUDA",
+        python_version="3.11",
+        cuda_version="11.8",
+        target_os="LINUX",
+        packages=[
+            ResolvedPackage(name="torch", version="2.1.2", cuda_variant="cu118"),
+            ResolvedPackage(name="numpy", version="1.26.4", cuda_variant=None),
+        ],
+    )
+    renderer = TemplateRenderer()
+    result = await renderer.render("setup.sh", context)
+
+    assert 'TORCH_INDEX="https://download.pytorch.org/whl/cu118"' in result.content
+    assert '"torch==2.1.2+cu118"' in result.content
+    assert '"numpy==1.26.4"' in result.content
+    assert '--index-url "$TORCH_INDEX"' in result.content
+
+
+@pytest.mark.asyncio
+async def test_setup_linux_cuda_without_cuda_variant_packages():
+    """Verify setup.sh does NOT render an empty TORCH_INDEX pip install for non-PyTorch CUDA profiles."""
+    context = make_context(
+        profile_name="TensorFlow GPU",
+        python_version="3.11",
+        cuda_version="11.8",
+        target_os="LINUX",
+        packages=[
+            ResolvedPackage(name="tensorflow", version="2.14.0", cuda_variant=None),
+            ResolvedPackage(name="numpy", version="1.26.4", cuda_variant=None),
+        ],
+    )
+    renderer = TemplateRenderer()
+    result = await renderer.render("setup.sh", context)
+
+    # TORCH_INDEX should not be rendered when no packages have cuda_variant
+    assert "TORCH_INDEX" not in result.content
+    assert '--index-url "$TORCH_INDEX"' not in result.content
+    assert '"tensorflow==2.14.0"' in result.content
+    assert '"numpy==1.26.4"' in result.content
+
+
+@pytest.mark.asyncio
+async def test_setup_linux_cpu_only():
+    """Verify setup.sh renders CPU-only installation cleanly."""
+    context = make_context(
+        profile_name="OpenCV Beginner",
+        python_version="3.11",
+        cuda_version=None,
+        target_os="LINUX",
+        packages=[
+            ResolvedPackage(name="opencv-python", version="4.9.0.80", cuda_variant=None),
+            ResolvedPackage(name="numpy", version="1.26.4", cuda_variant=None),
+        ],
+    )
+    renderer = TemplateRenderer()
+    result = await renderer.render("setup.sh", context)
+
+    assert "TORCH_INDEX" not in result.content
+    assert '"opencv-python==4.9.0.80"' in result.content
+    assert '"numpy==1.26.4"' in result.content
+
+
+@pytest.mark.asyncio
+async def test_setup_windows_python_launcher_check():
+    """Verify setup.ps1 separates the py launcher binary from version argument."""
+    context = make_context(
+        profile_name="Windows Setup",
+        python_version="3.11",
+        target_os="WIN",
+        packages=[
+            ResolvedPackage(name="numpy", version="1.26.4", cuda_variant=None),
+        ],
+    )
+    renderer = TemplateRenderer()
+    result = await renderer.render("setup.ps1", context)
+
+    assert '& py "-$RequiredPython" --version' in result.content
+    assert '& "py -' not in result.content
+    assert '& $PythonBin @PythonArgs -m venv $VenvDir' in result.content


### PR DESCRIPTION
**Description**

Prevents generated setup scripts from running `pip install` commands when there are no packages to install.

Because apparently installing nothing is hard.

## Related Issues

N/A

## Changes Made

- Added checks before generating `pip install` commands.
- Updated Linux setup script template.
- Updated Windows setup script template.
- Updated template models.
- Added tests to cover the changes.

## Verification

- [x] Added unit tests
- [x] Ran pytest tests successfully
- [ ] Manually tested via the API / CLI
- [ ] Generated scripts pass `SafetyFilter`

## Documentation

- [x] Code is fully documented and type-hinted
- [ ] Updated documentation (not required for this change)

## Screenshots

Not applicable — this change only affects generated setup scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux setup scripts so CUDA and standard package installations run only when the appropriate packages are available.
  * Improved Windows Python detection, including support for version-specific Python Launcher commands and more consistent virtual environment setup.

* **Tests**
  * Added coverage for Linux CUDA, CPU-only, and Windows setup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->